### PR TITLE
New entry with url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The `jabkit check` command now runs both the consistency and integrity checks when given an input file without a subcommand (e.g. `jabkit check references.bib`). [#15759](https://github.com/JabRef/jabref/pull/15759)
 - We added OCR feature using OCRmyPDF to extract text from scanned PDFs and create searchable PDFs including the extracted text. [#15712](https://github.com/JabRef/jabref/pull/15712)
 - We Added generic CSV export filter that exports all standard BibTeX fields [#15711](https://github.com/JabRef/jabref/issues/15711)
+- We added generic URL importer that creates a new entry with the URL field filled in. [#15909](https://github.com/JabRef/jabref/pull/15909)
 
 ### Changed
 

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryDialogTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryDialogTab.java
@@ -5,4 +5,5 @@ public enum NewEntryDialogTab {
     ENTER_IDENTIFIER,
     INTERPRET_CITATIONS,
     SPECIFY_BIBTEX,
+    ENTER_URL,
 }

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryDialogTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryDialogTab.java
@@ -5,5 +5,5 @@ public enum NewEntryDialogTab {
     ENTER_IDENTIFIER,
     INTERPRET_CITATIONS,
     SPECIFY_BIBTEX,
-    ENTER_URL,
+    LOOKUP_URL,
 }

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
@@ -104,6 +104,7 @@ public class NewEntryView extends BaseDialog<BibEntry> {
     @FXML private Tab tabLookupIdentifier;
     @FXML private Tab tabInterpretCitations;
     @FXML private Tab tabSpecifyBibtex;
+    @FXML private Tab tabEnterUrl;
 
     @FXML private TitledPane entryRecommendedTitle;
     @FXML private TilePane entryRecommended;
@@ -127,6 +128,9 @@ public class NewEntryView extends BaseDialog<BibEntry> {
     @FXML private ComboBox<PlainCitationParserChoice> interpretParser;
 
     @FXML private TextArea bibtexText;
+
+    @FXML private TextField urlText;
+    @FXML private Label urlErrorInvalidText;
 
     private BibEntry result;
 
@@ -206,12 +210,17 @@ public class NewEntryView extends BaseDialog<BibEntry> {
                 tabs.getSelectionModel().select(tabSpecifyBibtex);
                 switchSpecifyBibtex();
                 break;
+            case NewEntryDialogTab.ENTER_URL:
+                tabs.getSelectionModel().select(tabEnterUrl);
+                switchEnterUrl();
+                break;
         }
 
         tabAddEntry.setOnSelectionChanged(_ -> switchAddEntry());
         tabLookupIdentifier.setOnSelectionChanged(_ -> switchLookupIdentifier());
         tabInterpretCitations.setOnSelectionChanged(_ -> switchInterpretCitations());
         tabSpecifyBibtex.setOnSelectionChanged(_ -> switchSpecifyBibtex());
+        tabEnterUrl.setOnSelectionChanged(_ -> switchEnterUrl());
     }
 
     @FXML
@@ -234,6 +243,7 @@ public class NewEntryView extends BaseDialog<BibEntry> {
         initializeLookupIdentifier();
         initializeInterpretCitations();
         initializeSpecifyBibTeX();
+        initializeEnterUrl();
     }
 
     private void initializeAddEntry() {
@@ -400,6 +410,14 @@ public class NewEntryView extends BaseDialog<BibEntry> {
         }
     }
 
+    private void initializeEnterUrl() {
+        urlText.setPromptText(Localization.lang("Enter the reference URL to search for."));
+        urlText.textProperty().bindBidirectional(viewModel.urlTextProperty());
+
+        urlErrorInvalidText.visibleProperty().bind(viewModel.urlTextValidatorProperty().not());
+        urlErrorInvalidText.managedProperty().bind(viewModel.urlTextValidatorProperty().not());
+    }
+
     @FXML
     private void switchAddEntry() {
         if (!tabAddEntry.isSelected()) {
@@ -474,6 +492,26 @@ public class NewEntryView extends BaseDialog<BibEntry> {
         }
     }
 
+    @FXML
+    private void switchEnterUrl() {
+        // TODO
+        if (!tabEnterUrl.isSelected()) {
+            return;
+        }
+
+        currentApproach = NewEntryDialogTab.ENTER_URL;
+        newEntryPreferences.setLatestApproach(NewEntryDialogTab.ENTER_URL);
+
+        if (urlText != null) {
+            Platform.runLater(() -> urlText.requestFocus());
+        }
+
+        if (generateButton != null) {
+            generateButton.disableProperty().bind(urlErrorInvalidText.visibleProperty());
+            generateButton.setText(Localization.lang("Search"));
+        }
+    }
+
     private void onEntryTypeSelected(EntryType type) {
         newEntryPreferences.setLatestImmediateType(type);
         result = new BibEntry(type);
@@ -508,6 +546,11 @@ public class NewEntryView extends BaseDialog<BibEntry> {
                 generateButton.setText(Localization.lang("Parsing..."));
                 viewModel.executeSpecifyBibtex();
                 switchSpecifyBibtex();
+                break;
+            case NewEntryDialogTab.ENTER_URL:
+                generateButton.setText(Localization.lang("Searching..."));
+                viewModel.executeEnterUrl();
+                switchEnterUrl();
                 break;
         }
     }

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
@@ -104,7 +104,7 @@ public class NewEntryView extends BaseDialog<BibEntry> {
     @FXML private Tab tabLookupIdentifier;
     @FXML private Tab tabInterpretCitations;
     @FXML private Tab tabSpecifyBibtex;
-    @FXML private Tab tabEnterUrl;
+    @FXML private Tab tabLookupUrl;
 
     @FXML private TitledPane entryRecommendedTitle;
     @FXML private TilePane entryRecommended;
@@ -210,9 +210,9 @@ public class NewEntryView extends BaseDialog<BibEntry> {
                 tabs.getSelectionModel().select(tabSpecifyBibtex);
                 switchSpecifyBibtex();
                 break;
-            case NewEntryDialogTab.ENTER_URL:
-                tabs.getSelectionModel().select(tabEnterUrl);
-                switchEnterUrl();
+            case NewEntryDialogTab.LOOKUP_URL:
+                tabs.getSelectionModel().select(tabLookupUrl);
+                switchLookupUrl();
                 break;
         }
 
@@ -220,7 +220,7 @@ public class NewEntryView extends BaseDialog<BibEntry> {
         tabLookupIdentifier.setOnSelectionChanged(_ -> switchLookupIdentifier());
         tabInterpretCitations.setOnSelectionChanged(_ -> switchInterpretCitations());
         tabSpecifyBibtex.setOnSelectionChanged(_ -> switchSpecifyBibtex());
-        tabEnterUrl.setOnSelectionChanged(_ -> switchEnterUrl());
+        tabLookupUrl.setOnSelectionChanged(_ -> switchLookupUrl());
     }
 
     @FXML
@@ -243,7 +243,7 @@ public class NewEntryView extends BaseDialog<BibEntry> {
         initializeLookupIdentifier();
         initializeInterpretCitations();
         initializeSpecifyBibTeX();
-        initializeEnterUrl();
+        initializeLookupUrl();
     }
 
     private void initializeAddEntry() {
@@ -410,7 +410,7 @@ public class NewEntryView extends BaseDialog<BibEntry> {
         }
     }
 
-    private void initializeEnterUrl() {
+    private void initializeLookupUrl() {
         urlText.setPromptText(Localization.lang("Enter the reference URL to search for."));
         urlText.textProperty().bindBidirectional(viewModel.urlTextProperty());
 
@@ -493,14 +493,13 @@ public class NewEntryView extends BaseDialog<BibEntry> {
     }
 
     @FXML
-    private void switchEnterUrl() {
-        // TODO
-        if (!tabEnterUrl.isSelected()) {
+    private void switchLookupUrl() {
+        if (!tabLookupUrl.isSelected()) {
             return;
         }
 
-        currentApproach = NewEntryDialogTab.ENTER_URL;
-        newEntryPreferences.setLatestApproach(NewEntryDialogTab.ENTER_URL);
+        currentApproach = NewEntryDialogTab.LOOKUP_URL;
+        newEntryPreferences.setLatestApproach(NewEntryDialogTab.LOOKUP_URL);
 
         if (urlText != null) {
             Platform.runLater(() -> urlText.requestFocus());
@@ -547,10 +546,10 @@ public class NewEntryView extends BaseDialog<BibEntry> {
                 viewModel.executeSpecifyBibtex();
                 switchSpecifyBibtex();
                 break;
-            case NewEntryDialogTab.ENTER_URL:
+            case NewEntryDialogTab.LOOKUP_URL:
                 generateButton.setText(Localization.lang("Searching..."));
-                viewModel.executeEnterUrl();
-                switchEnterUrl();
+                viewModel.executeLookupUrl();
+                switchLookupUrl();
                 break;
         }
     }

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
@@ -613,27 +613,28 @@ public class NewEntryViewModel {
         urlWorker.setOnSucceeded(_ -> {
             final Optional<List<BibEntry>> result = urlWorker.getValue();
 
-            if (result.isEmpty()) {
-                dialogService.showWarningDialogAndWait(
-                        Localization.lang("Invalid result"),
-                        Localization.lang(
-                                "An unknown error has occurred."));
-                LOGGER.error("An invalid result was returned when fetching URL entries");
-                executing.set(false);
-                return;
-            }
+            result.ifPresentOrElse(
+                entries -> {
+                    final ImportHandler handler = new ImportHandler(
+                            libraryTab.getBibDatabaseContext(),
+                            preferences,
+                            fileUpdateMonitor,
+                            libraryTab.getUndoManager(),
+                            stateManager,
+                            dialogService,
+                            taskExecutor);
+                    handler.importEntriesWithDuplicateCheck(null, entries);
 
-            final ImportHandler handler = new ImportHandler(
-                    libraryTab.getBibDatabaseContext(),
-                    preferences,
-                    fileUpdateMonitor,
-                    libraryTab.getUndoManager(),
-                    stateManager,
-                    dialogService,
-                    taskExecutor);
-            handler.importEntriesWithDuplicateCheck(null, result.get());
-
-            executedSuccessfully.set(true);
+                    executedSuccessfully.set(true);
+                },
+                () -> {
+                    dialogService.showWarningDialogAndWait(
+                            Localization.lang("Invalid result"),
+                            Localization.lang(
+                                    "An unknown error has occurred."));
+                    LOGGER.error("An invalid result was returned when fetching URL entries");
+                }
+            );
             executing.set(false);
         });
 

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
@@ -563,7 +563,7 @@ public class NewEntryViewModel {
         taskExecutor.execute(bibtexWorker);
     }
 
-    private class WorkerEnterUrl extends Task<Optional<List<BibEntry>>> {
+    private class WorkerLookupUrl extends Task<Optional<List<BibEntry>>> {
         @Override
         protected Optional<List<BibEntry>> call() throws FetcherException {
             String url = urlText.getValue();
@@ -576,11 +576,11 @@ public class NewEntryViewModel {
         }
     }
 
-    public void executeEnterUrl() {
+    public void executeLookupUrl() {
         executing.setValue(true);
 
         cancel();
-        urlWorker = new WorkerEnterUrl();
+        urlWorker = new WorkerLookupUrl();
 
         urlWorker.setOnFailed(_ -> {
             final Throwable exception = urlWorker.getException();

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
@@ -47,6 +47,7 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.util.FileUpdateMonitor;
+import org.jabref.logic.importer.fetcher.GenericUrlBasedFetcher;
 
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
@@ -93,6 +94,10 @@ public class NewEntryViewModel {
     private Task<Optional<List<BibEntry>>> bibtexWorker;
     private final Map<String, BibEntry> doiCache;
     private BibEntry duplicateEntry;
+
+    private final StringProperty urlText;
+    private final Validator urlTextValidator;
+    private Task<Optional<List<BibEntry>>> urlWorker;
 
     public NewEntryViewModel(GuiPreferences preferences,
                              LibraryTab libraryTab,
@@ -153,6 +158,12 @@ public class NewEntryViewModel {
                 StringUtil::isNotBlank,
                 ValidationMessage.error(Localization.lang("You must specify a Bib(La)TeX source.")));
         bibtexWorker = null;
+
+        urlText = new SimpleStringProperty();
+        urlTextValidator = new FunctionBasedValidator<>(
+                urlText,
+                StringUtil::isNotBlank,
+                ValidationMessage.error(Localization.lang("You must specify a URL.")));
     }
 
     public void populateDOICache() {
@@ -239,6 +250,14 @@ public class NewEntryViewModel {
 
     public ReadOnlyBooleanProperty bibtexTextValidatorProperty() {
         return bibtexTextValidator.getValidationStatus().validProperty();
+    }
+
+    public StringProperty urlTextProperty() {
+        return urlText;
+    }
+
+    public ReadOnlyBooleanProperty urlTextValidatorProperty() {
+        return urlTextValidator.getValidationStatus().validProperty();
     }
 
     private BibEntry withCoversDownloaded(BibEntry entry) {
@@ -486,7 +505,7 @@ public class NewEntryViewModel {
         bibtexWorker = new WorkerSpecifyBibtex();
 
         bibtexWorker.setOnFailed(_ -> {
-            final Throwable exception = interpretWorker.getException();
+            final Throwable exception = bibtexWorker.getException();
             final String exceptionMessage = exception.getMessage();
 
             final String dialogTitle = Localization.lang("Failed to parse Bib(La)TeX");
@@ -544,6 +563,83 @@ public class NewEntryViewModel {
         taskExecutor.execute(bibtexWorker);
     }
 
+    private class WorkerEnterUrl extends Task<Optional<List<BibEntry>>> {
+        @Override
+        protected Optional<List<BibEntry>> call() throws FetcherException {
+            String url = urlText.getValue();
+            if (StringUtil.isBlank(url)) {
+                return Optional.empty();
+            }
+
+            GenericUrlBasedFetcher fetcher = new GenericUrlBasedFetcher();
+            return fetcher.performSearch(url);
+        }
+    }
+
+    public void executeEnterUrl() {
+        executing.setValue(true);
+
+        cancel();
+        urlWorker = new WorkerEnterUrl();
+
+        urlWorker.setOnFailed(_ -> {
+            final Throwable exception = urlWorker.getException();
+            final String exceptionMessage = exception.getMessage();
+
+            final String dialogTitle = Localization.lang("Failed to fetch URL");
+
+            if (exception instanceof FetcherException) {
+                dialogService.showInformationDialogAndWait(
+                        dialogTitle,
+                        Localization.lang(
+                                "Failed to create entries.\n" +
+                                        "The following error was encountered:\n" +
+                                        "%0",
+                                exceptionMessage));
+            } else {
+                dialogService.showInformationDialogAndWait(
+                        dialogTitle,
+                        Localization.lang(
+                                "The following error occurred:\n" +
+                                        "%0",
+                                exceptionMessage));
+            }
+
+            LOGGER.error("An exception occurred when fetching URL.", exception);
+
+            executing.set(false);
+        });
+
+        urlWorker.setOnSucceeded(_ -> {
+            final Optional<List<BibEntry>> result = urlWorker.getValue();
+
+            if (result.isEmpty()) {
+                dialogService.showWarningDialogAndWait(
+                        Localization.lang("Invalid result"),
+                        Localization.lang(
+                                "An unknown error has occurred."));
+                LOGGER.error("An invalid result was returned when fetching URL entries");
+                executing.set(false);
+                return;
+            }
+
+            final ImportHandler handler = new ImportHandler(
+                    libraryTab.getBibDatabaseContext(),
+                    preferences,
+                    fileUpdateMonitor,
+                    libraryTab.getUndoManager(),
+                    stateManager,
+                    dialogService,
+                    taskExecutor);
+            handler.importEntriesWithDuplicateCheck(null, result.get());
+
+            executedSuccessfully.set(true);
+            executing.set(false);
+        });
+
+        taskExecutor.execute(urlWorker);
+    }
+
     public void cancel() {
         if (idLookupWorker != null) {
             idLookupWorker.cancel();
@@ -553,6 +649,9 @@ public class NewEntryViewModel {
         }
         if (bibtexWorker != null) {
             bibtexWorker.cancel();
+        }
+        if (urlWorker != null) {
+            urlWorker.cancel();
         }
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
@@ -33,6 +33,7 @@ import org.jabref.logic.importer.FetcherServerException;
 import org.jabref.logic.importer.IdBasedFetcher;
 import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.importer.WebFetchers;
+import org.jabref.logic.importer.fetcher.GenericUrlBasedFetcher;
 import org.jabref.logic.importer.fileformat.BibtexParser;
 import org.jabref.logic.importer.plaincitation.PlainCitationParser;
 import org.jabref.logic.importer.plaincitation.PlainCitationParserChoice;
@@ -47,7 +48,6 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.util.FileUpdateMonitor;
-import org.jabref.logic.importer.fetcher.GenericUrlBasedFetcher;
 
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
@@ -614,26 +614,26 @@ public class NewEntryViewModel {
             final Optional<List<BibEntry>> result = urlWorker.getValue();
 
             result.ifPresentOrElse(
-                entries -> {
-                    final ImportHandler handler = new ImportHandler(
-                            libraryTab.getBibDatabaseContext(),
-                            preferences,
-                            fileUpdateMonitor,
-                            libraryTab.getUndoManager(),
-                            stateManager,
-                            dialogService,
-                            taskExecutor);
-                    handler.importEntriesWithDuplicateCheck(null, entries);
+                    entries -> {
+                        final ImportHandler handler = new ImportHandler(
+                                libraryTab.getBibDatabaseContext(),
+                                preferences,
+                                fileUpdateMonitor,
+                                libraryTab.getUndoManager(),
+                                stateManager,
+                                dialogService,
+                                taskExecutor);
+                        handler.importEntriesWithDuplicateCheck(null, entries);
 
-                    executedSuccessfully.set(true);
-                },
-                () -> {
-                    dialogService.showWarningDialogAndWait(
-                            Localization.lang("Invalid result"),
-                            Localization.lang(
-                                    "An unknown error has occurred."));
-                    LOGGER.error("An invalid result was returned when fetching URL entries");
-                }
+                        executedSuccessfully.set(true);
+                    },
+                    () -> {
+                        dialogService.showWarningDialogAndWait(
+                                Localization.lang("Invalid result"),
+                                Localization.lang(
+                                        "An unknown error has occurred."));
+                        LOGGER.error("An invalid result was returned when fetching URL entries");
+                    }
             );
             executing.set(false);
         });

--- a/jabgui/src/main/resources/org/jabref/gui/newentry/NewEntry.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/newentry/NewEntry.fxml
@@ -244,6 +244,42 @@
                             wrapText="true"/>
                 </VBox>
             </Tab>
+
+            <Tab fx:id="tabEnterUrl"
+                 text="%Enter URL"
+                 closable="false">
+                <VBox spacing="10.0">
+                    <padding>
+                        <Insets top="10.0"/>
+                    </padding>
+                    <HBox alignment="CENTER_LEFT"
+                          spacing="10.0">
+                        <Label text="%URL"/>
+                        <TextField
+                                fx:id="urlText"
+                                prefHeight="30.0"
+                                HBox.hgrow="ALWAYS">
+                            <tooltip>
+                                <Tooltip
+                                        fx:id="urlTextTooltip"
+                                        text="%Specify the source URL to look up."/>
+                            </tooltip>
+                        </TextField>
+                    </HBox>
+                    <VBox spacing="5.0">
+                        <padding>
+                            <Insets top="5.0"/>
+                        </padding>
+                        <Label fx:id="urlErrorInvalidText"
+                               text="%You must provide a URL.">
+                            <font>
+                                <Font name="System Italic"
+                                      size="13.0"/>
+                            </font>
+                        </Label>
+                    </VBox>
+                </VBox>
+            </Tab>
         </TabPane>
     </content>
     <ButtonType

--- a/jabgui/src/main/resources/org/jabref/gui/newentry/NewEntry.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/newentry/NewEntry.fxml
@@ -245,7 +245,7 @@
                 </VBox>
             </Tab>
 
-            <Tab fx:id="tabEnterUrl"
+            <Tab fx:id="tabLookupUrl"
                  text="%Enter URL"
                  closable="false">
                 <VBox spacing="10.0">
@@ -260,9 +260,7 @@
                                 prefHeight="30.0"
                                 HBox.hgrow="ALWAYS">
                             <tooltip>
-                                <Tooltip
-                                        fx:id="urlTextTooltip"
-                                        text="%Specify the source URL to look up."/>
+                                <Tooltip text="%Specify the source URL to look up."/>
                             </tooltip>
                         </TextField>
                     </HBox>

--- a/jablib/src/main/java/org/jabref/logic/importer/UrlBasedFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/UrlBasedFetcher.java
@@ -1,0 +1,18 @@
+package org.jabref.logic.importer;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.jabref.model.entry.BibEntry;
+
+import org.jspecify.annotations.NonNull;
+
+/// Searches web resources for bibliographic information based on a URL.
+public interface UrlBasedFetcher extends WebFetcher {
+
+    /// Looks for bibliographic information associated to the given URL.
+    ///
+    /// @param url a string which contains information regarding one or more entries
+    /// @return a {@link BibEntry} containing the bibliographic information (or an empty optional if no data was found)
+    Optional<List<BibEntry>> performSearch(@NonNull String url) throws FetcherException;
+}

--- a/jablib/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -27,6 +27,7 @@ import org.jabref.logic.importer.fetcher.DiVA;
 import org.jabref.logic.importer.fetcher.DoiFetcher;
 import org.jabref.logic.importer.fetcher.DoiResolution;
 import org.jabref.logic.importer.fetcher.EuropePmcFetcher;
+import org.jabref.logic.importer.fetcher.GenericUrlBasedFetcher;
 import org.jabref.logic.importer.fetcher.GvkFetcher;
 import org.jabref.logic.importer.fetcher.IEEE;
 import org.jabref.logic.importer.fetcher.INSPIREFetcher;
@@ -301,6 +302,14 @@ public class WebFetchers {
                 new SpringerNatureWebFetcher(importerPreferences),
                 new UnpaywallFetcher(importerPreferences),
                 new WileyFetcher(importerPreferences)
+        );
+
+        return fetchers;
+    }
+
+    public static Set<UrlBasedFetcher> getURLBasedFetchers() {
+        Set<UrlBasedFetcher> fetchers = Set.of(
+                new GenericUrlBasedFetcher()
         );
 
         return fetchers;

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/GenericUrlBasedFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/GenericUrlBasedFetcher.java
@@ -1,0 +1,25 @@
+package org.jabref.logic.importer.fetcher;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.importer.UrlBasedFetcher;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+
+import org.jspecify.annotations.NonNull;
+
+public class GenericUrlBasedFetcher implements UrlBasedFetcher {
+    @Override
+    public @NonNull String getName() {
+        return "Generic URL";
+    }
+
+    public Optional<List<BibEntry>> performSearch(@NonNull String url) throws FetcherException {
+        BibEntry entry = new BibEntry(StandardEntryType.Misc);
+        entry.setField(StandardField.URL, url);
+        return Optional.of(List.of(entry));
+    }
+}

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -3146,6 +3146,10 @@ URL=URL
 Specify\ the\ source\ URL\ to\ look\ up.=Specify the source URL to look up.
 You\ must\ provide\ a\ URL.=You must provide a URL.
 You\ must\ specify\ a\ URL.=You must specify a URL.
+An\ unknown\ error\ has\ occurred.=An unknown error has occurred.
+Enter\ the\ reference\ URL\ to\ search\ for.=Enter the reference URL to search for.
+Failed\ to\ create\ entries.\nThe\ following\ error\ was\ encountered\:\n%0=Failed to create entries.\nThe following error was encountered:\n%0
+Failed\ to\ fetch\ URL=Failed to fetch URL
 
 # Walkthrough Menu
 Walkthroughs=Walkthroughs

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -3145,6 +3145,7 @@ Enter\ URL=Enter URL
 URL=URL
 Specify\ the\ source\ URL\ to\ look\ up.=Specify the source URL to look up.
 You\ must\ provide\ a\ URL.=You must provide a URL.
+You\ must\ specify\ a\ URL.=You must specify a URL.
 
 # Walkthrough Menu
 Walkthroughs=Walkthroughs

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -3141,6 +3141,10 @@ You\ must\ select\ an\ identifier\ type.=You must select an identifier type.
 You\ must\ specify\ a\ Bib(La)TeX\ source.=You must specify a Bib(La)TeX source.
 You\ must\ specify\ an\ identifier.=You must specify an identifier.
 You\ must\ specify\ one\ (or\ more)\ citations.=You must specify one (or more) citations.
+Enter\ URL=Enter URL
+URL=URL
+Specify\ the\ source\ URL\ to\ look\ up.=Specify the source URL to look up.
+You\ must\ provide\ a\ URL.=You must provide a URL.
 
 # Walkthrough Menu
 Walkthroughs=Walkthroughs


### PR DESCRIPTION
### Related issues and pull requests

Closes #15411 

### PR Description

Added a "Enter URL" tab when adding a new entry. Currently only creates a new empty entry with the given URL in the URL field. Added a new URLBasedFetcher to be used for future implementations.

### Steps to test

1. Click "New empty library" <br>
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7d3baa21-6329-43c9-8bf9-a08981187adf" /><br>
2. Click "Add entry using..." <br>
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fae00c0d-0c93-4514-aee9-13d302f37bd0" /><br>
3. Click "Enter URL" <br>
<img width="600" height="645" alt="image" src="https://github.com/user-attachments/assets/2191ef1c-048b-48e9-972d-13c0f80a49e7" /><br>
4. Enter https://gi-radar.de/397-coding-unterstuetzung-im-lauf-der-zeit/ into URL text field and click "Submit" <br>
<img width="602" height="639" alt="image" src="https://github.com/user-attachments/assets/087da681-d68a-498b-81ce-4c22e1654ccc" /><br>
5. Double click the new entry and switch to the "General" tab to verify that the URL field is filled <br>
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f095391e-c681-4188-ad64-37a4704bb52a" />

### AI usage

Claude (Sonnet 4.6)

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [ ] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [ ] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
