### PR TITLE
Add ability to view citation previews on hover in 'Citations' tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- We added the ability to view citation previews rendered using the selected style on hover in the "Citations" tab.
 - We added support for selecting answer engines and summarization algorithms, allowing users to change the underlying AI behavior. [#15688](https://github.com/JabRef/jabref/pull/15688)
 - The citation key generator also normalizes super and subscript characters. [#15743](https://github.com/JabRef/jabref/pull/15743)
 - We added automatic source groups to SLR results and fixed group merging to preserve all source groups. [#12542](https://github.com/JabRef/jabref/issues/12542)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- We added the ability to view citation previews rendered using the selected style on hover in the "Citations" tab.
+- We added the ability to view citation previews rendered using the selected style on hover in the "Citations" tab. [#15914](https://github.com/JabRef/jabref/pull/15914)
 - We added support for selecting answer engines and summarization algorithms, allowing users to change the underlying AI behavior. [#15688](https://github.com/JabRef/jabref/pull/15688)
 - The citation key generator also normalizes super and subscript characters. [#15743](https://github.com/JabRef/jabref/pull/15743)
 - We added automatic source groups to SLR results and fixed group merging to preserve all source groups. [#12542](https://github.com/JabRef/jabref/issues/12542)

--- a/docs/requirements/entry-editor.md
+++ b/docs/requirements/entry-editor.md
@@ -12,4 +12,11 @@ When users search or select a group not containing the entry shown in the Entry 
 
 Needs: impl
 
+## Citations tab should show citation preview on hover
+`req~entry-editor.citations.hover-preview~1`
+
+When the user hovers over a citation entry inside the Entry Editor's "Citations" tab, a tooltip containing the entry preview rendered in the current selected style should be displayed.
+
+Needs: impl
+
 <!-- markdownlint-disable-file MD022 -->

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -400,6 +400,7 @@ public class EntryEditor extends BorderPane implements PreviewControls, AdaptVis
                 fileMonitor,
                 preferences,
                 taskExecutor,
+                themeManager,
                 bibEntryTypesManager,
                 searchCitationsRelationsService
         ));

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -12,12 +12,10 @@ import java.util.Optional;
 
 import javax.swing.undo.UndoManager;
 
-import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import javafx.concurrent.Worker;
 import javafx.css.PseudoClass;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -62,10 +60,10 @@ import org.jabref.gui.desktop.os.NativeDesktop;
 import org.jabref.gui.entryeditor.EntryEditorPreferences;
 import org.jabref.gui.entryeditor.EntryEditorTab;
 import org.jabref.gui.icon.IconTheme;
+import org.jabref.gui.maintable.MainTableTooltip;
 import org.jabref.gui.mergeentries.threewaymerge.EntriesMergeResult;
 import org.jabref.gui.mergeentries.threewaymerge.MergeEntriesDialog;
 import org.jabref.gui.preferences.GuiPreferences;
-import org.jabref.gui.preview.PreviewViewer;
 import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.undo.NamedCompoundEdit;
 import org.jabref.gui.undo.UndoableInsertEntries;
@@ -128,8 +126,7 @@ public class CitationRelationsTab extends EntryEditorTab {
     private final ProgressIndicator progressIndicator;
     private final GridPane sciteResultsPane;
     private final EntryEditorPreferences entryEditorPreferences;
-    private final Tooltip previewTooltip;
-    private final PreviewViewer previewViewer;
+    private final MainTableTooltip previewTooltip;
     private ComboBox<CitationFetcherType> fetcherCombo;
 
     private boolean shouldClearSelectionOnDrop = false;
@@ -177,15 +174,7 @@ public class CitationRelationsTab extends EntryEditorTab {
 
         this.entryEditorPreferences = preferences.getEntryEditorPreferences();
 
-        this.previewTooltip = new Tooltip();
-        this.previewViewer = new PreviewViewer(dialogService, preferences, themeManager, taskExecutor);
-        this.previewViewer.resizeForTooltipContent();
-        this.previewTooltip.setGraphic(previewViewer);
-        this.previewViewer.getEngine().getLoadWorker().stateProperty().addListener((_, _, newState) -> {
-            if (newState == Worker.State.SUCCEEDED) {
-                Platform.runLater(this.previewTooltip::sizeToScene);
-            }
-        });
+        this.previewTooltip = new MainTableTooltip(dialogService, preferences, themeManager, taskExecutor);
     }
 
     private void setSciteResultsPane() {
@@ -592,9 +581,9 @@ public class CitationRelationsTab extends EntryEditorTab {
                     hContainer.getStyleClass().add("entry-container");
 
                     hContainer.setOnMouseEntered(_ -> {
-                        previewViewer.setLayout(preferences.getPreviewPreferences().getSelectedPreviewLayout());
-                        previewViewer.setDatabaseContext(stateManager.getActiveDatabase().orElse(new BibDatabaseContext()));
-                        previewViewer.setEntry(entry.entry());
+                        stateManager.getActiveDatabase().ifPresent(databaseContext -> {
+                            previewTooltip.createPreviewTooltip(databaseContext, entry.entry());
+                        });
                     });
                     Tooltip.install(hContainer, previewTooltip);
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -12,10 +12,12 @@ import java.util.Optional;
 
 import javax.swing.undo.UndoManager;
 
+import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.concurrent.Worker;
 import javafx.css.PseudoClass;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -63,6 +65,8 @@ import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.mergeentries.threewaymerge.EntriesMergeResult;
 import org.jabref.gui.mergeentries.threewaymerge.MergeEntriesDialog;
 import org.jabref.gui.preferences.GuiPreferences;
+import org.jabref.gui.preview.PreviewViewer;
+import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.undo.NamedCompoundEdit;
 import org.jabref.gui.undo.UndoableInsertEntries;
 import org.jabref.gui.undo.UndoableRemoveEntries;
@@ -124,6 +128,8 @@ public class CitationRelationsTab extends EntryEditorTab {
     private final ProgressIndicator progressIndicator;
     private final GridPane sciteResultsPane;
     private final EntryEditorPreferences entryEditorPreferences;
+    private final Tooltip previewTooltip;
+    private final PreviewViewer previewViewer;
     private ComboBox<CitationFetcherType> fetcherCombo;
 
     private boolean shouldClearSelectionOnDrop = false;
@@ -134,6 +140,7 @@ public class CitationRelationsTab extends EntryEditorTab {
                                 FileUpdateMonitor fileUpdateMonitor,
                                 GuiPreferences preferences,
                                 TaskExecutor taskExecutor,
+                                ThemeManager themeManager,
                                 BibEntryTypesManager bibEntryTypesManager,
                                 SearchCitationsRelationsService searchCitationsRelationsService) {
         this.dialogService = dialogService;
@@ -169,6 +176,16 @@ public class CitationRelationsTab extends EntryEditorTab {
         setSciteResultsPane();
 
         this.entryEditorPreferences = preferences.getEntryEditorPreferences();
+
+        this.previewTooltip = new Tooltip();
+        this.previewViewer = new PreviewViewer(dialogService, preferences, themeManager, taskExecutor);
+        this.previewViewer.resizeForTooltipContent();
+        this.previewTooltip.setGraphic(previewViewer);
+        this.previewViewer.getEngine().getLoadWorker().stateProperty().addListener((_, _, newState) -> {
+            if (newState == Worker.State.SUCCEEDED) {
+                Platform.runLater(this.previewTooltip::sizeToScene);
+            }
+        });
     }
 
     private void setSciteResultsPane() {
@@ -573,6 +590,13 @@ public class CitationRelationsTab extends EntryEditorTab {
 
                     hContainer.getChildren().addAll(entryNode, separator, vContainer);
                     hContainer.getStyleClass().add("entry-container");
+
+                    hContainer.setOnMouseEntered(_ -> {
+                        previewViewer.setLayout(preferences.getPreviewPreferences().getSelectedPreviewLayout());
+                        previewViewer.setDatabaseContext(stateManager.getActiveDatabase().orElse(new BibDatabaseContext()));
+                        previewViewer.setEntry(entry.entry());
+                    });
+                    Tooltip.install(hContainer, previewTooltip);
 
                     return hContainer;
                 })

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -580,6 +580,7 @@ public class CitationRelationsTab extends EntryEditorTab {
                     hContainer.getChildren().addAll(entryNode, separator, vContainer);
                     hContainer.getStyleClass().add("entry-container");
 
+                    // [impl->req~entry-editor.citations.hover-preview~1]
                     hContainer.setOnMouseEntered(_ -> {
                         stateManager.getActiveDatabase().ifPresent(databaseContext -> {
                             previewTooltip.createPreviewTooltip(databaseContext, entry.entry());

--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTableTooltip.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTableTooltip.java
@@ -44,4 +44,12 @@ public class MainTableTooltip extends Tooltip {
         }
         return this;
     }
+
+    public Tooltip createPreviewTooltip(BibDatabaseContext databaseContext, BibEntry entry) {
+        preview.setLayout(preferences.getPreviewPreferences().getSelectedPreviewLayout());
+        preview.setDatabaseContext(databaseContext);
+        preview.setEntry(entry);
+        setGraphic(preview);
+        return this;
+    }
 }


### PR DESCRIPTION
### Related issues and pull requests

Closes #15879 


### PR Description
1. In Citations Tab(`CitationRelationsTab.java`) I added a single reused hover pop up
2. I passed theme manager from `EntryEditor.java` to use the current theme in the pop up.
3. The intent was to improve the workflow of the user, so that they don't have to click on the {} button, as clicking disturbs the user flow.
<img width="1892" height="1043" alt="jab-ref-light" src="https://github.com/user-attachments/assets/8de02505-922b-4d2d-b21e-b12ca031bd03" />

_citation preview in light mode_

<img width="1898" height="1029" alt="jab-ref-dark" src="https://github.com/user-attachments/assets/0958389b-2289-49f9-a0dd-016cdd7572c2" />

_citation preview in dark mode_

 `jabref-contrib-policy:4.2:reviewed​:ok`



### Steps to test

1. Create a  new library
2. Add the following entry: 
```
@InProceedings{Karetnikov2024,
  author    = {Karetnikov, Aleksei and Ehrlinger, Lisa and Buchgeher, Georg and Geist, Verena},
  booktitle = {2024 IEEE International Conference on Software Analysis, Evolution and Reengineering (SANER)},
  date      = {2024-03},
  title     = {Semantic Modeling of Architecture Decision Records to Enable AI-based Analysis},
  doi       = {10.1109/SANER60148.2024.00014},
  pages     = {62--66},
  publisher = {IEEE},
}
```
3. Go to the citations tab
4. Hover over an entry in references cited in Karetnikov2024.
5. It should give a citation preview.


### AI usage
Used Antigravity(Gemini 3.5 Flash), to understand the repository, and similar implementations, and resolve issues raised by qodo.
Code was reviewed by me and I take full ownership of the code in this PR.
_____

### Checklist


- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
