### PR TITLE
SLR : Added performRawSearchQuery to Search Based Fetcher interface

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/SearchBasedFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/SearchBasedFetcher.java
@@ -39,6 +39,11 @@ public interface SearchBasedFetcher extends WebFetcher {
         return this.performSearch(getQueryNode(searchQuery));
     }
 
+    default List<BibEntry> performRawSearchQuery(String rawQuery) throws FetcherException {
+        throw new UnsupportedOperationException(
+                getName() + " has not yet been migrated to performRawSearchQuery");
+    }
+
     /// This method provides a BaseQueryNode for performSearch/performSearchPaged method
     static BaseQueryNode getQueryNode(String searchQuery) {
         // Interface does not allow private constants

--- a/jablib/src/test/java/org/jabref/logic/importer/SearchBasedFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/SearchBasedFetcherTest.java
@@ -99,7 +99,7 @@ class SearchBasedFetcherTest {
     }
 
     @Test
-    void unmigatedFetcherThrowsOnRawQuery() {
+    void unmigratedFetcherThrowsOnRawQuery() {
         StubSearchBasedFetcher fetcher = new StubSearchBasedFetcher();
         assertThrows(UnsupportedOperationException.class,
                 () -> fetcher.performRawSearchQuery("quantum"));

--- a/jablib/src/test/java/org/jabref/logic/importer/SearchBasedFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/SearchBasedFetcherTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SearchBasedFetcherTest {
@@ -95,6 +96,13 @@ class SearchBasedFetcherTest {
         // DOI fails ANTLR parsing, so it becomes a raw SearchQueryNode
         SearchQueryNode searchNode = assertInstanceOf(SearchQueryNode.class, fetcher.getLastQueryNode());
         assertEquals("10.1109/5.771073", searchNode.term());
+    }
+
+    @Test
+    void unmigatedFetcherThrowsOnRawQuery() {
+        StubSearchBasedFetcher fetcher = new StubSearchBasedFetcher();
+        assertThrows(UnsupportedOperationException.class,
+                () -> fetcher.performRawSearchQuery("quantum"));
     }
 }
 


### PR DESCRIPTION
### Related issues and pull requests

Refers #12642 

### PR Description

This is part of the SLR query routing work.
I've added `performRawSearchQuery(String)` as a new default method on `SearchBasedFetcher`. This is the method that will become the primary query execution path as fetchers override it to send a query string directly to their API without transformation.

### Steps to test

### AI usage

None

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
