### PR TITLE
Fix permission

### DIFF
--- a/.github/workflows/on-pr-changes-requested-move-labels.yml
+++ b/.github/workflows/on-pr-changes-requested-move-labels.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       actions: read
-      issues: write
+      pull-requests: write
     steps:
       - name: Download artifact from triggering run
         uses: actions/download-artifact@v8


### PR DESCRIPTION
### Related issues and pull requests

Follow-up to https://github.com/JabRef/jabref/pull/15881/

### PR Description

The workflow "Adapt PR status labels (Move)" is on a pull request - not on an issue. Different permissions are needed.

### Steps to test

1. Merge
2. See <https://github.com/JabRef/jabref/actions/workflows/on-pr-changes-requested-move-labels.yml> not failing any more.

### AI usage

AI was helpless, I needed to use my 🧠.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
