### PR TITLE
IEEE paged search start_record calculation

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -310,7 +310,7 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
             uriBuilder.addParameter("article_number", transformer.getArticleNumber().get());
         }
         // Starts to index at 1 for the first entry
-        uriBuilder.addParameter("start_record", String.valueOf(getPageSize() * pageNumber) + 1);
+        uriBuilder.addParameter("start_record", String.valueOf(getPageSize() * pageNumber + 1));
 
         return uriBuilder.build().toURL();
     }


### PR DESCRIPTION
### Related issues and pull requests

### PR Description

Just found a small bug while reading the IEEE fetcher for the SLR query routing.
`getURLForQuery(BaseQueryNode, int)` built the `start_record` URL parameter using concatenation instead of arithmetic addition.
The comment on the same line says "Starts to index at 1 for the first entry". Page 0 worked since "01" parses as 1 but pages 1 - 4 would use values like "201" which the IEEE would interpret as 201 returning empty result.

### AI usage

Claude Mythos 6.7 ( Super Secret Private Model )

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
