### PR TITLE
Fix Xmp, NameFormatter, Grobid and ProtectedTerms clear and import

### DIFF
--- a/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -227,7 +227,7 @@ public class PreferencesMigrations {
     private static void migrateFileImportPattern(String oldStylePattern,
                                                  String newStylePattern,
                                                  JabRefCliPreferences prefs) {
-        String preferenceFileNamePattern = prefs.get(V4_0_IMPORT_FILENAME_PATTERN, null);
+        String preferenceFileNamePattern = prefs.get(V4_0_IMPORT_FILENAME_PATTERN);
 
         if (oldStylePattern.equals(preferenceFileNamePattern)) {
             // Upgrade the old-style File Name pattern to new one:

--- a/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -41,6 +41,8 @@ import org.slf4j.LoggerFactory;
 
 public class PreferencesMigrations {
 
+    public static final String V4_0_IMPORT_FILENAME_PATTERN = "importFileNamePattern";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(PreferencesMigrations.class);
 
     private PreferencesMigrations() {
@@ -52,9 +54,8 @@ public class PreferencesMigrations {
 
         upgradePrefsToOrgJabRef(mainPrefsNode);
         upgradeSortOrder(preferences);
-        upgradeFaultyEncodingStrings(preferences);
         upgradeLabelPatternToCitationKeyPattern(preferences, mainPrefsNode);
-        upgradeImportFileAndDirePatterns(preferences, mainPrefsNode);
+        upgradeImportFileAndDirePatterns(preferences);
         upgradeStoredBibEntryTypes(preferences, mainPrefsNode, preferences.getCustomEntryTypesRepository());
         upgradeKeyBindingsToJavaFX(preferences);
         addCrossRefRelatedFieldsForAutoComplete(preferences);
@@ -191,27 +192,6 @@ public class PreferencesMigrations {
         }
     }
 
-    /// Migrate Import File Name and Directory name Patterns from versions <=4.0 to new BracketedPatterns
-    private static void migrateFileImportPattern(String oldStylePattern, String newStylePattern,
-                                                 JabRefCliPreferences prefs, Preferences mainPrefsNode) {
-        String preferenceFileNamePattern = mainPrefsNode.get(JabRefCliPreferences.IMPORT_FILENAMEPATTERN, null);
-
-        if (oldStylePattern.equals(preferenceFileNamePattern)) {
-            // Upgrade the old-style File Name pattern to new one:
-            mainPrefsNode.put(JabRefCliPreferences.IMPORT_FILENAMEPATTERN, newStylePattern);
-            LOGGER.info("migrated old style {} value \"{}\" to new value \"{}\" in the preference file", JabRefCliPreferences.IMPORT_FILENAMEPATTERN, oldStylePattern, newStylePattern);
-
-            if (prefs.hasKey(JabRefCliPreferences.IMPORT_FILENAMEPATTERN)) {
-                // Update also the key in the current application settings, if necessary:
-                String fileNamePattern = prefs.get(JabRefCliPreferences.IMPORT_FILENAMEPATTERN);
-                if (oldStylePattern.equals(fileNamePattern)) {
-                    prefs.put(JabRefCliPreferences.IMPORT_FILENAMEPATTERN, newStylePattern);
-                    LOGGER.info("migrated old style {} value \"{}\" to new value \"{}\" in the running application", JabRefCliPreferences.IMPORT_FILENAMEPATTERN, oldStylePattern, newStylePattern);
-                }
-            }
-        }
-    }
-
     static void upgradeResolveBibTeXStringsFields(JabRefCliPreferences prefs) {
         String oldPrefsValue = "author;booktitle;editor;editora;editorb;editorc;institution;issuetitle;journal;journalsubtitle;journaltitle;mainsubtitle;month;publisher;shortauthor;shorteditor;subtitle;titleaddon";
         String currentPrefs = prefs.get(JabRefCliPreferences.RESOLVE_STRINGS_FOR_FIELDS);
@@ -222,10 +202,9 @@ public class PreferencesMigrations {
         }
     }
 
-    static void upgradeImportFileAndDirePatterns(JabRefCliPreferences prefs, Preferences mainPrefsNode) {
-        // Migrate Import patterns
-        // Check for prefs node for Version <= 4.0
-        if (mainPrefsNode.get(JabRefCliPreferences.IMPORT_FILENAMEPATTERN, null) != null) {
+    /// Migrate Import File Name and Directory name Patterns from versions <=4.0 to new BracketedPatterns
+    static void upgradeImportFileAndDirePatterns(JabRefCliPreferences prefs) {
+        if (prefs.get(V4_0_IMPORT_FILENAME_PATTERN, null) != null) {
             String[] oldStylePatterns = new String[] {
                     "\\bibtexkey",
                     "\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}"};
@@ -235,14 +214,32 @@ public class PreferencesMigrations {
             String[] oldDisplayStylePattern = new String[] {"bibtexkey", "bibtexkey - title"};
 
             for (int i = 0; i < oldStylePatterns.length; i++) {
-                migrateFileImportPattern(oldStylePatterns[i], newStylePatterns[i], prefs, mainPrefsNode);
+                migrateFileImportPattern(oldStylePatterns[i], newStylePatterns[i], prefs);
             }
             for (int i = 0; i < oldDisplayStylePattern.length; i++) {
-                migrateFileImportPattern(oldDisplayStylePattern[i], newStylePatterns[i], prefs, mainPrefsNode);
+                migrateFileImportPattern(oldDisplayStylePattern[i], newStylePatterns[i], prefs);
             }
         }
-        // Directory preferences are not yet migrated, since it is not quote clear how to parse and reinterpret
-        // the user defined old-style patterns, and the default pattern is "".
+        // Directory preferences are not yet migrated, since it is not quite clear how to parse and reinterpret
+        // the user-defined old-style patterns, and the default pattern is "".
+    }
+
+    private static void migrateFileImportPattern(String oldStylePattern,
+                                                 String newStylePattern,
+                                                 JabRefCliPreferences prefs) {
+        String preferenceFileNamePattern = prefs.get(V4_0_IMPORT_FILENAME_PATTERN, null);
+
+        if (oldStylePattern.equals(preferenceFileNamePattern)) {
+            // Upgrade the old-style File Name pattern to new one:
+            prefs.put(V4_0_IMPORT_FILENAME_PATTERN, newStylePattern);
+            LOGGER.info("migrated old style {} value \"{}\" to new value \"{}\" in the preference file", V4_0_IMPORT_FILENAME_PATTERN, oldStylePattern, newStylePattern);
+
+            // Update also the key in the current application settings, if necessary:
+            if (oldStylePattern.equals(prefs.getFilePreferences().getFileNamePattern())) {
+                prefs.getFilePreferences().setFileNamePattern(newStylePattern);
+                LOGGER.info("migrated old style {} value \"{}\" to new value \"{}\" in the running application", V4_0_IMPORT_FILENAME_PATTERN, oldStylePattern, newStylePattern);
+            }
+        }
     }
 
     private static void upgradeKeyBindingsToJavaFX(JabRefCliPreferences prefs) {

--- a/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -2,7 +2,6 @@ package org.jabref.migrations;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -105,41 +104,6 @@ public class PreferencesMigrations {
             Preferences childNode = from.node(child);
             Preferences newChildNode = to.node(child);
             copyPrefsRecursively(childNode, newChildNode);
-        }
-    }
-
-    /// Added from Jabref 2.11 beta 4 onwards to fix wrong encoding names
-    private static void upgradeFaultyEncodingStrings(JabRefCliPreferences prefs) {
-        String defaultEncoding = prefs.get(JabRefCliPreferences.DEFAULT_ENCODING);
-        if (defaultEncoding == null) {
-            return;
-        }
-
-        Map<String, String> encodingMap = new HashMap<>();
-        encodingMap.put("UTF8", "UTF-8");
-        encodingMap.put("Cp1250", "CP1250");
-        encodingMap.put("Cp1251", "CP1251");
-        encodingMap.put("Cp1252", "CP1252");
-        encodingMap.put("Cp1253", "CP1253");
-        encodingMap.put("Cp1254", "CP1254");
-        encodingMap.put("Cp1257", "CP1257");
-        encodingMap.put("ISO8859_1", "ISO8859-1");
-        encodingMap.put("ISO8859_2", "ISO8859-2");
-        encodingMap.put("ISO8859_3", "ISO8859-3");
-        encodingMap.put("ISO8859_4", "ISO8859-4");
-        encodingMap.put("ISO8859_5", "ISO8859-5");
-        encodingMap.put("ISO8859_6", "ISO8859-6");
-        encodingMap.put("ISO8859_7", "ISO8859-7");
-        encodingMap.put("ISO8859_8", "ISO8859-8");
-        encodingMap.put("ISO8859_9", "ISO8859-9");
-        encodingMap.put("ISO8859_13", "ISO8859-13");
-        encodingMap.put("ISO8859_15", "ISO8859-15");
-        encodingMap.put("KOI8_R", "KOI8-R");
-        encodingMap.put("Big5_HKSCS", "Big5-HKSCS");
-        encodingMap.put("EUC_JP", "EUC-JP");
-
-        if (encodingMap.containsKey(defaultEncoding)) {
-            prefs.put(JabRefCliPreferences.DEFAULT_ENCODING, encodingMap.get(defaultEncoding));
         }
     }
 

--- a/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -204,7 +204,7 @@ public class PreferencesMigrations {
 
     /// Migrate Import File Name and Directory name Patterns from versions <=4.0 to new BracketedPatterns
     static void upgradeImportFileAndDirePatterns(JabRefCliPreferences prefs) {
-        if (prefs.get(V4_0_IMPORT_FILENAME_PATTERN, null) != null) {
+        if (prefs.hasKey(V4_0_IMPORT_FILENAME_PATTERN)) {
             String[] oldStylePatterns = new String[] {
                     "\\bibtexkey",
                     "\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}"};

--- a/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
+++ b/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
@@ -2,7 +2,6 @@ package org.jabref.migrations;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.prefs.Preferences;
 
 import org.jabref.gui.WorkspacePreferences;
 import org.jabref.gui.preferences.JabRefGuiPreferences;
@@ -30,7 +29,6 @@ import static org.mockito.Mockito.when;
 class GuiPreferencesMigrationsTest {
 
     private JabRefGuiPreferences preferences;
-    private Preferences mainPrefsNode;
 
     private final String[] oldStylePatterns = new String[] {"\\bibtexkey",
             "\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}"};
@@ -41,44 +39,37 @@ class GuiPreferencesMigrationsTest {
     void setUp() {
         preferences = mock(JabRefGuiPreferences.class, Answers.RETURNS_DEEP_STUBS);
         Injector.setModelOrService(CliPreferences.class, preferences);
-        mainPrefsNode = mock(Preferences.class);
     }
 
     @Test
     void oldStyleBibtexkeyPattern0() {
-        when(preferences.get(JabRefCliPreferences.IMPORT_FILENAMEPATTERN)).thenReturn(oldStylePatterns[0]);
-        when(mainPrefsNode.get(JabRefCliPreferences.IMPORT_FILENAMEPATTERN, null)).thenReturn(oldStylePatterns[0]);
-        when(preferences.hasKey(JabRefCliPreferences.IMPORT_FILENAMEPATTERN)).thenReturn(true);
+        when(preferences.get(PreferencesMigrations.V4_0_IMPORT_FILENAME_PATTERN)).thenReturn(oldStylePatterns[0]);
+        when(preferences.hasKey(PreferencesMigrations.V4_0_IMPORT_FILENAME_PATTERN)).thenReturn(true);
 
-        PreferencesMigrations.upgradeImportFileAndDirePatterns(preferences, mainPrefsNode);
+        PreferencesMigrations.upgradeImportFileAndDirePatterns(preferences);
 
-        verify(preferences).put(JabRefCliPreferences.IMPORT_FILENAMEPATTERN, newStylePatterns[0]);
-        verify(mainPrefsNode).put(JabRefCliPreferences.IMPORT_FILENAMEPATTERN, newStylePatterns[0]);
+        verify(preferences).put(PreferencesMigrations.V4_0_IMPORT_FILENAME_PATTERN, newStylePatterns[0]);
     }
 
     @Test
     void oldStyleBibtexkeyPattern1() {
-        when(preferences.get(JabRefCliPreferences.IMPORT_FILENAMEPATTERN)).thenReturn(oldStylePatterns[1]);
-        when(mainPrefsNode.get(JabRefCliPreferences.IMPORT_FILENAMEPATTERN, null)).thenReturn(oldStylePatterns[1]);
-        when(preferences.hasKey(JabRefCliPreferences.IMPORT_FILENAMEPATTERN)).thenReturn(true);
+        when(preferences.get(PreferencesMigrations.V4_0_IMPORT_FILENAME_PATTERN)).thenReturn(oldStylePatterns[1]);
+        when(preferences.hasKey(PreferencesMigrations.V4_0_IMPORT_FILENAME_PATTERN)).thenReturn(true);
 
-        PreferencesMigrations.upgradeImportFileAndDirePatterns(preferences, mainPrefsNode);
+        PreferencesMigrations.upgradeImportFileAndDirePatterns(preferences);
 
-        verify(preferences).put(JabRefCliPreferences.IMPORT_FILENAMEPATTERN, newStylePatterns[1]);
-        verify(mainPrefsNode).put(JabRefCliPreferences.IMPORT_FILENAMEPATTERN, newStylePatterns[1]);
+        verify(preferences).put(PreferencesMigrations.V4_0_IMPORT_FILENAME_PATTERN, newStylePatterns[1]);
     }
 
     @Test
     void arbitraryBibtexkeyPattern() {
         String arbitraryPattern = "[anyUserPrividedString]";
 
-        when(preferences.get(JabRefCliPreferences.IMPORT_FILENAMEPATTERN)).thenReturn(arbitraryPattern);
-        when(mainPrefsNode.get(JabRefCliPreferences.IMPORT_FILENAMEPATTERN, null)).thenReturn(arbitraryPattern);
+        when(preferences.get(PreferencesMigrations.V4_0_IMPORT_FILENAME_PATTERN)).thenReturn(arbitraryPattern);
 
-        PreferencesMigrations.upgradeImportFileAndDirePatterns(preferences, mainPrefsNode);
+        PreferencesMigrations.upgradeImportFileAndDirePatterns(preferences);
 
-        verify(preferences, never()).put(JabRefCliPreferences.IMPORT_FILENAMEPATTERN, arbitraryPattern);
-        verify(mainPrefsNode, never()).put(JabRefCliPreferences.IMPORT_FILENAMEPATTERN, arbitraryPattern);
+        verify(preferences, never()).put(PreferencesMigrations.V4_0_IMPORT_FILENAME_PATTERN, arbitraryPattern);
     }
 
     @Test

--- a/jablib/src/main/java/org/jabref/logic/importer/util/GrobidPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/util/GrobidPreferences.java
@@ -6,9 +6,18 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
 public class GrobidPreferences {
+
     private final BooleanProperty grobidEnabled;
     private final BooleanProperty grobidUseAsked;
     private final StringProperty grobidURL;
+
+    private GrobidPreferences() {
+        this(
+                false,                          // Grobid enabled
+                false,                          // Grobid use asked
+                "http://grobid.jabref.org:8070" // Grobid URL
+        );
+    }
 
     public GrobidPreferences(boolean grobidEnabled,
                              boolean grobidUseAsked,
@@ -16,6 +25,16 @@ public class GrobidPreferences {
         this.grobidEnabled = new SimpleBooleanProperty(grobidEnabled);
         this.grobidUseAsked = new SimpleBooleanProperty(grobidUseAsked);
         this.grobidURL = new SimpleStringProperty(grobidURL);
+    }
+
+    public static GrobidPreferences getDefault() {
+        return new GrobidPreferences();
+    }
+
+    public void setAll(GrobidPreferences preferences) {
+        this.grobidEnabled.set(preferences.isGrobidEnabled());
+        this.grobidUseAsked.set(preferences.isGrobidUseAsked());
+        this.grobidURL.set(preferences.getGrobidURL());
     }
 
     public boolean isGrobidEnabled() {

--- a/jablib/src/main/java/org/jabref/logic/layout/format/NameFormatterPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/layout/format/NameFormatterPreferences.java
@@ -7,16 +7,13 @@ import javafx.collections.ObservableList;
 
 public class NameFormatterPreferences {
 
-    private static final List<String> DEFAULT_NAME_FORMATTER_KEY = List.of();   // No default name formatter keys
-    private static final List<String> DEFAULT_NAME_FORMATTER_VALUE = List.of(); // No default name formatter values
-
     private final ObservableList<String> nameFormatterKey;
     private final ObservableList<String> nameFormatterValue;
 
     private NameFormatterPreferences() {
         this(
-                DEFAULT_NAME_FORMATTER_KEY,   // Name formatter keys
-                DEFAULT_NAME_FORMATTER_VALUE  // Name formatter values
+                List.of(), // Name formatter keys
+                List.of()  // Name formatter values
         );
     }
 

--- a/jablib/src/main/java/org/jabref/logic/layout/format/NameFormatterPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/layout/format/NameFormatterPreferences.java
@@ -7,12 +7,31 @@ import javafx.collections.ObservableList;
 
 public class NameFormatterPreferences {
 
+    private static final List<String> DEFAULT_NAME_FORMATTER_KEY = List.of();   // No default name formatter keys
+    private static final List<String> DEFAULT_NAME_FORMATTER_VALUE = List.of(); // No default name formatter values
+
     private final ObservableList<String> nameFormatterKey;
     private final ObservableList<String> nameFormatterValue;
+
+    private NameFormatterPreferences() {
+        this(
+                DEFAULT_NAME_FORMATTER_KEY,   // Name formatter keys
+                DEFAULT_NAME_FORMATTER_VALUE  // Name formatter values
+        );
+    }
 
     public NameFormatterPreferences(List<String> nameFormatterKey, List<String> nameFormatterValue) {
         this.nameFormatterKey = FXCollections.observableArrayList(nameFormatterKey);
         this.nameFormatterValue = FXCollections.observableArrayList(nameFormatterValue);
+    }
+
+    public static NameFormatterPreferences getDefault() {
+        return new NameFormatterPreferences();
+    }
+
+    public void setAll(NameFormatterPreferences preferences) {
+        this.nameFormatterKey.setAll(preferences.getNameFormatterKey());
+        this.nameFormatterValue.setAll(preferences.getNameFormatterValue());
     }
 
     public ObservableList<String> getNameFormatterKey() {

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -295,9 +295,6 @@ public class JabRefCliPreferences implements CliPreferences {
     // Helper string
     protected static final String USER_HOME = System.getProperty("user.home");
 
-    // UI
-    private static final String FONT_FAMILY = "fontFamily";
-
     // region last files opened
     private static final String LAST_EDITED = "lastEdited";
     private static final String LAST_FOCUSED = "lastFocused";
@@ -390,8 +387,6 @@ public class JabRefCliPreferences implements CliPreferences {
 
     private static final String OPEN_FILE_EXPLORER_IN_FILE_DIRECTORY = "openFileExplorerInFileDirectory";
     private static final String OPEN_FILE_EXPLORER_IN_LAST_USED_DIRECTORY = "openFileExplorerInLastUsedDirectory";
-
-    private static final String MAIN_FILE_DIRECTORY_WALKTHROUGH_COMPLETED = "mainFileDirectoryWalkthroughCompleted";
 
     // region Push to application preferences
     private static final String PUSH_TO_APPLICATION = "pushToApplication";
@@ -491,13 +486,6 @@ public class JabRefCliPreferences implements CliPreferences {
         defaults.put(GROBID_URL, "http://grobid.jabref.org:8070");
         // endregion
 
-        if (OS.OS_X) {
-            defaults.put(FONT_FAMILY, "SansSerif");
-        } else {
-            // Linux
-            defaults.put(FONT_FAMILY, "SansSerif");
-        }
-
         // system locale as default
         defaults.put(LANGUAGE, Locale.getDefault().getLanguage());
 
@@ -524,9 +512,6 @@ public class JabRefCliPreferences implements CliPreferences {
         // Otherwise that language framework will be instantiated and more importantly, statically initialized preferences
         // will never be translated.
         Localization.setLanguage(getLanguage());
-
-        // WalkThrough
-        defaults.put(MAIN_FILE_DIRECTORY_WALKTHROUGH_COMPLETED, Boolean.FALSE);
 
         // region Git preferences
         defaults.put(GITHUB_PAT_KEY, "");

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -138,24 +138,23 @@ public class JabRefCliPreferences implements CliPreferences {
     public static final String LIBRARY_ADD_IMPORTED_ENTRIES_GROUP_NAME = "addImportedEntriesGroupName";
     // endregion
 
-    public static final String EXPORT_IN_ORIGINAL_ORDER = "exportInOriginalOrder";
-    public static final String EXPORT_IN_SPECIFIED_ORDER = "exportInSpecifiedOrder";
-
+    // region ExportPreferences
+    public static final String LAST_USED_EXPORT = "lastUsedExport";
+    public static final String EXPORT_WORKING_DIRECTORY = "exportWorkingDirectory";
     public static final String EXPORT_PRIMARY_SORT_FIELD = "exportPriSort";
     public static final String EXPORT_PRIMARY_SORT_DESCENDING = "exportPriDescending";
     public static final String EXPORT_SECONDARY_SORT_FIELD = "exportSecSort";
     public static final String EXPORT_SECONDARY_SORT_DESCENDING = "exportSecDescending";
     public static final String EXPORT_TERTIARY_SORT_FIELD = "exportTerSort";
     public static final String EXPORT_TERTIARY_SORT_DESCENDING = "exportTerDescending";
+    public static final String EXPORT_IN_ORIGINAL_ORDER = "exportInOriginalOrder";
+    public static final String EXPORT_IN_SPECIFIED_ORDER = "exportInSpecifiedOrder";
+    // endregion
 
+    // region XmpPreferences
+    public static final String XMP_USE_PRIVACY_FILTER = "useXmpPrivacyFilter";
     public static final String XMP_PRIVACY_FILTERS = "xmpPrivacyFilters";
-    public static final String USE_XMP_PRIVACY_FILTER = "useXmpPrivacyFilter";
-
-    public static final String LAST_USED_EXPORT = "lastUsedExport";
-    public static final String EXPORT_WORKING_DIRECTORY = "exportWorkingDirectory";
-    public static final String WORKING_DIRECTORY = "workingDirectory";
-    public static final String BACKUP_DIRECTORY = "backupDirectory";
-    public static final String CREATE_BACKUP = "createBackup";
+    // endregion
 
     public static final String KEYWORD_SEPARATOR = "groupKeywordSeparator";
 
@@ -199,8 +198,6 @@ public class JabRefCliPreferences implements CliPreferences {
 
     public static final String CUSTOM_EXPORT_FORMAT = "customExportFormat";
 
-    public static final String MAIN_FILE_DIRECTORY = "fileDirectory";
-
     public static final String SEARCH_DISPLAY_MODE = "searchDisplayMode";
     public static final String SEARCH_CASE_SENSITIVE = "caseSensitiveSearch";
     public static final String SEARCH_REG_EXP = "regExpSearch";
@@ -214,13 +211,6 @@ public class JabRefCliPreferences implements CliPreferences {
     public static final String GROBID_ENABLED = "grobidEnabled";
     public static final String GROBID_PREFERENCE = "grobidPreference";
     public static final String GROBID_URL = "grobidURL";
-
-    public static final String CONFIRM_LINKED_FILE_DELETE = "confirmLinkedFileDelete";
-    public static final String TRASH_INSTEAD_OF_DELETE = "trashInsteadOfDelete";
-
-    public static final String ADJUST_FILE_LINKS_ON_TRANSFER = "adjustFileLinksOnTransfer";
-    public static final String COPY_LINKED_FILES_ON_TRANSFER = "copyLinkedFilesOnTransfer";
-    public static final String MOVE_LINKED_FILES_ON_TRANSFER = "moveLinkedFilesOnTransfer";
 
     // region CitationKeyPreferences
     public static final String CITATION_KEY_TRANSLITERATE_FIELDS = "transliterateFields";
@@ -240,15 +230,10 @@ public class JabRefCliPreferences implements CliPreferences {
     public static final String AUTOLINK_USE_REG_EXP_SEARCH_KEY = "useRegExpSearch";
     // bibLocAsPrimaryDir is a misleading antique variable name, we keep it for reason of compatibility
 
-    public static final String STORE_RELATIVE_TO_BIB = "bibLocAsPrimaryDir";
-
     public static final String ASK_AUTO_NAMING_PDFS_AGAIN = "AskAutoNamingPDFsAgain";
     public static final String CLEANUP_JOBS = "CleanUpJobs";
     public static final String CLEANUP_FIELD_FORMATTERS_ENABLED = "CleanUpFormattersEnabled";
     public static final String CLEANUP_FIELD_FORMATTERS = "CleanUpFormatters";
-    public static final String AUTO_RENAME_FILES_ON_CHANGE = "autoRenameFilesOnChange";
-    public static final String IMPORT_FILENAMEPATTERN = "importFileNamePattern";
-    public static final String IMPORT_FILEDIRPATTERN = "importFileDirPattern";
     public static final String NAME_FORMATTER_VALUE = "nameFormatterFormats";
     public static final String NAME_FORMATER_KEY = "nameFormatterNames";
 
@@ -288,6 +273,31 @@ public class JabRefCliPreferences implements CliPreferences {
     // String delimiter
     public static final Character STRINGLIST_DELIMITER = ';';
 
+    // region (Linked)FilePreferences
+    private static final String FILES_MAIN_DIRECTORY = "fileDirectory";
+    private static final String FILES_STORE_RELATIVE_TO_BIB = "bibLocAsPrimaryDir";
+    private static final String FILES_AUTO_RENAME_ON_CHANGE = "autoRenameFilesOnChange";
+    private static final String FILES_IMPORT_NAMEPATTERN = "importFileNamePattern";
+    private static final String FILES_IMPORT_DIRPATTERN = "importFileDirPattern";
+    private static final String FILES_DOWNLOAD_LINKED = "downloadLinkedFiles";
+    private static final String FILES_FULLTEXT_INDEX = "fulltextIndexLinkedFiles";
+    private static final String FILES_WORKING_DIRECTORY = "workingDirectory";
+
+    // FixMe: Missplaced
+    private static final String BACKUP_ENABLED = "createBackup";
+    private static final String BACKUP_DIRECTORY = "backupDirectory";
+
+    private static final String FILES_CONFIRM_DELETE_LINKED = "confirmLinkedFileDelete";
+    private static final String FILES_TRASH_INSTEAD_OF_DELETE = "trashInsteadOfDelete";
+    private static final String FILES_ADJUST_FILE_LINKS_ON_TRANSFER = "adjustFileLinksOnTransfer";
+    private static final String FILES_COPY_LINKED_FILES_ON_TRANSFER = "copyLinkedFilesOnTransfer";
+    private static final String FILES_MOVE_LINKED_FILES_ON_TRANSFER = "moveLinkedFilesOnTransfer";
+    private static final String FILES_KEEP_DOWNLOAD_URL = "keepDownloadUrl";
+    private static final String FILES_LAST_USED_DIRECTORY = "lastUsedDirectory";
+    private static final String FILES_OPEN_FILE_EXPLORER_IN_FILE_DIRECTORY = "openFileExplorerInFileDirectory";
+    private static final String FILES_OPEN_FILE_EXPLORER_IN_LAST_USED_DIRECTORY = "openFileExplorerInLastUsedDirectory";
+    // endregion
+
     // region last files opened
     private static final String LAST_EDITED = "lastEdited";
     private static final String LAST_FOCUSED = "lastFocused";
@@ -319,9 +329,6 @@ public class JabRefCliPreferences implements CliPreferences {
 
     // Dialog states
     private static final String PREFS_EXPORT_PATH = "prefsExportPath";
-    private static final String DOWNLOAD_LINKED_FILES = "downloadLinkedFiles";
-    private static final String FULLTEXT_INDEX_LINKED_FILES = "fulltextIndexLinkedFiles";
-    private static final String KEEP_DOWNLOAD_URL = "keepDownloadUrl";
 
     // Indexes for Strings within stored custom export entries
     private static final int EXPORTER_NAME_INDEX = 0;
@@ -375,11 +382,6 @@ public class JabRefCliPreferences implements CliPreferences {
     private static final String AI_SUMMARIZATION_FULL_DOCUMENT_SYSTEM_MESSAGE_TEMPLATE = "aiSummarizationFullDocumentSystemMessageTemplate";
     private static final String AI_MARKDOWN_CHAT_EXPORT_TEMPLATE = "aiMarkdownChatExportTemplate";
     // endregion
-
-    private static final String LAST_USED_DIRECTORY = "lastUsedDirectory";
-
-    private static final String OPEN_FILE_EXPLORER_IN_FILE_DIRECTORY = "openFileExplorerInFileDirectory";
-    private static final String OPEN_FILE_EXPLORER_IN_LAST_USED_DIRECTORY = "openFileExplorerInLastUsedDirectory";
 
     // region Push to application preferences
     private static final String PUSH_TO_APPLICATION = "pushToApplication";
@@ -1491,25 +1493,25 @@ public class JabRefCliPreferences implements CliPreferences {
 
         filePreferences = getFilePreferencesFromBackingStore(FilePreferences.getDefault());
 
-        EasyBind.listen(filePreferences.mainFileDirectoryProperty(), (_, _, newValue) -> put(MAIN_FILE_DIRECTORY, newValue != null ? newValue.toString() : ""));
-        EasyBind.listen(filePreferences.storeFilesRelativeToBibFileProperty(), (_, _, newValue) -> putBoolean(STORE_RELATIVE_TO_BIB, newValue));
-        EasyBind.listen(filePreferences.autoRenameFilesOnChangeProperty(), (_, _, newValue) -> putBoolean(AUTO_RENAME_FILES_ON_CHANGE, newValue));
-        EasyBind.listen(filePreferences.fileNamePatternProperty(), (_, _, newValue) -> put(IMPORT_FILENAMEPATTERN, newValue));
-        EasyBind.listen(filePreferences.fileDirectoryPatternProperty(), (_, _, newValue) -> put(IMPORT_FILEDIRPATTERN, newValue));
-        EasyBind.listen(filePreferences.downloadLinkedFilesProperty(), (_, _, newValue) -> putBoolean(DOWNLOAD_LINKED_FILES, newValue));
-        EasyBind.listen(filePreferences.fulltextIndexLinkedFilesProperty(), (_, _, newValue) -> putBoolean(FULLTEXT_INDEX_LINKED_FILES, newValue));
-        EasyBind.listen(filePreferences.workingDirectoryProperty(), (_, _, newValue) -> put(WORKING_DIRECTORY, newValue.toString()));
-        EasyBind.listen(filePreferences.createBackupProperty(), (_, _, newValue) -> putBoolean(CREATE_BACKUP, newValue));
+        EasyBind.listen(filePreferences.mainFileDirectoryProperty(), (_, _, newValue) -> put(FILES_MAIN_DIRECTORY, newValue != null ? newValue.toString() : ""));
+        EasyBind.listen(filePreferences.storeFilesRelativeToBibFileProperty(), (_, _, newValue) -> putBoolean(FILES_STORE_RELATIVE_TO_BIB, newValue));
+        EasyBind.listen(filePreferences.autoRenameFilesOnChangeProperty(), (_, _, newValue) -> putBoolean(FILES_AUTO_RENAME_ON_CHANGE, newValue));
+        EasyBind.listen(filePreferences.fileNamePatternProperty(), (_, _, newValue) -> put(FILES_IMPORT_NAMEPATTERN, newValue));
+        EasyBind.listen(filePreferences.fileDirectoryPatternProperty(), (_, _, newValue) -> put(FILES_IMPORT_DIRPATTERN, newValue));
+        EasyBind.listen(filePreferences.downloadLinkedFilesProperty(), (_, _, newValue) -> putBoolean(FILES_DOWNLOAD_LINKED, newValue));
+        EasyBind.listen(filePreferences.fulltextIndexLinkedFilesProperty(), (_, _, newValue) -> putBoolean(FILES_FULLTEXT_INDEX, newValue));
+        EasyBind.listen(filePreferences.workingDirectoryProperty(), (_, _, newValue) -> put(FILES_WORKING_DIRECTORY, newValue.toString()));
+        EasyBind.listen(filePreferences.createBackupProperty(), (_, _, newValue) -> putBoolean(BACKUP_ENABLED, newValue));
         EasyBind.listen(filePreferences.backupDirectoryProperty(), (_, _, newValue) -> put(BACKUP_DIRECTORY, newValue.toString()));
-        EasyBind.listen(filePreferences.confirmDeleteLinkedFileProperty(), (_, _, newValue) -> putBoolean(CONFIRM_LINKED_FILE_DELETE, newValue));
-        EasyBind.listen(filePreferences.moveToTrashProperty(), (_, _, newValue) -> putBoolean(TRASH_INSTEAD_OF_DELETE, newValue));
-        EasyBind.listen(filePreferences.adjustFileLinksOnTransferProperty(), (_, _, newValue) -> putBoolean(ADJUST_FILE_LINKS_ON_TRANSFER, newValue));
-        EasyBind.listen(filePreferences.copyLinkedFilesOnTransferProperty(), (_, _, newValue) -> putBoolean(COPY_LINKED_FILES_ON_TRANSFER, newValue));
-        EasyBind.listen(filePreferences.moveLinkedFilesOnTransferPropertyProperty(), (_, _, newValue) -> putBoolean(MOVE_LINKED_FILES_ON_TRANSFER, newValue));
-        EasyBind.listen(filePreferences.shouldKeepDownloadUrlProperty(), (_, _, newValue) -> putBoolean(KEEP_DOWNLOAD_URL, newValue));
-        EasyBind.listen(filePreferences.lastUsedDirectoryProperty(), (_, _, newValue) -> put(LAST_USED_DIRECTORY, newValue.toString()));
-        EasyBind.listen(filePreferences.openFileExplorerInFileDirectoryProperty(), (_, _, newValue) -> putBoolean(OPEN_FILE_EXPLORER_IN_FILE_DIRECTORY, newValue));
-        EasyBind.listen(filePreferences.openFileExplorerInLastUsedDirectoryProperty(), (_, _, newValue) -> putBoolean(OPEN_FILE_EXPLORER_IN_LAST_USED_DIRECTORY, newValue));
+        EasyBind.listen(filePreferences.confirmDeleteLinkedFileProperty(), (_, _, newValue) -> putBoolean(FILES_CONFIRM_DELETE_LINKED, newValue));
+        EasyBind.listen(filePreferences.moveToTrashProperty(), (_, _, newValue) -> putBoolean(FILES_TRASH_INSTEAD_OF_DELETE, newValue));
+        EasyBind.listen(filePreferences.adjustFileLinksOnTransferProperty(), (_, _, newValue) -> putBoolean(FILES_ADJUST_FILE_LINKS_ON_TRANSFER, newValue));
+        EasyBind.listen(filePreferences.copyLinkedFilesOnTransferProperty(), (_, _, newValue) -> putBoolean(FILES_COPY_LINKED_FILES_ON_TRANSFER, newValue));
+        EasyBind.listen(filePreferences.moveLinkedFilesOnTransferPropertyProperty(), (_, _, newValue) -> putBoolean(FILES_MOVE_LINKED_FILES_ON_TRANSFER, newValue));
+        EasyBind.listen(filePreferences.shouldKeepDownloadUrlProperty(), (_, _, newValue) -> putBoolean(FILES_KEEP_DOWNLOAD_URL, newValue));
+        EasyBind.listen(filePreferences.lastUsedDirectoryProperty(), (_, _, newValue) -> put(FILES_LAST_USED_DIRECTORY, newValue.toString()));
+        EasyBind.listen(filePreferences.openFileExplorerInFileDirectoryProperty(), (_, _, newValue) -> putBoolean(FILES_OPEN_FILE_EXPLORER_IN_FILE_DIRECTORY, newValue));
+        EasyBind.listen(filePreferences.openFileExplorerInLastUsedDirectoryProperty(), (_, _, newValue) -> putBoolean(FILES_OPEN_FILE_EXPLORER_IN_LAST_USED_DIRECTORY, newValue));
 
         return filePreferences;
     }
@@ -1517,27 +1519,27 @@ public class JabRefCliPreferences implements CliPreferences {
     private FilePreferences getFilePreferencesFromBackingStore(FilePreferences defaults) {
         return new FilePreferences(
                 getInternalPreferences().getUserAndHostInfoProperty(),
-                getPath(MAIN_FILE_DIRECTORY, defaults.mainFileDirectoryProperty().get()),
-                getBoolean(STORE_RELATIVE_TO_BIB, defaults.shouldStoreFilesRelativeToBibFile()),
-                getBoolean(AUTO_RENAME_FILES_ON_CHANGE, defaults.shouldAutoRenameFilesOnChange()),
-                get(IMPORT_FILENAMEPATTERN, defaults.getFileNamePattern()),
-                get(IMPORT_FILEDIRPATTERN, defaults.getFileDirectoryPattern()),
-                getBoolean(DOWNLOAD_LINKED_FILES, defaults.shouldDownloadLinkedFiles()),
-                getBoolean(FULLTEXT_INDEX_LINKED_FILES, defaults.shouldFulltextIndexLinkedFiles()),
-                Path.of(get(WORKING_DIRECTORY, defaults.getWorkingDirectory().toString())),
-                getBoolean(CREATE_BACKUP, defaults.shouldCreateBackup()),
+                getPath(FILES_MAIN_DIRECTORY, defaults.mainFileDirectoryProperty().get()),
+                getBoolean(FILES_STORE_RELATIVE_TO_BIB, defaults.shouldStoreFilesRelativeToBibFile()),
+                getBoolean(FILES_AUTO_RENAME_ON_CHANGE, defaults.shouldAutoRenameFilesOnChange()),
+                get(FILES_IMPORT_NAMEPATTERN, defaults.getFileNamePattern()),
+                get(FILES_IMPORT_DIRPATTERN, defaults.getFileDirectoryPattern()),
+                getBoolean(FILES_DOWNLOAD_LINKED, defaults.shouldDownloadLinkedFiles()),
+                getBoolean(FILES_FULLTEXT_INDEX, defaults.shouldFulltextIndexLinkedFiles()),
+                Path.of(get(FILES_WORKING_DIRECTORY, defaults.getWorkingDirectory().toString())),
+                getBoolean(BACKUP_ENABLED, defaults.shouldCreateBackup()),
                 // We choose the data directory, because a ".bak" file should survive cache cleanups
                 getPath(BACKUP_DIRECTORY, defaults.getBackupDirectory()),
-                getBoolean(CONFIRM_LINKED_FILE_DELETE, defaults.confirmDeleteLinkedFile()),
+                getBoolean(FILES_CONFIRM_DELETE_LINKED, defaults.confirmDeleteLinkedFile()),
                 // We make use of the fallback, because we need AWT being initialized, which is not the case at the constructor JabRefPreferences()
-                getBoolean(TRASH_INSTEAD_OF_DELETE, moveToTrashSupported()),
-                getBoolean(ADJUST_FILE_LINKS_ON_TRANSFER, defaults.shouldAdjustFileLinksOnTransfer()),
-                getBoolean(COPY_LINKED_FILES_ON_TRANSFER, defaults.shouldCopyLinkedFilesOnTransfer()),
-                getBoolean(MOVE_LINKED_FILES_ON_TRANSFER, defaults.shouldMoveLinkedFilesOnTransfer()),
-                getBoolean(KEEP_DOWNLOAD_URL, defaults.shouldKeepDownloadUrl()),
-                getPath(LAST_USED_DIRECTORY, defaults.getLastUsedDirectory()),
-                getBoolean(OPEN_FILE_EXPLORER_IN_FILE_DIRECTORY, defaults.shouldOpenFileExplorerInFileDirectory()),
-                getBoolean(OPEN_FILE_EXPLORER_IN_LAST_USED_DIRECTORY, defaults.shouldOpenFileExplorerInLastUsedDirectory()));
+                getBoolean(FILES_TRASH_INSTEAD_OF_DELETE, moveToTrashSupported()),
+                getBoolean(FILES_ADJUST_FILE_LINKS_ON_TRANSFER, defaults.shouldAdjustFileLinksOnTransfer()),
+                getBoolean(FILES_COPY_LINKED_FILES_ON_TRANSFER, defaults.shouldCopyLinkedFilesOnTransfer()),
+                getBoolean(FILES_MOVE_LINKED_FILES_ON_TRANSFER, defaults.shouldMoveLinkedFilesOnTransfer()),
+                getBoolean(FILES_KEEP_DOWNLOAD_URL, defaults.shouldKeepDownloadUrl()),
+                getPath(FILES_LAST_USED_DIRECTORY, defaults.getLastUsedDirectory()),
+                getBoolean(FILES_OPEN_FILE_EXPLORER_IN_FILE_DIRECTORY, defaults.shouldOpenFileExplorerInFileDirectory()),
+                getBoolean(FILES_OPEN_FILE_EXPLORER_IN_LAST_USED_DIRECTORY, defaults.shouldOpenFileExplorerInLastUsedDirectory()));
     }
 
     protected boolean moveToTrashSupported() {
@@ -2003,7 +2005,7 @@ public class JabRefCliPreferences implements CliPreferences {
         xmpPreferences = getXmpPreferencesFromBackingStore(XmpPreferences.getDefault());
 
         EasyBind.listen(xmpPreferences.useXmpPrivacyFilterProperty(),
-                (_, _, newValue) -> putBoolean(USE_XMP_PRIVACY_FILTER, newValue));
+                (_, _, newValue) -> putBoolean(XMP_USE_PRIVACY_FILTER, newValue));
         xmpPreferences.getXmpPrivacyFilter().addListener((SetChangeListener<Field>) _ ->
                 putStringList(XMP_PRIVACY_FILTERS, xmpPreferences.getXmpPrivacyFilter().stream()
                                                                  .map(Field::getName)
@@ -2014,7 +2016,7 @@ public class JabRefCliPreferences implements CliPreferences {
 
     private XmpPreferences getXmpPreferencesFromBackingStore(XmpPreferences defaults) {
         return new XmpPreferences(
-                getBoolean(USE_XMP_PRIVACY_FILTER, defaults.shouldUseXmpPrivacyFilter()),
+                getBoolean(XMP_USE_PRIVACY_FILTER, defaults.shouldUseXmpPrivacyFilter()),
                 convertStringToList(get(XMP_PRIVACY_FILTERS,
                         convertListToString(defaults.getXmpPrivacyFilter().stream().map(Field::getName).toList())))
                         .stream()

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -71,7 +71,6 @@ import org.jabref.logic.openoffice.OpenOfficePreferences;
 import org.jabref.logic.openoffice.style.JStyle;
 import org.jabref.logic.openoffice.style.OOStyle;
 import org.jabref.logic.os.OS;
-import org.jabref.logic.protectedterms.ProtectedTermsLoader;
 import org.jabref.logic.protectedterms.ProtectedTermsPreferences;
 import org.jabref.logic.push.CitationCommandString;
 import org.jabref.logic.push.PushApplications;
@@ -500,11 +499,6 @@ public class JabRefCliPreferences implements CliPreferences {
 
         defaults.put(DEFAULT_ENCODING, StandardCharsets.UTF_8.name());
 
-        defaults.put(PROTECTED_TERMS_ENABLED_INTERNAL, convertListToString(ProtectedTermsLoader.getInternalLists()));
-        defaults.put(PROTECTED_TERMS_DISABLED_INTERNAL, "");
-        defaults.put(PROTECTED_TERMS_ENABLED_EXTERNAL, "");
-        defaults.put(PROTECTED_TERMS_DISABLED_EXTERNAL, "");
-
         defaults.put(LAST_USED_EXPORT, "");
 
         // Since some of the preference settings themselves use localized strings, we cannot set the language after
@@ -835,6 +829,7 @@ public class JabRefCliPreferences implements CliPreferences {
         getSearchPreferences().setAll(SearchPreferences.getDefault());
         getLastFilesOpenedPreferences().setAll(LastFilesOpenedPreferences.getDefault());
         getXmpPreferences().setAll(XmpPreferences.getDefault());
+        getProtectedTermsPreferences().setAll(ProtectedTermsPreferences.getDefault());
         getOpenOfficePreferences(JournalAbbreviationLoader.loadRepository(getJournalAbbreviationPreferences())).setAll(
                 OpenOfficePreferences.getDefault());
     }
@@ -874,6 +869,7 @@ public class JabRefCliPreferences implements CliPreferences {
         getSearchPreferences().setAll(getSearchPreferencesFromBackingStore(getSearchPreferences()));
         getLastFilesOpenedPreferences().setAll(getLastFilesOpenedPreferencesFromBackingStore(getLastFilesOpenedPreferences()));
         getXmpPreferences().setAll(getXmpPreferencesFromBackingStore(getXmpPreferences()));
+        getProtectedTermsPreferences().setAll(getProtectedTermsPreferencesFromBackingStore(getProtectedTermsPreferences()));
         JournalAbbreviationRepository repository = JournalAbbreviationLoader.loadRepository(getJournalAbbreviationPreferences());
         getOpenOfficePreferences(repository).setAll(
                 getOpenOfficePreferencesFromBackingStore(getOpenOfficePreferences(repository), repository));
@@ -2085,12 +2081,7 @@ public class JabRefCliPreferences implements CliPreferences {
             return protectedTermsPreferences;
         }
 
-        protectedTermsPreferences = new ProtectedTermsPreferences(
-                getStringList(PROTECTED_TERMS_ENABLED_INTERNAL),
-                getStringList(PROTECTED_TERMS_ENABLED_EXTERNAL),
-                getStringList(PROTECTED_TERMS_DISABLED_INTERNAL),
-                getStringList(PROTECTED_TERMS_DISABLED_EXTERNAL)
-        );
+        protectedTermsPreferences = getProtectedTermsPreferencesFromBackingStore(ProtectedTermsPreferences.getDefault());
 
         protectedTermsPreferences.getEnabledExternalTermLists().addListener((InvalidationListener) _ ->
                 putStringList(PROTECTED_TERMS_ENABLED_EXTERNAL, protectedTermsPreferences.getEnabledExternalTermLists()));
@@ -2102,6 +2093,15 @@ public class JabRefCliPreferences implements CliPreferences {
                 putStringList(PROTECTED_TERMS_DISABLED_INTERNAL, protectedTermsPreferences.getDisabledInternalTermLists()));
 
         return protectedTermsPreferences;
+    }
+
+    private ProtectedTermsPreferences getProtectedTermsPreferencesFromBackingStore(ProtectedTermsPreferences defaults) {
+        return new ProtectedTermsPreferences(
+                convertStringToList(get(PROTECTED_TERMS_ENABLED_INTERNAL, convertListToString(defaults.getEnabledInternalTermLists()))),
+                convertStringToList(get(PROTECTED_TERMS_ENABLED_EXTERNAL, convertListToString(defaults.getEnabledExternalTermLists()))),
+                convertStringToList(get(PROTECTED_TERMS_DISABLED_INTERNAL, convertListToString(defaults.getDisabledInternalTermLists()))),
+                convertStringToList(get(PROTECTED_TERMS_DISABLED_EXTERNAL, convertListToString(defaults.getDisabledExternalTermLists())))
+        );
     }
     // endregion
 

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -476,9 +476,6 @@ public class JabRefCliPreferences implements CliPreferences {
             LOGGER.warn("Could not import preferences from jabref.xml", e);
         }
 
-        // system locale as default
-        defaults.put(LANGUAGE, Locale.getDefault().getLanguage());
-
         // Since some of the preference settings themselves use localized strings, we cannot set the language after
         // the initialization of the preferences in main
         // Otherwise that language framework will be instantiated and more importantly, statically initialized preferences
@@ -872,7 +869,7 @@ public class JabRefCliPreferences implements CliPreferences {
     }
 
     protected Language getLanguage() {
-        return Language.getLanguageFor(get(LANGUAGE));
+        return Language.getLanguageFor(get(LANGUAGE, Locale.getDefault().getLanguage()));
     }
 
     // region JournalAbbreviationPreferences
@@ -1190,7 +1187,7 @@ public class JabRefCliPreferences implements CliPreferences {
     }
     // endregion
 
-    // region Proxy Preferences
+    // region ProxyPreferences
     @Override
     public ProxyPreferences getProxyPreferences() {
         if (proxyPreferences != null) {
@@ -1489,10 +1486,6 @@ public class JabRefCliPreferences implements CliPreferences {
     // endregion
 
     // region (Linked)FilePreferences
-    protected boolean moveToTrashSupported() {
-        return false;
-    }
-
     @Override
     public FilePreferences getFilePreferences() {
         if (filePreferences != null) {
@@ -1548,6 +1541,10 @@ public class JabRefCliPreferences implements CliPreferences {
                 getPath(LAST_USED_DIRECTORY, defaults.getLastUsedDirectory()),
                 getBoolean(OPEN_FILE_EXPLORER_IN_FILE_DIRECTORY, defaults.shouldOpenFileExplorerInFileDirectory()),
                 getBoolean(OPEN_FILE_EXPLORER_IN_LAST_USED_DIRECTORY, defaults.shouldOpenFileExplorerInLastUsedDirectory()));
+    }
+
+    protected boolean moveToTrashSupported() {
+        return false;
     }
     // endregion
 
@@ -2296,6 +2293,7 @@ public class JabRefCliPreferences implements CliPreferences {
     }
     // endregion
 
+    // region OpenOfficePreferences
     @Override
     public OpenOfficePreferences getOpenOfficePreferences(JournalAbbreviationRepository journalAbbreviationRepository) {
         if (openOfficePreferences != null) {
@@ -2355,6 +2353,7 @@ public class JabRefCliPreferences implements CliPreferences {
                 getStringList(OO_EXTERNAL_CSL_STYLES),
                 getBoolean(OO_ADD_SPACE_AFTER, defaults.getAddSpaceAfter()));
     }
+    // endregion
 
     @Override
     public GitPreferences getGitPreferences() {

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -3,7 +3,6 @@ package org.jabref.logic.preferences;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -162,7 +161,6 @@ public class JabRefCliPreferences implements CliPreferences {
     public static final String KEYWORD_SEPARATOR = "groupKeywordSeparator";
 
     public static final String MEMORY_STICK_MODE = "memoryStickMode";
-    public static final String DEFAULT_ENCODING = "defaultEncoding";
 
     // region DOIPreferences
     public static final String DOI_BASE_URI = "baseDOIURI";
@@ -485,8 +483,6 @@ public class JabRefCliPreferences implements CliPreferences {
         defaults.put(NEWLINE, System.lineSeparator());
 
         defaults.put(LAST_USED_DIRECTORY, getDefaultPath().toString());
-
-        defaults.put(DEFAULT_ENCODING, StandardCharsets.UTF_8.name());
 
         defaults.put(LAST_USED_EXPORT, "");
 

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -824,6 +824,7 @@ public class JabRefCliPreferences implements CliPreferences {
                                                    .withLastUsedDirectory(getDefaultPath())
         );
         getAiPreferences().setAll(AiPreferences.getDefault());
+        getNameFormatterPreferences().setAll(NameFormatterPreferences.getDefault());
         getCleanupPreferences().setAll(CleanupPreferences.getDefault());
         getImporterPreferences().setAll(ImporterPreferences.getDefault());
         getAutoLinkPreferences().setAll(
@@ -864,6 +865,7 @@ public class JabRefCliPreferences implements CliPreferences {
         getFilePreferences().setAll(getFilePreferencesFromBackingStore(getFilePreferences()));
         getBibEntryPreferences().setAll(getBibEntryPreferencesFromBackingStore(getBibEntryPreferences()));
         getAiPreferences().setAll(getAiPreferencesFromBackingStore(getAiPreferences()));
+        getNameFormatterPreferences().setAll(getNameFormatterPreferencesFromBackingStore(getNameFormatterPreferences()));
         getCleanupPreferences().setAll(getCleanupPreferencesFromBackingStore(getCleanupPreferences()));
         getImporterPreferences().setAll(getImporterPreferencesFromBackingStore(getImporterPreferences()));
         getAutoLinkPreferences().setAll(getAutoLinkPreferencesFromBackingStore(getAutoLinkPreferences()));
@@ -2059,9 +2061,7 @@ public class JabRefCliPreferences implements CliPreferences {
             return nameFormatterPreferences;
         }
 
-        nameFormatterPreferences = new NameFormatterPreferences(
-                getStringList(NAME_FORMATER_KEY),
-                getStringList(NAME_FORMATTER_VALUE));
+        nameFormatterPreferences = getNameFormatterPreferencesFromBackingStore(NameFormatterPreferences.getDefault());
 
         nameFormatterPreferences.getNameFormatterKey().addListener((InvalidationListener) _ ->
                 putStringList(NAME_FORMATER_KEY, nameFormatterPreferences.getNameFormatterKey()));
@@ -2069,6 +2069,12 @@ public class JabRefCliPreferences implements CliPreferences {
                 putStringList(NAME_FORMATTER_VALUE, nameFormatterPreferences.getNameFormatterValue()));
 
         return nameFormatterPreferences;
+    }
+
+    private NameFormatterPreferences getNameFormatterPreferencesFromBackingStore(NameFormatterPreferences defaults) {
+        return new NameFormatterPreferences(
+                convertStringToList(get(NAME_FORMATER_KEY, convertListToString(defaults.getNameFormatterKey()))),
+                convertStringToList(get(NAME_FORMATTER_VALUE, convertListToString(defaults.getNameFormatterValue()))));
     }
     // endregion
 

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -479,12 +479,6 @@ public class JabRefCliPreferences implements CliPreferences {
             LOGGER.warn("Could not import preferences from jabref.xml", e);
         }
 
-        // region Grobid
-        defaults.put(GROBID_ENABLED, Boolean.FALSE);
-        defaults.put(GROBID_PREFERENCE, Boolean.FALSE);
-        defaults.put(GROBID_URL, "http://grobid.jabref.org:8070");
-        // endregion
-
         // system locale as default
         defaults.put(LANGUAGE, Locale.getDefault().getLanguage());
 
@@ -830,6 +824,7 @@ public class JabRefCliPreferences implements CliPreferences {
         getLastFilesOpenedPreferences().setAll(LastFilesOpenedPreferences.getDefault());
         getXmpPreferences().setAll(XmpPreferences.getDefault());
         getProtectedTermsPreferences().setAll(ProtectedTermsPreferences.getDefault());
+        getGrobidPreferences().setAll(GrobidPreferences.getDefault());
         getOpenOfficePreferences(JournalAbbreviationLoader.loadRepository(getJournalAbbreviationPreferences())).setAll(
                 OpenOfficePreferences.getDefault());
     }
@@ -870,6 +865,7 @@ public class JabRefCliPreferences implements CliPreferences {
         getLastFilesOpenedPreferences().setAll(getLastFilesOpenedPreferencesFromBackingStore(getLastFilesOpenedPreferences()));
         getXmpPreferences().setAll(getXmpPreferencesFromBackingStore(getXmpPreferences()));
         getProtectedTermsPreferences().setAll(getProtectedTermsPreferencesFromBackingStore(getProtectedTermsPreferences()));
+        getGrobidPreferences().setAll(getGrobidPreferencesFromBackingStore(getGrobidPreferences()));
         JournalAbbreviationRepository repository = JournalAbbreviationLoader.loadRepository(getJournalAbbreviationPreferences());
         getOpenOfficePreferences(repository).setAll(
                 getOpenOfficePreferencesFromBackingStore(getOpenOfficePreferences(repository), repository));
@@ -2292,16 +2288,14 @@ public class JabRefCliPreferences implements CliPreferences {
     }
     // endregion
 
+    // region GrobidPreferences
     @Override
     public GrobidPreferences getGrobidPreferences() {
         if (grobidPreferences != null) {
             return grobidPreferences;
         }
 
-        grobidPreferences = new GrobidPreferences(
-                getBoolean(GROBID_ENABLED),
-                getBoolean(GROBID_PREFERENCE),
-                get(GROBID_URL));
+        grobidPreferences = getGrobidPreferencesFromBackingStore(GrobidPreferences.getDefault());
 
         EasyBind.listen(grobidPreferences.grobidEnabledProperty(), (_, _, newValue) -> putBoolean(GROBID_ENABLED, newValue));
         EasyBind.listen(grobidPreferences.grobidUseAskedProperty(), (_, _, newValue) -> putBoolean(GROBID_PREFERENCE, newValue));
@@ -2309,6 +2303,14 @@ public class JabRefCliPreferences implements CliPreferences {
 
         return grobidPreferences;
     }
+
+    private GrobidPreferences getGrobidPreferencesFromBackingStore(GrobidPreferences defaults) {
+        return new GrobidPreferences(
+                getBoolean(GROBID_ENABLED, defaults.isGrobidEnabled()),
+                getBoolean(GROBID_PREFERENCE, defaults.isGrobidUseAsked()),
+                get(GROBID_URL, defaults.getGrobidURL()));
+    }
+    // endregion
 
     @Override
     public OpenOfficePreferences getOpenOfficePreferences(JournalAbbreviationRepository journalAbbreviationRepository) {

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -482,13 +482,8 @@ public class JabRefCliPreferences implements CliPreferences {
         // system locale as default
         defaults.put(LANGUAGE, Locale.getDefault().getLanguage());
 
-        // export order
-        defaults.put(EXPORT_IN_ORIGINAL_ORDER, Boolean.TRUE);
-        defaults.put(EXPORT_IN_SPECIFIED_ORDER, Boolean.FALSE);
-
         defaults.put(NEWLINE, System.lineSeparator());
 
-        defaults.put(EXPORT_WORKING_DIRECTORY, USER_HOME);
         defaults.put(LAST_USED_DIRECTORY, getDefaultPath().toString());
 
         defaults.put(DEFAULT_ENCODING, StandardCharsets.UTF_8.name());

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -288,9 +288,6 @@ public class JabRefCliPreferences implements CliPreferences {
     // String delimiter
     public static final Character STRINGLIST_DELIMITER = ';';
 
-    // Helper string
-    protected static final String USER_HOME = System.getProperty("user.home");
-
     // region last files opened
     private static final String LAST_EDITED = "lastEdited";
     private static final String LAST_FOCUSED = "lastFocused";

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -147,7 +147,6 @@ public class JabRefCliPreferences implements CliPreferences {
     public static final String EXPORT_SECONDARY_SORT_DESCENDING = "exportSecDescending";
     public static final String EXPORT_TERTIARY_SORT_FIELD = "exportTerSort";
     public static final String EXPORT_TERTIARY_SORT_DESCENDING = "exportTerDescending";
-    public static final String NEWLINE = "newline";
 
     public static final String XMP_PRIVACY_FILTERS = "xmpPrivacyFilters";
     public static final String USE_XMP_PRIVACY_FILTER = "useXmpPrivacyFilter";
@@ -479,12 +478,6 @@ public class JabRefCliPreferences implements CliPreferences {
 
         // system locale as default
         defaults.put(LANGUAGE, Locale.getDefault().getLanguage());
-
-        defaults.put(NEWLINE, System.lineSeparator());
-
-        defaults.put(LAST_USED_DIRECTORY, getDefaultPath().toString());
-
-        defaults.put(LAST_USED_EXPORT, "");
 
         // Since some of the preference settings themselves use localized strings, we cannot set the language after
         // the initialization of the preferences in main

--- a/jablib/src/main/java/org/jabref/logic/protectedterms/ProtectedTermsPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/protectedterms/ProtectedTermsPreferences.java
@@ -12,6 +12,15 @@ public class ProtectedTermsPreferences {
     private final ObservableList<String> disabledInternalTermLists;
     private final ObservableList<String> disabledExternalTermLists;
 
+    private ProtectedTermsPreferences() {
+        this(
+                ProtectedTermsLoader.getInternalLists(), // Enabled internal term lists
+                List.of(),                               // Enabled external term lists
+                List.of(),                               // Disabled internal term lists
+                List.of()                                // Disabled external term lists
+        );
+    }
+
     public ProtectedTermsPreferences(List<String> enabledInternalTermLists,
                                      List<String> enabledExternalTermLists,
                                      List<String> disabledInternalTermLists,
@@ -20,6 +29,17 @@ public class ProtectedTermsPreferences {
         this.disabledInternalTermLists = FXCollections.observableArrayList(disabledInternalTermLists);
         this.enabledExternalTermLists = FXCollections.observableArrayList(enabledExternalTermLists);
         this.disabledExternalTermLists = FXCollections.observableArrayList(disabledExternalTermLists);
+    }
+
+    public static ProtectedTermsPreferences getDefault() {
+        return new ProtectedTermsPreferences();
+    }
+
+    public void setAll(ProtectedTermsPreferences preferences) {
+        this.enabledInternalTermLists.setAll(preferences.getEnabledInternalTermLists());
+        this.enabledExternalTermLists.setAll(preferences.getEnabledExternalTermLists());
+        this.disabledInternalTermLists.setAll(preferences.getDisabledInternalTermLists());
+        this.disabledExternalTermLists.setAll(preferences.getDisabledExternalTermLists());
     }
 
     public ObservableList<String> getEnabledInternalTermLists() {


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Refactor preferences defaults/reset and simplify legacy import-pattern migration
<code>🐞 Bug fix</code> <code>✨ Enhancement</code> <code>🧪 Tests</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

### Related issues and pull requests

Follow-up to #15908

### PR Description

- Removed obsolete preferences
- Migrated XmpPreferences, NameFormatterPreferences, GrobidPreferences and ProtectedTermsPreferences to new pattern
- Removed unused encoding preferences option and therefor also useless preference migration
- Fixed and added region comments
- Started reordering of preference options.

Decided to make a break to not escalated the PR too much, as reordering public and private internal preference labels / privatizing the labels requires also work on refactoring preference migrations. Prototype of refactorings though included for review.

        `jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

Run JabRef
Open Preferences
Mess around with preferences
Save
Reopen
Reset
See preferences reset

### AI usage

"Claude Code (model claude-sonnet-4-6) for initial quick migration stuff

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add getDefault()/setAll() pattern for preference sections to support clear/import flows.
• Remove obsolete encoding preference/migration and simplify legacy import filename-pattern
  migration.
• Reorganize preference keys (file/XMP/export) and update migration tests accordingly.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  App["App startup"] --> Mig["PreferencesMigrations"] --> Cli["JabRefCliPreferences"] --> Store[("Prefs backing store")]
  Cli --> Sections["Preference sections"] --> Name["NameFormatterPrefs"] --> Terms["ProtectedTermsPrefs"] --> Grobid["GrobidPrefs"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Introduce a shared PreferencesSection interface (getDefault/setAll)</b></summary>

- ➕ Enforces consistent reset/import behavior across all preference sections
- ➕ Reduces boilerplate and makes missing resets easier to detect
- ➖ Requires touching many preference classes at once
- ➖ May force awkward abstractions where sections are not uniform

</details>

<details>
<summary><b>2. Use immutable preference records + replace-on-change</b></summary>

- ➕ Simplifies reasoning about state; avoids partially-updated objects
- ➕ Makes clear/import operations just assignment
- ➖ Requires broader refactor of JavaFX properties/bindings
- ➖ Potentially higher churn and UI-binding breakage risk

</details>

<details>
<summary><b>3. Centralize preference keys via typed key registry (enum/class)</b></summary>

- ➕ Avoids scattering string constants and accidental key reuse/typos
- ➕ Can encode deprecation/migration metadata alongside keys
- ➖ Non-trivial refactor; may conflict with existing legacy key usage
- ➖ Could complicate access patterns in existing code

</details>

**Recommendation:** Current approach is a good incremental step: adding getDefault()/setAll() to targeted sections fixes clear/import gaps with limited churn, and removing the obsolete encoding migration reduces dead maintenance. Consider evolving toward a lightweight PreferencesSection interface once a few more sections adopt the pattern, to prevent future omissions (like the prior missing NameFormatter reset).

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>GrobidPreferences.java</strong> <code>Add default factory and bulk setter for GrobidPreferences</code> <code>+19/-0</code></summary>

<br/>

>Add default factory and bulk setter for GrobidPreferences
>
><pre>
>• Introduces a private default constructor, a getDefault() factory, and a setAll(...) method. Enables consistent reset/import behavior in the preferences facade.
></pre>
>
><a href='https://github.com/JabRef/jabref/pull/15921/files#diff-73e99d889d0601bbac89e067e15fb06512c00d205f8dff66bde95947da2bc560'>jablib/src/main/java/org/jabref/logic/importer/util/GrobidPreferences.java</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ProtectedTermsPreferences.java</strong> <code>Add default factory and bulk setter for ProtectedTermsPreferences</code> <code>+20/-0</code></summary>

<br/>

>Add default factory and bulk setter for ProtectedTermsPreferences
>
><pre>
>• Adds a default constructor (using internal lists as enabled by default), a getDefault() factory, and setAll(...) to enable consistent reset/import behavior from JabRefCliPreferences.
></pre>
>
><a href='https://github.com/JabRef/jabref/pull/15921/files#diff-0d3d30500d18c69b06205c418be9903b8a50c08427c45e778b43d2cf6165cd42'>jablib/src/main/java/org/jabref/logic/protectedterms/ProtectedTermsPreferences.java</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>PreferencesMigrations.java</strong> <code>Remove obsolete encoding migration and rework legacy import-pattern migration</code> <code>+28/-67</code></summary>

<br/>

>Remove obsolete encoding migration and rework legacy import-pattern migration
>
><pre>
>• Drops the legacy encoding-string correction migration and its HashMap usage. Refactors the &lt;=4.0 import filename-pattern migration to operate via a dedicated legacy key (V4_0_IMPORT_FILENAME_PATTERN) and to update the running FilePreferences when needed.
></pre>
>
><a href='https://github.com/JabRef/jabref/pull/15921/files#diff-96c26f0da56e7a57bf360db658380cb3572468a9c332f5908c14990f5891dde0'>jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>NameFormatterPreferences.java</strong> <code>Add default factory and bulk setter for NameFormatterPreferences</code> <code>+16/-0</code></summary>

<br/>

>Add default factory and bulk setter for NameFormatterPreferences
>
><pre>
>• Adds a default constructor providing empty lists, plus getDefault() and setAll(...) to support preference reset and rehydration from the backing store.
></pre>
>
><a href='https://github.com/JabRef/jabref/pull/15921/files#diff-457a03d1297a70b4143d74dbaad8454ad188dab69afacebdd25db560d51a5293'>jablib/src/main/java/org/jabref/logic/layout/format/NameFormatterPreferences.java</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Refactor</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>JabRefCliPreferences.java</strong> <code>Reorganize preference keys and ensure sections reset/import correctly</code> <code>+112/-137</code></summary>

<br/>

>Reorganize preference keys and ensure sections reset/import correctly
>
><pre>
>• Removes obsolete/duplicate preference constants (including default encoding) and groups file/export/XMP keys with clearer naming. Updates clear() and importPreferences() to reset/rehydrate NameFormatter, ProtectedTerms, and Grobid sections via new setAll/getDefault patterns; also adds safer language fallback and refactors file-preference backing-store key usage.
></pre>
>
><a href='https://github.com/JabRef/jabref/pull/15921/files#diff-2ab744cd10eeea9eccf84f1a10b40b79862bcd79ddb96775f8824d370e705b32'>jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>GuiPreferencesMigrationsTest.java</strong> <code>Update migration tests for new legacy import-pattern key and API</code> <code>+11/-20</code></summary>

<br/>

>Update migration tests for new legacy import-pattern key and API
>
><pre>
>• Removes the mocked Preferences node and validates migration behavior through the new V4_0_IMPORT_FILENAME_PATTERN key. Updates test calls to the simplified upgradeImportFileAndDirePatterns(preferences) signature.
></pre>
>
><a href='https://github.com/JabRef/jabref/pull/15921/files#diff-78d6b6168b9a7b0326aec117e04b33675fcd4e703f911c68ddd406511157ba48'>jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>