### PR TITLE
Extract shared parsePlainCitation into ServerUtils

### DIFF
--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -11,15 +11,11 @@ import org.jabref.http.server.services.CitationCacheService;
 import org.jabref.http.server.services.ServerUtils;
 import org.jabref.logic.UiCommand;
 import org.jabref.logic.UiMessageHandler;
-import org.jabref.logic.ai.chatting.ChatModel;
-import org.jabref.logic.ai.chatting.util.ChatModelFactory;
 import org.jabref.logic.bibtex.BibEntryWriter;
 import org.jabref.logic.bibtex.FieldWriter;
 import org.jabref.logic.database.DuplicateCheck;
 import org.jabref.logic.exporter.BibWriter;
 import org.jabref.logic.importer.FetcherException;
-import org.jabref.logic.importer.plaincitation.PlainCitationParserChoice;
-import org.jabref.logic.importer.plaincitation.PlainCitationParserFactory;
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.model.database.BibDatabaseContext;
@@ -103,9 +99,8 @@ public class CitationsResource {
         // library, any other id -> that open library (404 if unknown/closed).
         BibDatabaseContext targetContext = resolveTargetContext(id);
 
-        PlainCitationParserChoice choice = preferences.getImporterPreferences().getDefaultPlainCitationParser();
-        BibEntry parsed = parsePlainCitation(choice, citationText)
-                .orElseThrow(() -> new BadRequestException("Could not parse a bibliography entry from the given text."));
+        BibEntry parsed = ServerUtils.parsePlainCitation(preferences, citationText)
+                                     .orElseThrow(() -> new BadRequestException("Could not parse a bibliography entry from the given text."));
 
         // Cross-library lookup: walk every open library so we can tell the
         // client whether the citation is in the *target* library (Ctrl+J
@@ -239,24 +234,5 @@ public class CitationsResource {
             return Optional.empty();
         }
         return Optional.of(ServerUtils.getLibraryPath(id, srvStateManager));
-    }
-
-    /// Mirrors `EntriesResource.parsePlainCitation` — kept in sync by hand for
-    /// now; pulling it into a shared helper is a follow-up refactor.
-    private Optional<BibEntry> parsePlainCitation(PlainCitationParserChoice choice, String citationText) throws FetcherException {
-        if (choice == PlainCitationParserChoice.LLM) {
-            try (ChatModel chatModel = ChatModelFactory.create(preferences.getAiPreferences())) {
-                return PlainCitationParserFactory.getLlmPlainCitationParser(
-                                                         preferences.getImportFormatPreferences(),
-                                                         preferences.getAiPreferences(),
-                                                         chatModel)
-                                                 .parsePlainCitation(citationText);
-            }
-        }
-        return PlainCitationParserFactory.getPlainCitationParser(
-                choice,
-                preferences.getCitationKeyPatternPreferences(),
-                preferences.getGrobidPreferences(),
-                preferences.getImportFormatPreferences()).parsePlainCitation(citationText);
     }
 }

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/EntriesResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/EntriesResource.java
@@ -15,14 +15,10 @@ import org.jabref.http.dto.LinkedPdfFileDTO;
 import org.jabref.http.server.services.ServerUtils;
 import org.jabref.logic.UiCommand;
 import org.jabref.logic.UiMessageHandler;
-import org.jabref.logic.ai.chatting.ChatModel;
-import org.jabref.logic.ai.chatting.util.ChatModelFactory;
 import org.jabref.logic.bibtex.BibEntryWriter;
 import org.jabref.logic.bibtex.FieldWriter;
 import org.jabref.logic.exporter.BibWriter;
 import org.jabref.logic.importer.FetcherException;
-import org.jabref.logic.importer.plaincitation.PlainCitationParserChoice;
-import org.jabref.logic.importer.plaincitation.PlainCitationParserFactory;
 import org.jabref.logic.importer.util.MediaTypes;
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.util.strings.StringUtil;
@@ -104,9 +100,8 @@ public class EntriesResource {
         }
         Optional<java.nio.file.Path> targetLibrary = resolveTargetLibrary(id);
 
-        PlainCitationParserChoice choice = preferences.getImporterPreferences().getDefaultPlainCitationParser();
-        BibEntry parsed = parsePlainCitation(choice, citationText)
-                .orElseThrow(() -> new BadRequestException("Could not parse a bibliography entry from the given text."));
+        BibEntry parsed = ServerUtils.parsePlainCitation(preferences, citationText)
+                                     .orElseThrow(() -> new BadRequestException("Could not parse a bibliography entry from the given text."));
 
         StringWriter rawEntry = new StringWriter();
         BibWriter bibWriter = new BibWriter(rawEntry, "\n");
@@ -118,25 +113,6 @@ public class EntriesResource {
         uiMessageHandler.handleUiCommands(List.of(targetLibrary
                 .map(library -> new UiCommand.AppendBibTeXToLibrary(library, rawEntry.toString(), group))
                 .orElseGet(() -> new UiCommand.AppendBibTeXToLibrary(rawEntry.toString(), group))));
-    }
-
-    private Optional<BibEntry> parsePlainCitation(PlainCitationParserChoice choice, String citationText) throws FetcherException {
-        if (choice == PlainCitationParserChoice.LLM) {
-            // The LLM parser needs a ChatModel; build one for this request and
-            // close it afterwards so the underlying HTTP client is released.
-            try (ChatModel chatModel = ChatModelFactory.create(preferences.getAiPreferences())) {
-                return PlainCitationParserFactory.getLlmPlainCitationParser(
-                                                         preferences.getImportFormatPreferences(),
-                                                         preferences.getAiPreferences(),
-                                                         chatModel)
-                                                 .parsePlainCitation(citationText);
-            }
-        }
-        return PlainCitationParserFactory.getPlainCitationParser(
-                choice,
-                preferences.getCitationKeyPatternPreferences(),
-                preferences.getGrobidPreferences(),
-                preferences.getImportFormatPreferences()).parsePlainCitation(citationText);
     }
 
     @POST

--- a/jabsrv/src/main/java/org/jabref/http/server/services/ServerUtils.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/services/ServerUtils.java
@@ -10,11 +10,18 @@ import java.util.List;
 import java.util.Optional;
 
 import org.jabref.http.SrvStateManager;
+import org.jabref.logic.ai.chatting.ChatModel;
+import org.jabref.logic.ai.chatting.util.ChatModelFactory;
+import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.fileformat.BibtexImporter;
+import org.jabref.logic.importer.plaincitation.PlainCitationParserChoice;
+import org.jabref.logic.importer.plaincitation.PlainCitationParserFactory;
+import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.util.io.BackupFileUtil;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import com.google.common.html.HtmlEscapers;
@@ -77,5 +84,29 @@ public class ServerUtils {
                               })
                               .findFirst()
                               .orElseThrow(() -> new NotFoundException("No library with id " + HtmlEscapers.htmlEscaper().escape(id) + " found"));
+    }
+
+    /// Parses a single plain-text bibliography reference into a {@link BibEntry} using the
+    /// plain-citation parser the user selected in preferences (including the LLM parser).
+    ///
+    /// Shared by the `entries` and `citations` resources so the parser wiring stays in one place.
+    public static Optional<BibEntry> parsePlainCitation(CliPreferences preferences, String citationText) throws FetcherException {
+        PlainCitationParserChoice choice = preferences.getImporterPreferences().getDefaultPlainCitationParser();
+        if (choice == PlainCitationParserChoice.LLM) {
+            // The LLM parser needs a ChatModel; build one for this request and
+            // close it afterwards so the underlying HTTP client is released.
+            try (ChatModel chatModel = ChatModelFactory.create(preferences.getAiPreferences())) {
+                return PlainCitationParserFactory.getLlmPlainCitationParser(
+                                                         preferences.getImportFormatPreferences(),
+                                                         preferences.getAiPreferences(),
+                                                         chatModel)
+                                                 .parsePlainCitation(citationText);
+            }
+        }
+        return PlainCitationParserFactory.getPlainCitationParser(
+                choice,
+                preferences.getCitationKeyPatternPreferences(),
+                preferences.getGrobidPreferences(),
+                preferences.getImportFormatPreferences()).parsePlainCitation(citationText);
     }
 }


### PR DESCRIPTION
### Related issues and pull requests

**Stacked PR.** Based on #15929 (`refine-http-import-3`), not `main` — review/merge that one first. This branch (`refine-http-import-4`) contains only the commit on top.

### PR Description

Pure refactor extracted from #15929: the identical plain-citation parser wiring that lived in both `EntriesResource` and `CitationsResource` (each flagged in-code as a follow-up) is pulled into `ServerUtils.parsePlainCitation(CliPreferences, String)` and called from both. No behavior change.

#### Analogies

Like honey, the two copies were the same nectar gathered into separate combs; this pours them into one jar. Like chocolate, it takes two bars from the same mould and stops re-casting the recipe twice. And like the moon, the parser logic shows only one face to both callers now — one shared body, seen from two sides.

jabref-contrib-policy:4.2:reviewed​:ok

### Steps to test

This is a no-behavior refactor; covered by the existing `EntriesResourceTest` and the rest of the `:jabsrv:test` suite (all green). Manual check: `POST /libraries/current/entries` with `Content-Type: text/plain` body of a plain citation still parses and imports.

### AI usage

Claude Code (model claude-opus-4-8).

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
