### PR TITLE
Fix reflected XSS in HTTP server HTML entry preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where non latin caseless author names being parsed as nameprefix instead of familyname. [#15813](https://github.com/JabRef/jabref/issues/15813)
 - We fixed an issue where `Quality-> Cleanup -> Rename PDF` together with `Moved linked files to file directory` would lead to an exception [#15833](https://github.com/JabRef/jabref/issues/15833)
 - We fixed an issue where renaming a linked file with a very long title showed a misleading "file is being used by another process" error instead of renaming successfully [#14771](https://github.com/JabRef/jabref/issues/14771)
+- We fixed a reflected cross-site scripting (XSS) issue in the HTTP server's HTML entry preview, where an unknown citation key or library id was echoed unescaped into the error page.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where non latin caseless author names being parsed as nameprefix instead of familyname. [#15813](https://github.com/JabRef/jabref/issues/15813)
 - We fixed an issue where `Quality-> Cleanup -> Rename PDF` together with `Moved linked files to file directory` would lead to an exception [#15833](https://github.com/JabRef/jabref/issues/15833)
 - We fixed an issue where renaming a linked file with a very long title showed a misleading "file is being used by another process" error instead of renaming successfully [#14771](https://github.com/JabRef/jabref/issues/14771)
-- We fixed a reflected cross-site scripting (XSS) issue in the HTTP server's HTML entry preview, where an unknown citation key or library id was echoed unescaped into the error page. [#15937](https://github.com/JabRef/jabref/pull/15937)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where non latin caseless author names being parsed as nameprefix instead of familyname. [#15813](https://github.com/JabRef/jabref/issues/15813)
 - We fixed an issue where `Quality-> Cleanup -> Rename PDF` together with `Moved linked files to file directory` would lead to an exception [#15833](https://github.com/JabRef/jabref/issues/15833)
 - We fixed an issue where renaming a linked file with a very long title showed a misleading "file is being used by another process" error instead of renaming successfully [#14771](https://github.com/JabRef/jabref/issues/14771)
-- We fixed a reflected cross-site scripting (XSS) issue in the HTTP server's HTML entry preview, where an unknown citation key or library id was echoed unescaped into the error page.
+- We fixed a reflected cross-site scripting (XSS) issue in the HTTP server's HTML entry preview, where an unknown citation key or library id was echoed unescaped into the error page. [#15937](https://github.com/JabRef/jabref/pull/15937)
 
 ### Removed
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -13,6 +13,7 @@ code until all points are fulfilled. Do not skip any point.
 - [ ] No commented-out code left behind.
 - [ ] User-facing text is localized (`Localization.lang` in Java, `%` prefix in FXML).
 - [ ] New `BibEntry` objects created with withers (`withField`, not `setField`).
+- [ ] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).
 - [ ] Tests added or updated for changed behavior in `org.jabref.model` / `org.jabref.logic`.
 
 ## Verification commands

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/EntryResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/EntryResource.java
@@ -110,9 +110,9 @@ public class EntryResource {
                     + HtmlEscapers.htmlEscaper().escape(entryId) + "' not found in library "
                     + HtmlEscapers.htmlEscaper().escape(id);
             throw new NotFoundException(Response.status(Response.Status.NOT_FOUND)
-                    .type(MediaType.TEXT_HTML + ";charset=UTF-8")
-                    .entity(message)
-                    .build());
+                                                .type(MediaType.TEXT_HTML + ";charset=UTF-8")
+                                                .entity(message)
+                                                .build());
         }
         if (entriesByCitationKey.size() > 1) {
             LOGGER.warn("Multiple entries found with citation key '{}'. Using the first one.", entryId);

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/EntryResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/EntryResource.java
@@ -44,7 +44,7 @@ public class EntryResource {
     @Inject
     SrvStateManager srvStateManager;
 
-    /// At http://localhost:23119/libraries/{id}/entries/{entryId} <br><br>
+    /// At [http://localhost:23119/libraries/){id}/entries/{entryId}](http://localhost:23119/libraries/){id}/entries/{entryId} <br><br>
     ///
     /// Combines attributes of a given BibEntry into a basic entry preview for as plain text.
     ///
@@ -76,16 +76,14 @@ public class EntryResource {
         String releaseDate = entry.getField(StandardField.DATE).orElse("(N/A)");
 
         // the only difference to the HTML version of this method is the format of the output:
-        String preview =
-                "Author: " + author
-                        + "\nTitle: " + title
-                        + "\nJournal: " + journal
-                        + "\nVolume: " + volume
-                        + "\nNumber: " + number
-                        + "\nPages: " + pages
-                        + "\nReleased on: " + releaseDate;
 
-        return preview;
+        return "Author: " + author
+                + "\nTitle: " + title
+                + "\nJournal: " + journal
+                + "\nVolume: " + volume
+                + "\nNumber: " + number
+                + "\nPages: " + pages
+                + "\nReleased on: " + releaseDate;
     }
 
     /// At http://localhost:23119/libraries/{id}/entries/{entryId} <br><br>
@@ -95,7 +93,6 @@ public class EntryResource {
     /// @param id      The name of the library
     /// @param entryId The CitationKey of the BibEntry
     /// @return a basic entry preview as HTML text
-    /// @throws IOException
     @GET
     @Path("entries/{entryId}")
     @Produces(MediaType.TEXT_HTML + ";charset=UTF-8")

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/EntryResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/EntryResource.java
@@ -103,10 +103,16 @@ public class EntryResource {
         List<BibEntry> entriesByCitationKey = getDatabaseContext(id).getDatabase().getEntriesByCitationKey(entryId);
         if (entriesByCitationKey.isEmpty()) {
             // This response is served as text/html, so escape the user-controlled path
-            // parameters before reflecting them into the message (XSS).
-            throw new NotFoundException("Entry with citation key '"
+            // parameters before reflecting them into the message (XSS). The message is
+            // attached as the text/html entity so it survives GlobalExceptionMapper, which
+            // forwards WebApplicationException.getResponse() verbatim.
+            String message = "Entry with citation key '"
                     + HtmlEscapers.htmlEscaper().escape(entryId) + "' not found in library "
-                    + HtmlEscapers.htmlEscaper().escape(id));
+                    + HtmlEscapers.htmlEscaper().escape(id);
+            throw new NotFoundException(Response.status(Response.Status.NOT_FOUND)
+                    .type(MediaType.TEXT_HTML + ";charset=UTF-8")
+                    .entity(message)
+                    .build());
         }
         if (entriesByCitationKey.size() > 1) {
             LOGGER.warn("Multiple entries found with citation key '{}'. Using the first one.", entryId);

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/EntryResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/EntryResource.java
@@ -102,7 +102,11 @@ public class EntryResource {
     public String getHTMLRepresentation(@PathParam("id") String id, @PathParam("entryId") String entryId) throws IOException {
         List<BibEntry> entriesByCitationKey = getDatabaseContext(id).getDatabase().getEntriesByCitationKey(entryId);
         if (entriesByCitationKey.isEmpty()) {
-            throw new NotFoundException("Entry with citation key '" + entryId + "' not found in library " + id);
+            // This response is served as text/html, so escape the user-controlled path
+            // parameters before reflecting them into the message (XSS).
+            throw new NotFoundException("Entry with citation key '"
+                    + HtmlEscapers.htmlEscaper().escape(entryId) + "' not found in library "
+                    + HtmlEscapers.htmlEscaper().escape(id));
         }
         if (entriesByCitationKey.size() > 1) {
             LOGGER.warn("Multiple entries found with citation key '{}'. Using the first one.", entryId);

--- a/jabsrv/src/main/java/org/jabref/http/server/services/ServerUtils.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/services/ServerUtils.java
@@ -17,6 +17,7 @@ import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
+import com.google.common.html.HtmlEscapers;
 import jakarta.ws.rs.NotFoundException;
 import org.jspecify.annotations.NonNull;
 
@@ -75,6 +76,6 @@ public class ServerUtils {
                                   return (p.getFileName() + "-" + BackupFileUtil.getUniqueFilePrefix(p)).equals(id);
                               })
                               .findFirst()
-                              .orElseThrow(() -> new NotFoundException("No library with id " + id + " found"));
+                              .orElseThrow(() -> new NotFoundException("No library with id " + HtmlEscapers.htmlEscaper().escape(id) + " found"));
     }
 }

--- a/jabsrv/src/test/java/org/jabref/http/server/EntryResourceTest.java
+++ b/jabsrv/src/test/java/org/jabref/http/server/EntryResourceTest.java
@@ -5,9 +5,11 @@ import java.util.EnumSet;
 import org.jabref.http.server.resources.EntryResource;
 
 import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -35,5 +37,24 @@ class EntryResourceTest extends ServerTest {
         assertTrue(response.contains("Alice &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt; &amp; Bob"));
         assertTrue(response.contains("Title &quot;quoted&quot; &lt;img src=x onerror=alert(1)&gt;"));
         assertTrue(response.contains("Journal &gt; Proceedings"));
+    }
+
+    @Test
+    void htmlRepresentationEscapesCitationKeyInNotFoundMessage() {
+        setAvailableLibraries(EnumSet.of(TestBibFile.XSS_SERVER_TEST));
+
+        String maliciousKey = "<script>alert('xss')</script>";
+        Response response = target("/libraries/{id}/entries/{key1}/entries/{key2}")
+                .resolveTemplate("id", TestBibFile.XSS_SERVER_TEST.id)
+                .resolveTemplate("key1", maliciousKey)
+                .resolveTemplate("key2", maliciousKey)
+                .request()
+                .get();
+
+        assertEquals(404, response.getStatus());
+
+        String body = response.readEntity(String.class);
+        assertFalse(body.contains("<script>alert('xss')</script>"));
+        assertTrue(body.contains("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;"));
     }
 }

--- a/jabsrv/src/test/rest-api.http
+++ b/jabsrv/src/test/rest-api.http
@@ -103,9 +103,17 @@ Accept: application/x-bibtex-library-csl+json
 
 GET http://localhost:23119/libraries/notfound
 
+### GET HTML entry preview for unknown citation key (404; key is HTML-escaped in the message)
+
+// The citation key below is `<script>alert(1)</script>` URL-encoded. The 404 body is served
+// as text/html, so the key is HTML-escaped (`&lt;script&gt;...`) and not reflected as raw markup.
+
+GET http://localhost:23119/libraries/demo/entries/%3Cscript%3Ealert(1)%3C%2Fscript%3E/entries/%3Cscript%3Ealert(1)%3C%2Fscript%3E
+Accept: text/html
+
 ## Creation
 
-JabRef offers `current` for the currently selected tab
+// JabRef offers `current` for the currently selected tab
 
 ### Add BibTeX to current library
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Escape path params in HTML entry preview NotFound messages to prevent reflected XSS
<code>🐞 Bug fix</code> <code>📝 Documentation</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• HTML entry preview now HTML-escapes user-controlled path parameters in error responses.
• Add a checklist rule to ensure all <b><i>text/html</i></b> responses escape reflected user input.
• Document the reflected XSS fix in the changelog.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
sequenceDiagram
  autonumber
  actor U as User/Browser
  participant R as "EntryResource"
  participant DB as "BibDatabase"
  participant EH as "JAX-RS error mapper"

  U->>R: GET /libraries/{id}/entries/{entryId}\nAccept: text/html
  R->>DB: getEntriesByCitationKey(entryId)
  alt Entry found
    R-->>U: 200 text/html\n(entry fields escaped)
  else Entry missing
    R-->>EH: throw NotFoundException\n(message includes escaped id+entryId)
    EH-->>U: 404 text/html\n(safe error page)
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Centralize HTML escaping in a global exception mapper</b></summary>

- ➕ Prevents future missed call sites where exceptions are rendered as text/html
- ➕ Keeps resource methods focused on domain logic rather than response-sanitization details
- ➖ Higher scope change; may require auditing all exception serialization paths/content-types
- ➖ Risk of double-escaping if some messages are already sanitized

</details>

<details>
<summary><b>2. Return generic 404 HTML without reflecting user input</b></summary>

- ➕ Eliminates the entire reflected-input class for error pages
- ➕ Simplifies escaping requirements for error paths
- ➖ Less helpful troubleshooting/debug info for users
- ➖ May be inconsistent with existing API behavior that includes identifiers in messages

</details>

<details>
<summary><b>3. Change error responses for this endpoint to text/plain</b></summary>

- ➕ Reduces XSS risk surface by avoiding HTML rendering for errors
- ➕ Minimal sanitization burden
- ➖ Inconsistent content-type behavior for clients expecting HTML
- ➖ Still requires care if HTML is reintroduced elsewhere

</details>

**Recommendation:** The PR’s localized fix (escaping `id` and `entryId` before building a `text/html` NotFound message) is an appropriate minimal remediation, especially paired with the new checklist rule. For broader hardening, consider a follow-up to centralize sanitization or avoid reflecting user input in HTML error pages, but that’s reasonably out of scope for this targeted security patch.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>EntryResource.java</strong> <code>Escape &#x27;id&#x27; and &#x27;entryId&#x27; in HTML 404 NotFoundException message to prevent XSS</code> <code>+5/-1</code></summary>

<br/>

>Escape &#x27;id&#x27; and &#x27;entryId&#x27; in HTML 404 NotFoundException message to prevent XSS
>
><pre>
>• Updates the HTML entry preview endpoint to HTML-escape the library id and citation key when constructing the NotFoundException message, preventing reflected markup injection in the HTML error page.
></pre>
>
><a href='https://github.com/JabRef/jabref/pull/15937/files#diff-8398d1160ef379f5849acc095041c7f7e5748b893d3172be1bd92f1e8a1c8a64'>jabsrv/src/main/java/org/jabref/http/server/resources/EntryResource.java</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>CHANGELOG.md</strong> <code>Document the reflected XSS fix in the HTTP HTML entry preview</code> <code>+1/-0</code></summary>

<br/>

>Document the reflected XSS fix in the HTTP HTML entry preview
>
><pre>
>• Adds a changelog entry describing the reflected XSS issue and its remediation for the HTTP server’s HTML entry preview error page.
></pre>
>
><a href='https://github.com/JabRef/jabref/pull/15937/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed'>CHANGELOG.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>CHECKLIST.md</strong> <code>Add checklist rule to escape user input in all text/html responses (including errors)</code> <code>+1/-0</code></summary>

<br/>

>Add checklist rule to escape user input in all text/html responses (including errors)
>
><pre>
>• Introduces an explicit checklist item requiring HTML-escaping of any user-controlled data in &#x27;text/html&#x27; responses, calling out exception/error messages as a common oversight.
></pre>
>
><a href='https://github.com/JabRef/jabref/pull/15937/files#diff-f8ac50821be8c450509fc9a21bc266dd6d3093d2293d6e7b89cc799a62160c00'>CHECKLIST.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>