### PR TITLE
Use TODO placeholder instead of fake number in CHANGELOG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -482,7 +482,7 @@ PR body — **must** be built from `.github/PULL_REQUEST_TEMPLATE.md`:
 - Add a CHANGELOG.md entry only if the change is visible to the user.
 - The CHANGELOG.md entry should be for end users (and not programmers).
 - Do not add extra blank lines in CHANGELOG.md
-- When the PR number is not yet known, use `TODO` as the issue/PR reference placeholder — never invent a fake number.
+- When no issue is known and the PR is not yet created, use `TODO` as the issue/PR reference placeholder — never invent a fake number.
 - Before using `TODO`, search <https://github.com/JabRef/jabref/issues> and <https://github.com/JabRef/jabref-koppor/issues> for a matching issue. Link it only on a confident match; otherwise list candidates for human review and keep `TODO`. Never use `closes`/`fixes` keywords for a merely-similar issue.
 - User documentation is available in a separate repository <https://github.com/JabRef/user-documentation>.
 - No AI-disclosure comments inside source code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,6 +473,7 @@ PR body — **must** be built from `.github/PULL_REQUEST_TEMPLATE.md`:
 5. Keep **all** checklist items. Mark each `[x]` (done), `[ ]` (TODO), or `[/]` (not applicable). Never `[ x]` or `[.]`.
 6. Remove **all** HTML comments before opening the PR.
 7. Write the body to a temp file and run `gh pr create --body-file <file>` — never `--body`, which bypasses the template.
+8. If the CHANGELOG.md entry used a `TODO` placeholder (no issue existed), immediately after the PR is created replace `TODO` with the real PR-number link (`[#NUM](https://github.com/JabRef/jabref/pull/NUM)`), then commit and push that change.
 
 ---
 
@@ -481,6 +482,7 @@ PR body — **must** be built from `.github/PULL_REQUEST_TEMPLATE.md`:
 - Add a CHANGELOG.md entry only if the change is visible to the user.
 - The CHANGELOG.md entry should be for end users (and not programmers).
 - Do not add extra blank lines in CHANGELOG.md
+- When the PR number is not yet known, use `TODO` as the issue/PR reference placeholder — never invent a fake number.
 - User documentation is available in a separate repository <https://github.com/JabRef/user-documentation>.
 - No AI-disclosure comments inside source code
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -483,6 +483,7 @@ PR body — **must** be built from `.github/PULL_REQUEST_TEMPLATE.md`:
 - The CHANGELOG.md entry should be for end users (and not programmers).
 - Do not add extra blank lines in CHANGELOG.md
 - When the PR number is not yet known, use `TODO` as the issue/PR reference placeholder — never invent a fake number.
+- Before using `TODO`, search <https://github.com/JabRef/jabref/issues> and <https://github.com/JabRef/jabref-koppor/issues> for a matching issue. Link it only on a confident match; otherwise list candidates for human review and keep `TODO`. Never use `closes`/`fixes` keywords for a merely-similar issue.
 - User documentation is available in a separate repository <https://github.com/JabRef/user-documentation>.
 - No AI-disclosure comments inside source code
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -27,7 +27,7 @@ code until all points are fulfilled. Do not skip any point.
 
 ## Documentation
 
-- [ ] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines).
+- [ ] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when the PR number is not yet known — never a fake number.
 - [ ] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
 - [ ] Developer documentation under `docs/` updated if behavior or architecture changed.
 
@@ -37,3 +37,4 @@ code until all points are fulfilled. Do not skip any point.
 - [ ] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
 - [ ] All HTML comments removed from the PR body.
 - [ ] PR created with `gh pr create --body-file <file>` (not `--body`).
+- [ ] If CHANGELOG.md used a `TODO` placeholder, it was replaced with the real PR-number link after PR creation, then committed and pushed.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -27,7 +27,7 @@ code until all points are fulfilled. Do not skip any point.
 
 ## Documentation
 
-- [ ] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when the PR number is not yet known — never a fake number.
+- [ ] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when no issue is known and the PR is not yet created — never a fake number.
 - [ ] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
 - [ ] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
 - [ ] Developer documentation under `docs/` updated if behavior or architecture changed.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -28,6 +28,7 @@ code until all points are fulfilled. Do not skip any point.
 ## Documentation
 
 - [ ] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when the PR number is not yet known — never a fake number.
+- [ ] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
 - [ ] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
 - [ ] Developer documentation under `docs/` updated if behavior or architecture changed.
 


### PR DESCRIPTION
### Related issues and pull requests

No issue — this is a tooling/contributor-guidance change.

### PR Description

This refines the contributor guidance so the CHANGELOG reference is never a fake number. When no issue is known and the PR is not yet created, agents use `TODO` as the `#NUM` placeholder; before doing so they search the `jabref/issues` and `jabref-koppor/issues` trackers and link a real issue only on a confident match. Immediately after PR creation, a `TODO` placeholder must be replaced with the real PR-number link, then committed and pushed. The rules are documented in both `AGENTS.md` (followed while developing) and `CHECKLIST.md` (the pre-PR gate).

### Steps to test

Documentation only — review the wording in `AGENTS.md` (Documentation, Pull requests) and `CHECKLIST.md` (Documentation, Pull request).

### AI usage

Claude Code (model claude-opus-4-8). All changes reviewed and owned by the contributor.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
