### PR TITLE
[#15934] Replace setStyle calls with getStyleClass in Java UI components

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabView.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabView.java
@@ -94,7 +94,7 @@ public class FileAnnotationTabView {
         Label date = new Label(annotation.getDate());
         Label page = new Label(Localization.lang("Page") + ": " + annotation.getPage());
 
-        marking.setStyle("-fx-font-size: 0.75em; -fx-font-weight: bold");
+        marking.getStyleClass().add("small-bold");
         marking.setMaxHeight(30);
 
         Tooltip markingTooltip = new Tooltip(annotation.getMarking());

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FulltextSearchResultsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FulltextSearchResultsTab.java
@@ -117,7 +117,7 @@ public class FulltextSearchResultsTab extends EntryEditorTab {
                                 }
                                 if (!searchResult.getAnnotationsResultStringsHtml().isEmpty()) {
                                     Text annotationsText = new Text(System.lineSeparator() + Localization.lang("Found matches in annotations:") + System.lineSeparator() + System.lineSeparator());
-                                    annotationsText.setStyle("-fx-font-style: italic;");
+                                    annotationsText.getStyleClass().add("italic");
                                     content.getChildren().add(annotationsText);
 
                                     for (String resultTextHtml : searchResult.getAnnotationsResultStringsHtml()) {
@@ -136,7 +136,7 @@ public class FulltextSearchResultsTab extends EntryEditorTab {
 
     private Text createFileLink(LinkedFile linkedFile) {
         Text fileLinkText = new Text(Localization.lang("Found match in %0", linkedFile.getLink()) + System.lineSeparator() + System.lineSeparator());
-        fileLinkText.setStyle("-fx-font-weight: bold;");
+        fileLinkText.getStyleClass().add("bold");
 
         ContextMenu fileContextMenu = getFileContextMenu(linkedFile);
         BibDatabaseContext databaseContext = stateManager.getActiveDatabase().orElse(new BibDatabaseContext());
@@ -159,7 +159,7 @@ public class FulltextSearchResultsTab extends EntryEditorTab {
 
     private Text createPageLink(LinkedFile linkedFile, int pageNumber, String searchExpression) {
         Text pageLink = new Text(Localization.lang("On page %0", pageNumber) + System.lineSeparator() + System.lineSeparator());
-        pageLink.setStyle("-fx-font-style: italic; -fx-font-weight: bold;");
+        pageLink.getStyleClass().add("bold-italic");
 
         pageLink.setOnMouseClicked(event -> {
             if (MouseButton.PRIMARY == event.getButton()) {

--- a/jabgui/src/main/java/org/jabref/gui/linkedfile/DeleteFileAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/linkedfile/DeleteFileAction.java
@@ -140,9 +140,7 @@ public class DeleteFileAction extends SimpleCommand {
         warning.setGlyphSize(24.0);
         Label header = new Label(description, warning);
         header.setWrapText(true);
-        header.setStyle("""
-                -fx-padding: 10px;
-                -fx-background-color: -fx-background;""");
+        header.getStyleClass().add("dialog-header");
 
         ListView<LinkedFileViewModel> filesToDeleteList = new ListView<>(FXCollections.observableArrayList(filesToDelete));
         new ViewModelListCellFactory<LinkedFileViewModel>()

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/cell/FieldValueCell.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/cell/FieldValueCell.java
@@ -98,7 +98,7 @@ public class FieldValueCell extends ThreeWayMergeCell implements Toggle {
         EasyBind.subscribe(textProperty(), label::replaceText);
         label.setAutoHeight(true);
         label.setWrapText(true);
-        label.setStyle("-fx-cursor: hand");
+        label.getStyleClass().add("cursor-hand");
 
         // Workarounds
         preventTextSelectionViaMouseEvents();

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/ManageCitationsDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/ManageCitationsDialogView.java
@@ -77,7 +77,7 @@ public class ManageCitationsDialogView extends BaseDialog<Void> {
 
         Text startText = new Text(start);
         Text inBetweenText = new Text(inBetween);
-        inBetweenText.setStyle("-fx-font-weight: bold");
+        inBetweenText.getStyleClass().add("bold");
         Text endText = new Text(end);
 
         return new FlowPane(startText, inBetweenText, endText);

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -67,6 +67,29 @@
     -fx-font-weight: bold;
 }
 
+.italic {
+    -fx-font-style: italic;
+}
+
+.bold-italic {
+    -fx-font-style: italic;
+    -fx-font-weight: bold;
+}
+
+.small-bold {
+    -fx-font-size: 0.75em;
+    -fx-font-weight: bold;
+}
+
+.cursor-hand {
+    -fx-cursor: hand;
+}
+
+.dialog-header {
+    -fx-padding: 10px;
+    -fx-background-color: -fx-background;
+}
+
 .merge-header-cell {
     -fx-border-color: -fx-outer-border;
     -fx-background-color: -jr-row-odd-background;

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -657,6 +657,18 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-padding: 0;
 }
 
+.padding-medium {
+    -fx-padding: 1em;
+}
+
+.padding-left-medium {
+    -fx-padding: 0em 0em 0em 1em;
+}
+
+.padding-large {
+    -fx-padding: 20 30 20 30;
+}
+
 .align-center-right {
     -fx-alignment: CENTER-RIGHT;
 }

--- a/jabgui/src/test/resources/org/jabref/testutils/interactive/styletester/StyleTester.fxml
+++ b/jabgui/src/test/resources/org/jabref/testutils/interactive/styletester/StyleTester.fxml
@@ -41,7 +41,7 @@
     <TabPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
              AnchorPane.topAnchor="0.0">
         <Tab text="Buttons">
-            <GridPane hgap="32" style="-fx-padding: 20 30 20 30;" vgap="16">
+            <GridPane hgap="32" styleClass="padding-large" vgap="16">
                 <Label GridPane.columnIndex="0" GridPane.columnSpan="6" GridPane.rowIndex="0">Normal buttons:</Label>
                 <Button text="Normal" GridPane.columnIndex="0" GridPane.rowIndex="1">
                     <graphic>
@@ -182,9 +182,9 @@
             </GridPane>
         </Tab>
         <Tab text="Switches">
-            <VBox spacing="10" style="-fx-padding: 1em">
+            <VBox spacing="10" styleClass="padding-medium">
                 <Label text="Checkboxes"/>
-                <VBox spacing="15" style="-fx-padding: 0em 0em 0em 1em">
+                <VBox spacing="15" styleClass="padding-left-medium">
                     <CheckBox text="Unchecked"/>
                     <CheckBox selected="true" text="Checked"/>
                     <CheckBox disable="true" text="Unchecked disabled"/>
@@ -195,7 +195,7 @@
                         <Insets top="20.0"/>
                     </VBox.margin>
                 </Label>
-                <VBox spacing="15" style="-fx-padding: 0em 0em 0em 1em">
+                <VBox spacing="15" styleClass="padding-left-medium">
                     <RadioButton text="Unchecked"/>
                     <RadioButton selected="true" text="Checked"/>
                     <RadioButton disable="true" text="Unchecked disabled"/>


### PR DESCRIPTION
Closes #15934

### Changes made
- Added 5 new utility CSS classes to `jabref-theme.css`: `.italic`, `.bold-italic`, `.small-bold`, `.cursor-hand`, `.dialog-header`
- Replaced 7 inline `setStyle` calls across 5 Java files with `getStyleClass().add(...)`:
  - `FulltextSearchResultsTab.java` — 3 replacements (`italic`, `bold`, `bold-italic`)
  - `FileAnnotationTabView.java` — 1 replacement (`small-bold`)
  - `ManageCitationsDialogView.java` — 1 replacement (`bold`)
  - `DeleteFileAction.java` — 1 replacement (`dialog-header`)
  - `FieldValueCell.java` — 1 replacement (`cursor-hand`)

### Notes
The following `setStyle` calls were intentionally left unchanged as they use dynamic runtime values or have existing comments explaining why a style class is insufficient:
- `ThemeManager.java` — font size is set from user preferences at runtime
- `WelcomeTab.java` — existing comment explains class selector is insufficient
- `LinkedFilesEditor.java` — alignment depends on sibling padding at runtime
- `InternalMaterialDesignIcon.java` — color is a dynamic runtime value

### Steps to test
1. Launch JabRef
2. Open the fulltext search results tab and verify italic/bold text appears correctly
3. Open the file annotation tab and verify marking label size and weight
4. Open the Manage Citations dialog and verify bold citation context text
5. Trigger the delete file dialog and verify header padding and background
6. Open the three-way merge view and verify the hand cursor on field value cells