### PR TITLE
Fix #15934: replace setStyle() calls with CSS style classes

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabView.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabView.java
@@ -94,7 +94,7 @@ public class FileAnnotationTabView {
         Label date = new Label(annotation.getDate());
         Label page = new Label(Localization.lang("Page") + ": " + annotation.getPage());
 
-        marking.setStyle("-fx-font-size: 0.75em; -fx-font-weight: bold");
+        marking.getStyleClass().add("small-bold");
         marking.setMaxHeight(30);
 
         Tooltip markingTooltip = new Tooltip(annotation.getMarking());

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FulltextSearchResultsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FulltextSearchResultsTab.java
@@ -117,7 +117,7 @@ public class FulltextSearchResultsTab extends EntryEditorTab {
                                 }
                                 if (!searchResult.getAnnotationsResultStringsHtml().isEmpty()) {
                                     Text annotationsText = new Text(System.lineSeparator() + Localization.lang("Found matches in annotations:") + System.lineSeparator() + System.lineSeparator());
-                                    annotationsText.setStyle("-fx-font-style: italic;");
+                                    annotationsText.getStyleClass().add("italic");
                                     content.getChildren().add(annotationsText);
 
                                     for (String resultTextHtml : searchResult.getAnnotationsResultStringsHtml()) {
@@ -136,7 +136,7 @@ public class FulltextSearchResultsTab extends EntryEditorTab {
 
     private Text createFileLink(LinkedFile linkedFile) {
         Text fileLinkText = new Text(Localization.lang("Found match in %0", linkedFile.getLink()) + System.lineSeparator() + System.lineSeparator());
-        fileLinkText.setStyle("-fx-font-weight: bold;");
+        fileLinkText.getStyleClass().add("bold");
 
         ContextMenu fileContextMenu = getFileContextMenu(linkedFile);
         BibDatabaseContext databaseContext = stateManager.getActiveDatabase().orElse(new BibDatabaseContext());
@@ -159,7 +159,7 @@ public class FulltextSearchResultsTab extends EntryEditorTab {
 
     private Text createPageLink(LinkedFile linkedFile, int pageNumber, String searchExpression) {
         Text pageLink = new Text(Localization.lang("On page %0", pageNumber) + System.lineSeparator() + System.lineSeparator());
-        pageLink.setStyle("-fx-font-style: italic; -fx-font-weight: bold;");
+        pageLink.getStyleClass().addAll("bold", "italic");
 
         pageLink.setOnMouseClicked(event -> {
             if (MouseButton.PRIMARY == event.getButton()) {

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/cell/FieldValueCell.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/cell/FieldValueCell.java
@@ -5,7 +5,6 @@ import javafx.beans.property.ObjectProperty;
 import javafx.css.PseudoClass;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ContentDisplay;
@@ -98,7 +97,6 @@ public class FieldValueCell extends ThreeWayMergeCell implements Toggle {
         EasyBind.subscribe(textProperty(), label::replaceText);
         label.setAutoHeight(true);
         label.setWrapText(true);
-        label.getStyleClass().add("cursor-hand");
 
         // Workarounds
         preventTextSelectionViaMouseEvents();
@@ -124,7 +122,7 @@ public class FieldValueCell extends ThreeWayMergeCell implements Toggle {
 
         HBox.setHgrow(labelBox, Priority.ALWAYS);
         labelBox.setPadding(new Insets(8));
-        labelBox.setCursor(Cursor.HAND);
+        labelBox.getStyleClass().add("cursor-hand");
     }
 
     private Button createCopyButton() {

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/cell/FieldValueCell.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/cell/FieldValueCell.java
@@ -98,7 +98,7 @@ public class FieldValueCell extends ThreeWayMergeCell implements Toggle {
         EasyBind.subscribe(textProperty(), label::replaceText);
         label.setAutoHeight(true);
         label.setWrapText(true);
-        label.setStyle("-fx-cursor: hand");
+        label.getStyleClass().add("cursor-hand");
 
         // Workarounds
         preventTextSelectionViaMouseEvents();

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/ManageCitationsDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/ManageCitationsDialogView.java
@@ -77,7 +77,7 @@ public class ManageCitationsDialogView extends BaseDialog<Void> {
 
         Text startText = new Text(start);
         Text inBetweenText = new Text(inBetween);
-        inBetweenText.setStyle("-fx-font-weight: bold");
+        inBetweenText.getStyleClass().add("bold");
         Text endText = new Text(end);
 
         return new FlowPane(startText, inBetweenText, endText);

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -71,6 +71,15 @@
     -fx-font-style: italic;
 }
 
+.small-bold {
+    -fx-font-size: 0.75em;
+    -fx-font-weight: bold;
+}
+
+.cursor-hand {
+    -fx-cursor: hand;
+}
+
 .bordered {
     -fx-border-width: 1;
     -fx-border-color: -fx-outer-border;


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/15934

### PR Description

Replaced inline `setStyle()` calls on Text, Label, and HBox nodes with `getStyleClass()` so custom themes and stylesheets like Atlanta are no longer overridden by hardcoded inline styles. Two new utility CSS classes (`.small-bold` and `.cursor-hand`) were added to `jabref-theme.css`.

`jabref-contrib-policy:4.2:reviewed​:ok`

**Analogies:** Like honey that enhances without overpowering, this change adds styling through CSS classes rather than forcing inline values. Like chocolate that works with any recipe, style classes work with any theme. Like the moon that reflects light rather than generating it, the components now defer to the stylesheet rather than defining their own look.

### Steps to test

1. Open JabRef and switch to a custom theme like Atlanta
2. Open a library and perform a fulltext search
3. Verify annotation text appears italic and file links appear bold
4. Open FileAnnotationTab and verify marking label shows smaller bold text
5. Open ManageCitations dialog and verify bold text renders correctly
6. Verify cursor changes to hand on hover in FieldValueCell

### AI usage

Claude (claude-sonnet-4-6) was used to identify the setStyle() calls and suggest CSS class replacements. All changes were reviewed and understood before applying.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

- [x] Code reviewed and understood by contributor
- [x] All AI suggestions verified against actual codebase
- [x] Contributor takes full ownership of submitted code

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)