### PR TITLE
Add native image support for convert and citationkeys generate

### DIFF
--- a/jabkit/src/main/resources/META-INF/native-image/org.jabref/jabkit/reachability-metadata.json
+++ b/jabkit/src/main/resources/META-INF/native-image/org.jabref/jabkit/reachability-metadata.json
@@ -330,6 +330,42 @@
         },
         {
           "name": "inputOption"
+        },
+        {
+          "name": "outputFile"
+        },
+        {
+          "name": "pattern"
+        },
+        {
+          "name": "transliterate"
+        },
+        {
+          "name": "warnBeforeOverwrite"
+        },
+        {
+          "name": "keySuffix"
+        },
+        {
+          "name": "keyPatternRegex"
+        },
+        {
+          "name": "keyPatternReplacement"
+        },
+        {
+          "name": "unwantedCharacters"
+        },
+        {
+          "name": "keywordDelimiter"
+        },
+        {
+          "name": "avoidOverwrite"
+        },
+        {
+          "name": "generateBeforeSaving"
+        },
+        {
+          "name": "keyPatterns"
         }
       ],
       "methods": [

--- a/jabkit/src/main/resources/META-INF/native-image/org.jabref/jabkit/reachability-metadata.json
+++ b/jabkit/src/main/resources/META-INF/native-image/org.jabref/jabkit/reachability-metadata.json
@@ -244,6 +244,18 @@
         },
         {
           "name": "inputOption"
+        },
+        {
+          "name": "inputFormat"
+        },
+        {
+          "name": "outputFile"
+        },
+        {
+          "name": "outputFormat"
+        },
+        {
+          "name": "fieldFormatters"
         }
       ],
       "methods": [

--- a/jabkit/src/test/nativeimage/jabkit.md
+++ b/jabkit/src/test/nativeimage/jabkit.md
@@ -8,3 +8,5 @@ $ "$JABKIT" check integrity --input=src/test/resources/org/jabref/toolkit/comman
 1
 $ grep -c "capital letters are not masked using curly brackets" build/tmp/integrity.out
 1
+$ "$JABKIT" convert --input=src/test/resources/org/jabref/toolkit/commands/origin.bib --input-format=bibtex 2>/dev/null | grep "to 'bibtex'"
+Converting 'src/test/resources/org/jabref/toolkit/commands/origin.bib' to 'bibtex'.

--- a/jabkit/src/test/nativeimage/jabkit.md
+++ b/jabkit/src/test/nativeimage/jabkit.md
@@ -10,3 +10,5 @@ $ grep -c "capital letters are not masked using curly brackets" build/tmp/integr
 1
 $ "$JABKIT" convert --input=src/test/resources/org/jabref/toolkit/commands/origin.bib --input-format=bibtex 2>/dev/null | grep "to 'bibtex'"
 Converting 'src/test/resources/org/jabref/toolkit/commands/origin.bib' to 'bibtex'.
+$ "$JABKIT" citationkeys generate --input=src/test/resources/org/jabref/toolkit/commands/origin.bib 2>/dev/null | grep "Regenerating citation keys"
+Regenerating citation keys according to metadata.

--- a/jabkit/src/test/nativeimage/jabkit.md
+++ b/jabkit/src/test/nativeimage/jabkit.md
@@ -1,14 +1,16 @@
 $ JABKIT=build/native/nativeCompile/jabkit
 $ "$JABKIT" --help 2>/dev/null | grep "^Usage:"
 Usage: jabkit [-dhpv] [COMMAND]
-$ "$JABKIT" check consistency --input=src/test/resources/org/jabref/toolkit/commands/origin.bib 2>/dev/null | grep -E "^Consistency check completed"
-Consistency check completed
+$ "$JABKIT" check consistency --porcelain --input=src/test/resources/org/jabref/toolkit/commands/origin.bib 2>/dev/null; echo $?
+0
 $ mkdir -p build/tmp
-$ "$JABKIT" check integrity --input=src/test/resources/org/jabref/toolkit/commands/origin.bib > build/tmp/integrity.out 2>/dev/null; echo $?
+$ "$JABKIT" check integrity --porcelain --input=src/test/resources/org/jabref/toolkit/commands/origin.bib > build/tmp/integrity.out 2>/dev/null; echo $?
 1
 $ grep -c "capital letters are not masked using curly brackets" build/tmp/integrity.out
 1
-$ "$JABKIT" convert --input=src/test/resources/org/jabref/toolkit/commands/origin.bib --input-format=bibtex 2>/dev/null | grep "to 'bibtex'"
-Converting 'src/test/resources/org/jabref/toolkit/commands/origin.bib' to 'bibtex'.
-$ "$JABKIT" citationkeys generate --input=src/test/resources/org/jabref/toolkit/commands/origin.bib 2>/dev/null | grep "Regenerating citation keys"
-Regenerating citation keys according to metadata.
+$ "$JABKIT" convert --porcelain --input=src/test/resources/org/jabref/toolkit/commands/origin.bib --input-format=bibtex --output=build/tmp/convert.bib 2>/dev/null; echo $?
+0
+$ grep -c "@Book{" build/tmp/convert.bib
+3
+$ "$JABKIT" citationkeys generate --porcelain --input=src/test/resources/org/jabref/toolkit/commands/origin.bib 2>/dev/null | grep -c "@Book{"
+3


### PR DESCRIPTION
### Related issues and pull requests

Closes no related issue.

This PR is part of [JabRef components as native images](https://jabref.github.io/GSoC/projects/#jabref-components-as-native-images) project.

### PR Description

Add GraalVM native image reachability metadata for the `convert` and `citationkeys generate` commands. 

The smoke test suite is also updated to use `--porcelain` and extended with test cases for both new commands.


### Steps to test
1. Build native binary:
    ```bash
    mise exec java@graalvm-community-25.0.2 -- ./gradlew :jabkit:nativeCompile
    ```
2. Run `convert`:
    ```bash
    jabkit/build/native/nativeCompile/jabkit convert \
      --input=<path-to-your>.bib \
      --input-format=bibtex
    ```
    Expected: BibTeX content printed to stdout
3. Run `citationkeys generate`:
    ```bash
    jabkit/build/native/nativeCompile/jabkit citationkeys generate \
      --input=<path-to-your>.bib
    ```
    Expected: BibTeX with regenerated citation keys printed to stdout
4. Run smoke tests via clitest:
    ```bash
    cd jabkit && clitest src/test/nativeimage/jabkit.md
    ```
    Expected: all 9 tests pass (`--help`, `check consistency`, `check integrity`, `convert`, `citationkeys generate`)

### AI usage

Claude Code (claude-sonnet-4-6) was used for discussion.


### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
