### PR TITLE
Fix Git preferences reset and import

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/preferences/network/NetworkTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/network/NetworkTab.java
@@ -132,6 +132,7 @@ public class NetworkTab extends AbstractPreferenceTabView<NetworkTabViewModel> i
 
         gitUsername.textProperty().bindBidirectional(viewModel.gitUsernameProperty());
         gitPat.textProperty().bindBidirectional(viewModel.gitPatProperty());
+        gitPersistPat.selectedProperty().bindBidirectional(viewModel.gitPersistPatProperty());
         gitPersistPat.disableProperty().bind(not(viewModel.passwordPersistAvailable()));
         EasyBind.subscribe(viewModel.passwordPersistAvailable(), available -> {
             if (available) {

--- a/jablib/src/main/java/org/jabref/logic/git/preferences/GitPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/git/preferences/GitPreferences.java
@@ -40,9 +40,9 @@ public class GitPreferences {
 
     public void setAll(GitPreferences preferences) {
         this.username.set(preferences.getUsername());
-        this.pat.set(preferences.getPat());
         this.repositoryUrl.set(preferences.getRepositoryUrl());
         this.rememberPat.set(preferences.getPersistPat());
+        this.pat.set(preferences.getPat());
     }
 
     public void setUsername(String username) {

--- a/jablib/src/main/java/org/jabref/logic/git/preferences/GitPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/git/preferences/GitPreferences.java
@@ -24,6 +24,27 @@ public class GitPreferences {
         this.rememberPat = new SimpleBooleanProperty(rememberPat);
     }
 
+    // Creates object with default preference values
+    private GitPreferences() {
+        this(
+                "",     // username: GitHub username
+                "",     // pat: GitHub personal access token (stored in keyring when rememberPat is enabled)
+                "",     // repositoryUrl: URL of the remote repository
+                false   // rememberPat: Whether the PAT should be persisted in the keyring
+        );
+    }
+
+    public static GitPreferences getDefault() {
+        return new GitPreferences();
+    }
+
+    public void setAll(GitPreferences preferences) {
+        this.username.set(preferences.getUsername());
+        this.pat.set(preferences.getPat());
+        this.repositoryUrl.set(preferences.getRepositoryUrl());
+        this.rememberPat.set(preferences.getPersistPat());
+    }
+
     public void setUsername(String username) {
         this.username.set(username);
     }

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -481,13 +481,6 @@ public class JabRefCliPreferences implements CliPreferences {
         // Otherwise that language framework will be instantiated and more importantly, statically initialized preferences
         // will never be translated.
         Localization.setLanguage(getLanguage());
-
-        // region Git preferences
-        defaults.put(GITHUB_PAT_KEY, "");
-        defaults.put(GITHUB_USERNAME_KEY, "");
-        defaults.put(GITHUB_REMOTE_URL_KEY, "");
-        defaults.put(GITHUB_REMEMBER_PAT_KEY, false);
-        // endregion
     }
 
     /// @deprecated Never ever add a call to this method. There should be only one
@@ -808,6 +801,7 @@ public class JabRefCliPreferences implements CliPreferences {
         getGrobidPreferences().setAll(GrobidPreferences.getDefault());
         getOpenOfficePreferences(JournalAbbreviationLoader.loadRepository(getAbbreviationPreferences())).setAll(
                 OpenOfficePreferences.getDefault());
+        getGitPreferences().setAll(GitPreferences.getDefault());
     }
 
     /// Imports Preferences from an XML file.
@@ -850,6 +844,7 @@ public class JabRefCliPreferences implements CliPreferences {
         JournalAbbreviationRepository repository = JournalAbbreviationLoader.loadRepository(getAbbreviationPreferences());
         getOpenOfficePreferences(repository).setAll(
                 getOpenOfficePreferencesFromBackingStore(getOpenOfficePreferences(repository), repository));
+        getGitPreferences().setAll(getGitPreferencesFromBackingStore(getGitPreferences()));
     }
 
     private static void importPreferencesToBackingStore(Path path) throws JabRefException {
@@ -2359,18 +2354,14 @@ public class JabRefCliPreferences implements CliPreferences {
     }
     // endregion
 
+    // region GitPreferences
     @Override
     public GitPreferences getGitPreferences() {
         if (gitPreferences != null) {
             return gitPreferences;
         }
 
-        gitPreferences = new GitPreferences(
-                get(GITHUB_USERNAME_KEY),
-                getGitHubPat(),
-                get(GITHUB_REMOTE_URL_KEY),
-                getBoolean(GITHUB_REMEMBER_PAT_KEY)
-        );
+        gitPreferences = getGitPreferencesFromBackingStore(GitPreferences.getDefault());
 
         EasyBind.listen(gitPreferences.usernameProperty(), (_, _, newVal) -> put(GITHUB_USERNAME_KEY, newVal));
         EasyBind.listen(gitPreferences.patProperty(), (_, _, newVal) -> setGitHubPat(newVal));
@@ -2385,7 +2376,16 @@ public class JabRefCliPreferences implements CliPreferences {
         return gitPreferences;
     }
 
-    // endregion
+    private GitPreferences getGitPreferencesFromBackingStore(GitPreferences defaults) {
+        boolean rememberPat = getBoolean(GITHUB_REMEMBER_PAT_KEY, defaults.getPersistPat());
+
+        return new GitPreferences(
+                get(GITHUB_USERNAME_KEY, defaults.getUsername()),
+                rememberPat ? getGitHubPat().orElse(defaults.getPat()) : defaults.getPat(),
+                get(GITHUB_REMOTE_URL_KEY, defaults.getRepositoryUrl()),
+                rememberPat
+        );
+    }
 
     private static void deleteGitHubPat() {
         try (final Keyring keyring = Keyring.create()) {
@@ -2395,20 +2395,18 @@ public class JabRefCliPreferences implements CliPreferences {
         }
     }
 
-    private String getGitHubPat() {
-        if (getBoolean(GITHUB_REMEMBER_PAT_KEY)) {
-            try (final Keyring keyring = Keyring.create()) {
-                return new Password(
-                        keyring.getPassword("org.jabref", "github"),
-                        getInternalPreferences().getUserHostInfo().getUserHostString())
-                        .decrypt();
-            } catch (PasswordAccessException ex) {
-                LOGGER.warn("No GitHub token stored in keyring");
-            } catch (Exception ex) {
-                LOGGER.warn("Could not read GitHub token from keyring", ex);
-            }
+    private Optional<String> getGitHubPat() {
+        try (final Keyring keyring = Keyring.create()) {
+            return Optional.of(new Password(
+                    keyring.getPassword("org.jabref", "github"),
+                    getInternalPreferences().getUserHostInfo().getUserHostString())
+                    .decrypt());
+        } catch (PasswordAccessException ex) {
+            LOGGER.warn("No GitHub token stored in keyring");
+        } catch (Exception ex) {
+            LOGGER.warn("Could not read GitHub token from keyring", ex);
         }
-        return (String) defaults.get(GITHUB_PAT_KEY);
+        return Optional.empty();
     }
 
     private void setGitHubPat(String pat) {
@@ -2427,4 +2425,5 @@ public class JabRefCliPreferences implements CliPreferences {
             }
         }
     }
+    // endregion
 }


### PR DESCRIPTION
### Related issues and pull requests

Follow-up to #15921 

### PR Description

- Migrate GitPreferences to new pattern
- Fix comments
- Fix missing binding in NetworkTab for PAT persist checkbox

        `jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

Run JabRef
Open Preferences
Mess around with preferences
Save
Reopen
Reset
See preferences reset

### AI usage

_____

Claude Code (model claude-sonnet-4-6)

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
