### PR TITLE
Fix null-away issues for `BibTexString`

### DIFF
--- a/jablib/src/main/java/org/jabref/model/entry/BibtexString.java
+++ b/jablib/src/main/java/org/jabref/model/entry/BibtexString.java
@@ -3,18 +3,25 @@ package org.jabref.model.entry;
 import java.util.Locale;
 import java.util.Objects;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /// This class models a BibTex String ("@String")
+@NullMarked
 public class BibtexString implements Cloneable {
 
-    /// Type of a \@String.
+    private static final Logger LOGGER = LoggerFactory.getLogger(BibtexString.class);
+
+    /// Type of \@String.
     ///
     /// Differentiate a \@String based on its usage:
     ///
-    /// - {@link #AUTHOR}: prefix "a", for author and editor fields.
-    /// - {@link #INSTITUTION}: prefix "i", for institution and organization
-    /// field
-    /// - {@link #PUBLISHER}: prefix "p", for publisher fields
-    /// - {@link #OTHER}: no prefix, for any field
+    /// - [#AUTHOR]: prefix "a", for author and editor fields.
+    /// - [#INSTITUTION: prefix "i", for institution and organization field
+    /// - [#PUBLISHER]: prefix "p", for publisher fields
+    /// - [#OTHER]: no prefix, for any field
     ///
     /// Examples:
     ///
@@ -29,13 +36,15 @@ public class BibtexString implements Cloneable {
     ///
     /// Usage:
     ///
-    /// \@Misc {
-    /// title       = "The GNU Project"
-    /// author      = aStallman # et # aKahle
-    /// institution = iMIT
-    /// publisher   = pMIT
-    /// note        = "Just " # eg
+    /// ```bibtex
+    /// @Misc {
+    ///   title       = "The GNU Project"
+    ///   author      = aStallman # et # aKahle
+    ///   institution = iMIT
+    ///   publisher   = pMIT
+    ///   note        = "Just " # eg
     /// }
+    /// ```
     public enum Type {
         AUTHOR("a"),
         INSTITUTION("i"),
@@ -82,6 +91,7 @@ public class BibtexString implements Cloneable {
         this.id = IdGenerator.next();
         this.name = name;
         this.content = content;
+        this.parsedSerialization = "";
         hasChanged = true;
         type = Type.get(name);
     }
@@ -116,11 +126,8 @@ public class BibtexString implements Cloneable {
         type = Type.get(name);
     }
 
-    /*
-     * Never returns null
-     */
     public String getContent() {
-        return content == null ? "" : content;
+        return content;
     }
 
     public void setContent(String content) {
@@ -144,13 +151,13 @@ public class BibtexString implements Cloneable {
      * Returns user comments (arbitrary text before the string) if there are any. If not returns the empty string
      */
     public String getUserComments() {
-        if (parsedSerialization != null) {
+        if (!parsedSerialization.isEmpty()) {
             try {
                 // get the text before the string
-                String prolog = parsedSerialization.substring(0, parsedSerialization.indexOf('@'));
-                return prolog;
-            } catch (StringIndexOutOfBoundsException ignore) {
-                // if this occurs a broken parsed serialization has been set, so just do nothing
+                return parsedSerialization.substring(0, parsedSerialization.indexOf('@'));
+            } catch (StringIndexOutOfBoundsException e) {
+                // if this occurs a broken parsed serialization has been set, so just do nothing.
+                LOGGER.error("Got an unexpected error, ignoring", e);
             }
         }
         return "";
@@ -159,7 +166,7 @@ public class BibtexString implements Cloneable {
     @Override
     public Object clone() {
         BibtexString clone;
-        if (parsedSerialization == null) {
+        if (parsedSerialization.isEmpty()) {
             clone = new BibtexString(name, content);
         } else {
             clone = new BibtexString(name, content, parsedSerialization);
@@ -174,7 +181,7 @@ public class BibtexString implements Cloneable {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/jablib/src/test/java/org/jabref/model/entry/BibtexStringTest.java
+++ b/jablib/src/test/java/org/jabref/model/entry/BibtexStringTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class BibtexStringTest {
 
@@ -87,12 +86,6 @@ class BibtexStringTest {
 
         assertEquals("AAA", original.getName());
         assertEquals("An alternative action", original.getContent());
-    }
-
-    @Test
-    void getContentNeverReturnsNull() {
-        BibtexString bs = new BibtexString("SomeName", null);
-        assertNotNull(bs.getContent());
     }
 
     @Test


### PR DESCRIPTION
### Related issues and pull requests

Closes nothing. Continuous improvement.

### PR Description

Well, removes nulls from `BibTexString`. But I'm not sure that I did everything correctly.

I double-checked the constructor usage of this class, and it seems that null values for `content` are never passed.

### Steps to test

JabRef should behave normally. Tests green.

### AI usage

No.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [.] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
