### PR TITLE
Update cache-apt-pkgs-action

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -14,7 +14,7 @@ jobs:
       USER:      ${{ github.event.pull_request.user.login }}
       TITLE:     ${{ github.event.pull_request.title }}
     steps:
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: jq
           version: 1.0

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -629,7 +629,7 @@ jobs:
           branch: main
       - name: Install pigz and cache (Linux)
         if: startsWith(matrix.os, 'ubuntu')
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: pigz
           version: 1.0

--- a/.github/workflows/link-issue.yml
+++ b/.github/workflows/link-issue.yml
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           show-progress: 'false'
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: jq
           version: 1.0

--- a/.github/workflows/on-issue-labeled.yml
+++ b/.github/workflows/on-issue-labeled.yml
@@ -89,7 +89,7 @@ jobs:
     if: "${{ github.event.label.name == 'good first issue' && github.repository_owner == 'JabRef' }}"
     runs-on: ubuntu-slim
     steps:
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: jq
           version: 1.0
@@ -103,7 +103,7 @@ jobs:
     if: github.event.label.name == 'needs-refinement' && github.repository_owner == 'JabRef'
     runs-on: ubuntu-slim
     steps:
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: jq
           version: 1.0
@@ -118,7 +118,7 @@ jobs:
     if: "${{ github.event.label.name == 'status: freeze' && github.repository_owner == 'JabRef' }}"
     runs-on: ubuntu-slim
     steps:
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: jq
           version: 1.0

--- a/.github/workflows/on-issue-unassigned.yml
+++ b/.github/workflows/on-issue-unassigned.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: jq
           version: 1.0

--- a/.github/workflows/on-pr-closed.yml
+++ b/.github/workflows/on-pr-closed.yml
@@ -144,7 +144,7 @@ jobs:
 
           # "brute force" remove assignee - it might happen that the contributor was unassinged, but the PR closed later; therefore we need " || true" to ignore any error
           gh issue edit "$ISSUE_NUMBER" --remove-assignee "$PR_USER" || true
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: jq
           version: 1.0

--- a/.github/workflows/on-pr-labeled-update-pr-status.yml
+++ b/.github/workflows/on-pr-labeled-update-pr-status.yml
@@ -30,7 +30,7 @@ jobs:
           else
             echo "continue=false" >> "$GITHUB_OUTPUT"
           fi
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: jq
           version: 1.0

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -100,7 +100,7 @@ jobs:
           show-progress: 'false'
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: jq
           version: 1.0

--- a/.github/workflows/rerun-merge-conflict-check.yml
+++ b/.github/workflows/rerun-merge-conflict-check.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: jq
           version: 1.0

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -229,7 +229,7 @@ jobs:
           tar xzvf clparse-0.9.1-x86_64-unknown-linux-musl.tar.gz
       - name: Install clparse
         run: sudo mv /tmp/clparse /usr/local/bin/clparse
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: jq
           version: 1.0
@@ -271,7 +271,7 @@ jobs:
           CI: "true"
       - name: Prepare format failed test results
         if: failure()
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: xml-twig-tools xsltproc
           version: 1.0


### PR DESCRIPTION
Refs https://github.com/awalsh128/cache-apt-pkgs-action/issues/199#issuecomment-4700114939

`latest` of that action is not the latest release any more. Moving to version "pinning"

### Steps to test

See CI passing

### AI usage

🧠 only

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
