### PR TITLE
Fix orElse(null)

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
@@ -289,10 +289,10 @@ public class ImportEntriesDialog extends BaseDialog<Boolean> {
             if (button == importButton) {
                 if (groupListView.getItems().size() > 1) {
                     // 1 is the "All entries" group, so if more than 1, we have groups defined
-                    GroupTreeNode prevSelectedGroup = stateManager.getSelectedGroups(stateManager.getActiveDatabase().orElse(null)).getFirst();
+                    GroupTreeNode prevSelectedGroup = stateManager.getSelectedGroups(database).getFirst();
                     stateManager.setSelectedGroups(libraryListView.getSelectionModel().getSelectedItem(), List.of(groupListView.getSelectionModel().getSelectedItem()));
                     viewModel.importEntries(viewModel.getCheckedEntries().stream().toList(), downloadLinkedOnlineFiles.isSelected());
-                    stateManager.setSelectedGroups(stateManager.getActiveDatabase().orElse(null), List.of(prevSelectedGroup));
+                    stateManager.setSelectedGroups(database, List.of(prevSelectedGroup));
                 } else {
                     viewModel.importEntries(viewModel.getCheckedEntries().stream().toList(), downloadLinkedOnlineFiles.isSelected());
                 }


### PR DESCRIPTION
Context: `org.jabref.gui.importer.ImportEntriesDialog`

The method `initializeDiag()` is called from the constructor, which passes the `BibDatabasecontext`. Has to be re-used AND NOT the StateManager asked.

### Steps to test

Import sth.

### AI usage

🧠


### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
