### PR TITLE
Fix UrlDownloadTest

### DIFF
--- a/jablib/src/test/java/org/jabref/logic/net/URLDownloadTest.java
+++ b/jablib/src/test/java/org/jabref/logic/net/URLDownloadTest.java
@@ -65,10 +65,12 @@ class URLDownloadTest {
 
     @Test
     void downloadToTemporaryFileKeepsName() throws MalformedURLException, FetcherException {
-        URLDownload robots = new URLDownload(URLUtil.create("https://httpbin.org/robots.txt"));
-
-        String path = robots.toTemporaryFile().toString();
-        assertTrue(path.contains("robots"), path);
+        URLDownload urlDownload = new URLDownload(
+                URLUtil.create("https://files.jabref.org/download-test.txt"));
+        Path path = urlDownload.toTemporaryFile();
+        String fileName = path.getFileName().toString();
+        // fileName is something like jabref-download-test8822989014397910829.txt; thus we cannot use assertEquals
+        assertTrue(fileName.contains("download-test"));
     }
 
     @Test


### PR DESCRIPTION
https://httpbin.org/robots.txt is 404 - I created https://files.jabref.org/download-test.txt

### Related issues and pull requests

Ported from https://github.com/JabRef/jabref/pull/15357

### Steps to test

See CI passing

### AI usage

🧠

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
