### PR TITLE
SLR : carry catalogSpecific overrides to the fetch dispatch

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/crawler/Crawler.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/Crawler.java
@@ -46,7 +46,7 @@ public class Crawler {
                 preferences.getImporterPreferences());
         this.studyFetcher = new StudyFetcher(
                 studyCatalogToFetcherConverter.getActiveFetchers(),
-                studyRepository.getSearchQueryStrings());
+                studyRepository.getStudyQueries());
     }
 
     /// This methods performs the crawling of the active libraries defined in the study definition file.

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
@@ -11,6 +11,7 @@ import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.study.FetchResult;
 import org.jabref.model.study.QueryResult;
+import org.jabref.model.study.StudyQuery;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,9 +23,9 @@ class StudyFetcher {
     private static final int MAX_AMOUNT_OF_RESULTS_PER_FETCHER = 100;
 
     private final List<SearchBasedFetcher> activeFetchers;
-    private final List<String> searchQueries;
+    private final List<StudyQuery> searchQueries;
 
-    StudyFetcher(List<SearchBasedFetcher> activeFetchers, List<String> searchQueries) throws IllegalArgumentException {
+    StudyFetcher(List<SearchBasedFetcher> activeFetchers, List<StudyQuery> searchQueries) throws IllegalArgumentException {
         this.searchQueries = searchQueries;
         this.activeFetchers = activeFetchers;
     }
@@ -38,31 +39,31 @@ class StudyFetcher {
                             .toList();
     }
 
-    private QueryResult getQueryResult(String searchQuery) {
-        return new QueryResult(searchQuery, performSearchOnQuery(searchQuery));
+    private QueryResult getQueryResult(StudyQuery searchQuery) {
+        return new QueryResult(searchQuery.getQuery(), performSearchOnQuery(searchQuery));
     }
 
     /// Queries all catalogs on the given searchQuery.
     ///
     /// @param searchQuery The query the search is performed for.
     /// @return Mapping of each fetcher by name and all their retrieved publications as a BibDatabase
-    private List<FetchResult> performSearchOnQuery(String searchQuery) {
+    private List<FetchResult> performSearchOnQuery(StudyQuery searchQuery) {
         return activeFetchers.parallelStream()
                              .map(fetcher -> performSearchOnQueryForFetcher(searchQuery, fetcher))
                              .filter(Objects::nonNull)
                              .toList();
     }
 
-    private FetchResult performSearchOnQueryForFetcher(String searchQuery, SearchBasedFetcher fetcher) {
+    private FetchResult performSearchOnQueryForFetcher(StudyQuery searchQuery, SearchBasedFetcher fetcher) {
         try {
             List<BibEntry> fetchResult = new ArrayList<>();
             if (fetcher instanceof PagedSearchBasedFetcher basedFetcher) {
                 int pages = (int) Math.ceil(((double) MAX_AMOUNT_OF_RESULTS_PER_FETCHER) / basedFetcher.getPageSize());
                 for (int page = 0; page < pages; page++) {
-                    fetchResult.addAll(basedFetcher.performSearchPaged(searchQuery, page).getContent());
+                    fetchResult.addAll(basedFetcher.performSearchPaged(searchQuery.getQuery(), page).getContent());
                 }
             } else {
-                fetchResult = fetcher.performSearch(searchQuery);
+                fetchResult = fetcher.performSearch(searchQuery.getQuery());
             }
             return new FetchResult(fetcher.getName(), new BibDatabase(fetchResult));
         } catch (FetcherException e) {

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -184,6 +184,11 @@ public class StudyRepository {
                     .collect(Collectors.toList());
     }
 
+    /// Returns all query definitions of the study, preserving catalog-specific overrides.
+    public List<StudyQuery> getStudyQueries() {
+        return study.getQueries();
+    }
+
     /// Extracts all active fetchers from the library entries.
     ///
     /// @return List of BibEntries of type Library


### PR DESCRIPTION
### Related issues and pull requests


### PR Description

StudyFetcher takes List StudyQuery instead of List String, fed by a new StudyRepository.getStudyQueries(), so it helps each query's catalogSpecific overrides until the fetch dispatch, where later routing will read them, for now no behavior change every caller unwraps .getQuery(), same as before

### Steps to test

### AI usage

_____
claude-opus-4.6 to investigate files and review my code

### Checklist


- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
