### PR TITLE
SLR: add performRawSearchQueryPaged to PagedSearchBasedFetcher

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/PagedSearchBasedFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/PagedSearchBasedFetcher.java
@@ -25,6 +25,14 @@ public interface PagedSearchBasedFetcher extends SearchBasedFetcher {
         return this.performSearchPaged(SearchBasedFetcher.getQueryNode(searchQuery), pageNumber);
     }
 
+    /// @param rawQuery   catalog-native query string sent verbatim to the catalog
+    /// @param pageNumber requested site number indexed from 0
+    /// @return Page with search results
+    default Page<BibEntry> performRawSearchQueryPaged(String rawQuery, int pageNumber) throws FetcherException {
+        throw new UnsupportedOperationException(
+                getName() + " has not yet been migrated to performRawSearchQueryPaged");
+    }
+
     /// @return default pageSize
     default int getPageSize() {
         return 20;
@@ -37,5 +45,10 @@ public interface PagedSearchBasedFetcher extends SearchBasedFetcher {
     @Override
     default List<BibEntry> performSearch(BaseQueryNode queryNode) throws FetcherException {
         return new ArrayList<>(performSearchPaged(queryNode, 0).getContent());
+    }
+
+    @Override
+    default List<BibEntry> performRawSearchQuery(String rawQuery) throws FetcherException {
+        return new ArrayList<>(performRawSearchQueryPaged(rawQuery, 0).getContent());
     }
 }


### PR DESCRIPTION
### Related issues and pull requests

follow-up https://github.com/JabRef/jabref/pull/15916

### PR Description
raw catalog-native queries can be sent page by page, it throws until a fetcher implements it
performRawSearchQuery now uses it for the first page, so a paged fetcher only needs to write the paged version.

### Steps to test
It only adds methods to the interface, the first real use comes with the IEEE migration.
 
### AI usage
claude-opus-4.6 to investigate files and review my code
_____


### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
