### PR TITLE
Refactor Replace setStyle calls with getStyleClass

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabView.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabView.java
@@ -94,7 +94,8 @@ public class FileAnnotationTabView {
         Label date = new Label(annotation.getDate());
         Label page = new Label(Localization.lang("Page") + ": " + annotation.getPage());
 
-        marking.setStyle("-fx-font-size: 0.75em; -fx-font-weight: bold");
+        marking.setStyle("-fx-font-size: 0.75em;");
+        marking.getStyleClass().add("bold");
         marking.setMaxHeight(30);
 
         Tooltip markingTooltip = new Tooltip(annotation.getMarking());

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FulltextSearchResultsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FulltextSearchResultsTab.java
@@ -117,7 +117,7 @@ public class FulltextSearchResultsTab extends EntryEditorTab {
                                 }
                                 if (!searchResult.getAnnotationsResultStringsHtml().isEmpty()) {
                                     Text annotationsText = new Text(System.lineSeparator() + Localization.lang("Found matches in annotations:") + System.lineSeparator() + System.lineSeparator());
-                                    annotationsText.setStyle("-fx-font-style: italic;");
+                                    annotationsText.getStyleClass().add("italic");
                                     content.getChildren().add(annotationsText);
 
                                     for (String resultTextHtml : searchResult.getAnnotationsResultStringsHtml()) {
@@ -135,7 +135,7 @@ public class FulltextSearchResultsTab extends EntryEditorTab {
 
     private Text createFileLink(LinkedFile linkedFile) {
         Text fileLinkText = new Text(Localization.lang("Found match in %0", linkedFile.getLink()) + System.lineSeparator() + System.lineSeparator());
-        fileLinkText.setStyle("-fx-font-weight: bold;");
+        fileLinkText.getStyleClass().add("bold");
 
         ContextMenu fileContextMenu = getFileContextMenu(linkedFile);
         BibDatabaseContext databaseContext = stateManager.getActiveDatabase().orElse(new BibDatabaseContext());
@@ -158,7 +158,7 @@ public class FulltextSearchResultsTab extends EntryEditorTab {
 
     private Text createPageLink(LinkedFile linkedFile, int pageNumber, String searchExpression) {
         Text pageLink = new Text(Localization.lang("On page %0", pageNumber) + System.lineSeparator() + System.lineSeparator());
-        pageLink.setStyle("-fx-font-style: italic; -fx-font-weight: bold;");
+        pageLink.getStyleClass().addAll("italic", "bold");
 
         pageLink.setOnMouseClicked(event -> {
             if (MouseButton.PRIMARY == event.getButton()) {

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -235,7 +235,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
 
         HBox info = new HBox(8);
         HBox.setHgrow(info, Priority.ALWAYS);
-        info.setStyle("-fx-padding: 0.5em 0 0.5em 0;"); // To align with buttons below which also have 0.5em padding
+        info.getStyleClass().add("linked-files-info"); // To align with buttons below which also have 0.5em padding
         info.getChildren().setAll(label, progressIndicator);
 
         Button acceptAutoLinkedFile = ControlHelper.iconButton(IconTheme.JabRefIcons.AUTO_LINKED_FILE);

--- a/jabgui/src/main/java/org/jabref/gui/linkedfile/DeleteFileAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/linkedfile/DeleteFileAction.java
@@ -140,9 +140,7 @@ public class DeleteFileAction extends SimpleCommand {
         warning.setGlyphSize(24.0);
         Label header = new Label(description, warning);
         header.setWrapText(true);
-        header.setStyle("""
-                -fx-padding: 10px;
-                -fx-background-color: -fx-background;""");
+        header.getStyleClass().add("delete-files-dialog");
 
         ListView<LinkedFileViewModel> filesToDeleteList = new ListView<>(FXCollections.observableArrayList(filesToDelete));
         new ViewModelListCellFactory<LinkedFileViewModel>()

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/cell/FieldValueCell.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/cell/FieldValueCell.java
@@ -98,7 +98,7 @@ public class FieldValueCell extends ThreeWayMergeCell implements Toggle {
         EasyBind.subscribe(textProperty(), label::replaceText);
         label.setAutoHeight(true);
         label.setWrapText(true);
-        label.setStyle("-fx-cursor: hand");
+        label.setCursor(Cursor.HAND);
 
         // Workarounds
         preventTextSelectionViaMouseEvents();

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/ManageCitationsDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/ManageCitationsDialogView.java
@@ -77,7 +77,7 @@ public class ManageCitationsDialogView extends BaseDialog<Void> {
 
         Text startText = new Text(start);
         Text inBetweenText = new Text(inBetween);
-        inBetweenText.setStyle("-fx-font-weight: bold");
+        inBetweenText.getStyleClass().add("bold");
         Text endText = new Text(end);
 
         return new FlowPane(startText, inBetweenText, endText);

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -67,23 +67,6 @@
     -fx-font-weight: bold;
 }
 
-.italic {
-    -fx-font-style: italic;
-}
-
-.bordered {
-    -fx-border-width: 1;
-    -fx-border-color: -fx-outer-border;
-}
-
-.bg-transparent {
-    -fx-background-color: transparent;
-}
-
-.padding-right-15 {
-    -fx-padding: 0 15 0 0;
-}
-
 .merge-header-cell {
     -fx-border-color: -fx-outer-border;
     -fx-background-color: -jr-row-odd-background;
@@ -634,27 +617,21 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-min-width: 10em;
 }
 
-.chat-bubble {
+.chat-message-text-area {
     -fx-border-radius: 10;
     -fx-background-radius: 10;
-    -fx-border-width: 1;
-    -fx-padding: 10;
-    -fx-max-width: 600;
 }
 
-.chat-bubble:user {
-    -fx-background-color: -jr-ai-message-user;
-    -fx-border-color: -jr-ai-message-user-border;
+.chat-message-text-area .scroll-pane {
+    -fx-background-color: transparent;
 }
 
-.chat-bubble:ai {
-    -fx-background-color: -jr-ai-message-ai;
-    -fx-border-color: -jr-ai-message-ai-border;
+.chat-message-text-area .scroll-pane .viewport {
+    -fx-background-color: transparent;
 }
 
-.chat-bubble:error {
-    -fx-background-color: -jr-ai-message-error;
-    -fx-border-color: -jr-ai-message-error-border;
+.chat-message-text-area .scroll-pane .content {
+    -fx-background-color: transparent;
 }
 
 /* CitationKeyPatternsPanel */
@@ -1176,13 +1153,9 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-background-insets: 0;
 }
 
-#entryEditor .icon-button .glyph-icon,
-#entryEditor .icon-button .ikonli-font-icon,
-#entryEditor .icon-buttonNoSpaceBottom .glyph-icon,
-#entryEditor .icon-buttonNoSpaceBottom .ikonli-font-icon,
-#entryEditor .icon-buttonNoSpaceTop .glyph-icon,
-#entryEditor .icon-buttonNoSpaceTop .ikonli-font-icon {
+#entryEditor .tool-bar .glyph-icon {
     -glyph-size: 1.0em;
+    -fx-font-size: 2em;
     -fx-fill: -jr-theme;
     -fx-text-fill: -jr-theme;
 }

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -67,6 +67,23 @@
     -fx-font-weight: bold;
 }
 
+.italic {
+    -fx-font-style: italic;
+}
+
+.bordered {
+    -fx-border-width: 1;
+    -fx-border-color: -fx-outer-border;
+}
+
+.bg-transparent {
+    -fx-background-color: transparent;
+}
+
+.padding-right-15 {
+    -fx-padding: 0 15 0 0;
+}
+
 .merge-header-cell {
     -fx-border-color: -fx-outer-border;
     -fx-background-color: -jr-row-odd-background;
@@ -617,21 +634,27 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-min-width: 10em;
 }
 
-.chat-message-text-area {
+.chat-bubble {
     -fx-border-radius: 10;
     -fx-background-radius: 10;
+    -fx-border-width: 1;
+    -fx-padding: 10;
+    -fx-max-width: 600;
 }
 
-.chat-message-text-area .scroll-pane {
-    -fx-background-color: transparent;
+.chat-bubble:user {
+    -fx-background-color: -jr-ai-message-user;
+    -fx-border-color: -jr-ai-message-user-border;
 }
 
-.chat-message-text-area .scroll-pane .viewport {
-    -fx-background-color: transparent;
+.chat-bubble:ai {
+    -fx-background-color: -jr-ai-message-ai;
+    -fx-border-color: -jr-ai-message-ai-border;
 }
 
-.chat-message-text-area .scroll-pane .content {
-    -fx-background-color: transparent;
+.chat-bubble:error {
+    -fx-background-color: -jr-ai-message-error;
+    -fx-border-color: -jr-ai-message-error-border;
 }
 
 /* CitationKeyPatternsPanel */
@@ -1153,9 +1176,13 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-background-insets: 0;
 }
 
-#entryEditor .tool-bar .glyph-icon {
+#entryEditor .icon-button .glyph-icon,
+#entryEditor .icon-button .ikonli-font-icon,
+#entryEditor .icon-buttonNoSpaceBottom .glyph-icon,
+#entryEditor .icon-buttonNoSpaceBottom .ikonli-font-icon,
+#entryEditor .icon-buttonNoSpaceTop .glyph-icon,
+#entryEditor .icon-buttonNoSpaceTop .ikonli-font-icon {
     -glyph-size: 1.0em;
-    -fx-font-size: 2em;
     -fx-fill: -jr-theme;
     -fx-text-fill: -jr-theme;
 }
@@ -2422,6 +2449,15 @@ journalInfo .grid-cell-b {
 
 .info-center-view .notification-view > .content > .text-container > .actions-box .button {
     -fx-background-color: -fx-default-button;
+}
+
+.linked-files-info {
+    -fx-padding: 0.5em 0 0.5em 0;
+}
+
+.delete-files-dialog {
+    -fx-padding: 10px;
+    -fx-background-color: -fx-background;
 }
 
 /* Note: stack-pane comes from GemsFX */


### PR DESCRIPTION
### Related issues and pull requests

Closes #15934 

### PR Description

Replaced static inline CSS setStyle calls with style classes where appropriate.

Added reusable CSS classes for styles that could not use existing classes.
This avoids hardcoded inline styles which prevented themes and custom stylesheets from overriding them.

Excluded FontIcon and -fx-font-size cases according to the issue scope.

### Steps to test

Run the JabRef GUI tests:

`./gradlew :jabgui:test`

### AI usage

Claude (Claude Sonnet 4.6) — used for code review, understanding issue scope, and double-checking changes.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
