### PR TITLE
Fix pdf subcommand hint: remove non-existent write-xmp subcommand

### DIFF
--- a/jabkit/src/main/java/org/jabref/toolkit/commands/Pdf.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/Pdf.java
@@ -24,7 +24,7 @@ class Pdf implements Callable<Integer> {
 
     @Override
     public Integer call() {
-        System.err.println(Localization.lang("Specify a subcommand (write-xmp, update)."));
+        System.err.println(Localization.lang("Specify a subcommand (update)."));
         return 2;
     }
 }

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -3592,5 +3592,5 @@ Click\ a\ cell\ to\ edit\ the\ reason=Click a cell to edit the reason
 
 Specify\ a\ subcommand\ (consistency,\ integrity)\ or\ an\ input\ file.=Specify a subcommand (consistency, integrity) or an input file.
 Specify\ a\ subcommand\ (reset,\ import,\ export).=Specify a subcommand (reset, import, export).
-Specify\ a\ subcommand\ (write-xmp,\ update).=Specify a subcommand (write-xmp, update).
+Specify\ a\ subcommand\ (update).=Specify a subcommand (update).
 The\ format\ option\ must\ contain\ either\ 'xmp'\ or\ 'bibtex-attachment'.=The format option must contain either 'xmp' or 'bibtex-attachment'.

--- a/jablib/src/main/resources/l10n/JabRef_fr.properties
+++ b/jablib/src/main/resources/l10n/JabRef_fr.properties
@@ -3592,5 +3592,5 @@ Click\ a\ cell\ to\ edit\ the\ reason=Cliquez sur une cellule pour modifier le m
 
 Specify\ a\ subcommand\ (consistency,\ integrity)\ or\ an\ input\ file.=Spécifiez une sous-commande (cohérence, intégrité) ou un fichier d'entrée.
 Specify\ a\ subcommand\ (reset,\ import,\ export).=Spécifiez une sous-commande (réinitialiser, importer, exporter).
-Specify\ a\ subcommand\ (write-xmp,\ update).=Spécifiez une sous-commande (write-xmp, update).
+Specify\ a\ subcommand\ (update).=Spécifiez une sous-commande (update).
 The\ format\ option\ must\ contain\ either\ 'xmp'\ or\ 'bibtex-attachment'.=L'option de format doit contenir soit 'xmp' soit 'bibtex-attachment'.

--- a/jablib/src/main/resources/l10n/JabRef_it.properties
+++ b/jablib/src/main/resources/l10n/JabRef_it.properties
@@ -3519,5 +3519,5 @@ Click\ a\ cell\ to\ edit\ the\ reason=Fare clic su una cella per modificare il m
 
 Specify\ a\ subcommand\ (consistency,\ integrity)\ or\ an\ input\ file.=Specifica un sottocomando (consistenza, integrità) o un file di input.
 Specify\ a\ subcommand\ (reset,\ import,\ export).=Specifica un sottocomando (reset, importazione, esportazione).
-Specify\ a\ subcommand\ (write-xmp,\ update).=Specifica un sottocomando (write-xmp, update).
+Specify\ a\ subcommand\ (update).=Specifica un sottocomando (update).
 The\ format\ option\ must\ contain\ either\ 'xmp'\ or\ 'bibtex-attachment'.=L'opzione di formato deve contenere 'xmp' o 'bibtex-attachment'.

--- a/jablib/src/main/resources/l10n/JabRef_zh_CN.properties
+++ b/jablib/src/main/resources/l10n/JabRef_zh_CN.properties
@@ -3555,5 +3555,5 @@ Click\ a\ cell\ to\ edit\ the\ reason=单击单元格编辑原因
 
 Specify\ a\ subcommand\ (consistency,\ integrity)\ or\ an\ input\ file.=指定子命令（consistency, integrity）或输入文件。
 Specify\ a\ subcommand\ (reset,\ import,\ export).=指定子命令（reset, import, export）。
-Specify\ a\ subcommand\ (write-xmp,\ update).=指定子命令（write-xmp, update）。
+Specify\ a\ subcommand\ (update).=指定子命令（update）。
 The\ format\ option\ must\ contain\ either\ 'xmp'\ or\ 'bibtex-attachment'.=格式选项必须包含 'xmp' 或 'bibtex-attachment'。


### PR DESCRIPTION
### Related issues and pull requests

The error message in `Pdf.java` referenced `write-xmp` as a subcommand, but only `update` exists.
<img width="1182" height="98" alt="image" src="https://github.com/user-attachments/assets/2d10eff8-1e7a-4ec4-8b7d-3a312a975cfc" />

### PR Description
Remove non-existent `write-xmp` subcommand and updated the corresponding localization key

### Steps to test
Run `./gradlew :jabkit:run --args="pdf"` and verify the error message reads "Specify a subcommand (update)."

### AI usage
No

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
