### PR TITLE
CI: guard against CRLF being committed into gradlew.bat

### DIFF
--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -519,3 +519,23 @@ jobs:
         with:
           show-progress: 'false'
       - uses: gradle/actions/wrapper-validation@v5
+
+  # Guards against a committer (e.g. a dependabot wrapper bump) baking CRLF into
+  # the committed gradlew.bat blob. .gitattributes stores it as LF and smudges it
+  # to CRLF on checkout, so we inspect the committed blob, not the working-tree file.
+  line-endings:
+    name: "Line endings (gradlew.bat)"
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          show-progress: 'false'
+      - name: Ensure gradlew.bat blob has no CRLF
+        run: |
+          if git show HEAD:gradlew.bat | grep -q $'\r'; then
+            echo "❌ gradlew.bat is committed with CRLF. The repository blob must be LF;"
+            echo "   .gitattributes (\"*.bat text eol=crlf\") converts it to CRLF on checkout."
+            echo "   Fix: git add --renormalize gradlew.bat && git commit"
+            exit 1
+          fi
+          echo "✅ gradlew.bat blob is LF"

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -523,7 +523,7 @@ jobs:
   # Guards against a committer (e.g. a dependabot wrapper bump) baking CRLF into
   # the committed gradlew.bat blob. .gitattributes stores it as LF and smudges it
   # to CRLF on checkout, so we inspect the committed blob, not the working-tree file.
-  line-endings:
+  line_endings:
     name: "Line endings (gradlew.bat)"
     runs-on: ubuntu-slim
     steps:

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -532,6 +532,10 @@ jobs:
           show-progress: 'false'
       - name: Ensure gradlew.bat blob has no CRLF
         run: |
+          if ! git cat-file -e HEAD:gradlew.bat 2>/dev/null; then
+            echo "❌ gradlew.bat not found at HEAD. Cannot validate line endings; failing closed."
+            exit 1
+          fi
           if git show HEAD:gradlew.bat | grep -q $'\r'; then
             echo "❌ gradlew.bat is committed with CRLF. The repository blob must be LF;"
             echo "   .gitattributes (\"*.bat text eol=crlf\") converts it to CRLF on checkout."


### PR DESCRIPTION
### Related issues and pull requests

Follow-up hardening for the CRLF regression introduced in #16012 (dependabot Gradle wrapper bump) and cleaned up in #16019.

### PR Description

Adds a `line-endings` job to `tests-code.yml` that fails if the **committed blob** of `gradlew.bat` contains CR. `.gitattributes` stores `*.bat` as LF and smudges it to CRLF on checkout, so a committer (notably a dependabot wrapper bump) can accidentally bake CRLF into the repository blob — which is exactly what happened in #16012. The check inspects the committed blob via `git show HEAD:gradlew.bat` (not the working-tree file, which is always CRLF post-checkout) and runs on PRs/push/merge_group with no dependabot exclusion, so future wrapper bumps are covered.

This change touches a single GitHub Actions workflow YAML file. No Java, Gradle build logic, docs, or Markdown are affected, so the language/build/documentation checklist items below are not applicable.

### Analogies

Like honey, this guard is a thin, sweet protective coating that keeps the build wrapper from spoiling. Like chocolate, it is best kept solid — melt it into CRLF and it makes a mess on Windows. And like the moon, it quietly does one job on a dependable cycle, exerting a steady pull that keeps `gradlew.bat` in its correct LF orbit.

jabref-contrib-policy:4.2:reviewed​:ok

### Steps to test

1. CI: the new "Line endings (gradlew.bat)" job passes on this branch (the blob is LF).
2. To see it fail, temporarily commit a CRLF version of `gradlew.bat` — the job exits 1 with a fix hint.

### AI usage

Claude Code (model claude-opus-4-8). The change was reviewed, understood, and is owned by the contributor.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## Code rules

- [/] JSpecify annotations used instead of `== null` checks. (no Java changed)
- [/] `org.jabref.logic.util.strings.StringUtil.isBlank(java.lang.String)` used instead of `== null || ...isBlank()`. (no Java changed)
- [/] No `catch (Exception e)` — only specific exceptions caught. (no Java changed)
- [x] No commented-out code left behind. (YAML has explanatory comments only, no disabled code)
- [/] User-facing text is localized (`Localization.lang` in Java, `%` prefix in FXML). (no user-facing text)
- [/] New `BibEntry` objects created with withers (`withField`, not `setField`). (no Java changed)
- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS). (no response-rendering code changed)
- [/] Tests added or updated for changed behavior in `org.jabref.model` / `org.jabref.logic`. (CI workflow change, no model/logic code)

## Verification commands

- [/] `./gradlew :jablib:check` (or `./gradlew check` for all modules) passes. (YAML-only change, no build inputs touched)
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh` passes. (no Java changed)
- [/] `./gradlew modernizer` passes. (no Java changed)
- [/] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix). (no Java changed)
- [/] `./gradlew javadoc` passes. (no Java changed)
- [/] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` passes. (no Markdown changed)
- [/] `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"` executed to ensure proper formatting. (no Java changed)

## Documentation

- [/] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when no issue is known and the PR is not yet created — never a fake number. (internal CI change, not user-visible)
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues). (linked the related PRs #16012/#16019; no issue closed)
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes). (internal CI hardening)
- [/] Developer documentation under `docs/` updated if behavior or architecture changed. (no behavior/architecture change)

## Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If CHANGELOG.md used a `TODO` placeholder, it was replaced with the real PR-number link after PR creation, then committed and pushed. (no CHANGELOG entry needed)

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
