### PR TITLE
Fix duplicate artifact name when packaging jbundle binaries

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -187,7 +187,7 @@ runs:
       if: ${{ (inputs.os == 'ubuntu-22.04') && (inputs.uploadAsArtifact == 'true') && (inputs.shouldJbundle == 'true') }}
       uses: actions/upload-artifact@v7
       with:
-        name: jbundle-${{ inputs.displayName }}
+        name: jbundle-${{ inputs.componentShort }}-${{ inputs.displayName }}
         path: build/jbundle/${{ inputs.componentShort }}*
     - name: Upload jbundle artifact to builds.jabref.org
       # background: true


### PR DESCRIPTION
Triggered by manually running binaries - https://github.com/JabRef/jabref/actions/runs/27938093149/job/82664769910

    Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

This PR fixes it.

### Steps to test

Run binaries workflow from this branch

**Edit** Test run: https://github.com/JabRef/jabref/actions/runs/27939367292

### AI usage

Claude made the fix

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
