### PR TITLE
migrate IEEE to performRawSearchQueryPaged

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -331,10 +331,10 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
     }
 
     /// Builds the IEEE search API URL for the given raw query string and page number.
-    /// The caller is responsible for setting {@link #transformer} before invoking {@link #getParser()}.
+    /// The caller is responsible for setting `transformer` before invoking `getParser()`.
     ///
-    /// @param rawQuery   the query string to pass directly as the {@code querytext} parameter
-    /// @param pageNumber zero indexed page number; converted to a 1 indexed {@code start_record} value
+    /// @param rawQuery   the query string to pass directly as the `querytext` parameter
+    /// @param pageNumber zero based page number; converted to a one based `start_record` value.
     private URL buildSearchURL(String rawQuery, int pageNumber) throws URISyntaxException, MalformedURLException {
         URIBuilder uriBuilder = new URIBuilder("https://ieeexploreapi.ieee.org/api/v1/search/articles");
         importerPreferences.getApiKey(FETCHER_NAME).ifPresent(apiKey -> uriBuilder.addParameter("apikey", apiKey));

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -309,7 +309,7 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
         }
         return uriBuilder.build().toURL();
     }
-    
+
     @Override
     public Page<BibEntry> performRawSearchQueryPaged(String rawQuery, int pageNumber) throws FetcherException {
         if (rawQuery.isBlank()) {
@@ -318,7 +318,9 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
         transformer = new IEEEQueryTransformer();
         try {
             URL url = buildSearchURL(rawQuery, pageNumber);
-            return new Page<>(rawQuery, pageNumber, getParser().parseEntries(getUrlDownload(url).asInputStream()));
+            try (var stream = getUrlDownload(url).asInputStream()) {
+                return new Page<>(rawQuery, pageNumber, getParser().parseEntries(stream));
+            }
         } catch (URISyntaxException e) {
             throw new FetcherException("IEEE raw search URL is malformed for query: " + rawQuery, e);
         } catch (IOException e) {

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -20,6 +20,7 @@ import org.jabref.logic.importer.FulltextFetcher;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.importer.PagedSearchBasedParserFetcher;
+import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.fetcher.transformers.IEEEQueryTransformer;
 import org.jabref.logic.net.URLDownload;
@@ -31,6 +32,7 @@ import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.paging.Page;
 import org.jabref.model.search.query.BaseQueryNode;
 
 import kong.unirest.core.UnirestException;
@@ -290,12 +292,8 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
         // the transformer stores the min and max year
         transformer = new IEEEQueryTransformer();
         String transformedQuery = transformer.transformSearchQuery(queryNode).orElse("");
-        URIBuilder uriBuilder = new URIBuilder("https://ieeexploreapi.ieee.org/api/v1/search/articles");
-        importerPreferences.getApiKey(FETCHER_NAME).ifPresent(apiKey -> uriBuilder.addParameter("apikey", apiKey));
-        if (!transformedQuery.isBlank()) {
-            uriBuilder.addParameter("querytext", transformedQuery);
-        }
-        uriBuilder.addParameter("max_records", String.valueOf(getPageSize()));
+        URL baseUrl = buildSearchURL(transformedQuery, pageNumber);
+        URIBuilder uriBuilder = new URIBuilder(baseUrl.toURI());
         // Currently not working as part of the query string
         if (transformer.getJournal().isPresent()) {
             uriBuilder.addParameter("publication_title", transformer.getJournal().get());
@@ -309,7 +307,39 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
         if (transformer.getArticleNumber().isPresent()) {
             uriBuilder.addParameter("article_number", transformer.getArticleNumber().get());
         }
-        // Starts to index at 1 for the first entry
+        return uriBuilder.build().toURL();
+    }
+    
+    @Override
+    public Page<BibEntry> performRawSearchQueryPaged(String rawQuery, int pageNumber) throws FetcherException {
+        if (rawQuery.isBlank()) {
+            return new Page<>(rawQuery, pageNumber, List.of());
+        }
+        transformer = new IEEEQueryTransformer();
+        try {
+            URL url = buildSearchURL(rawQuery, pageNumber);
+            return new Page<>(rawQuery, pageNumber, getParser().parseEntries(getUrlDownload(url).asInputStream()));
+        } catch (URISyntaxException e) {
+            throw new FetcherException("IEEE raw search URL is malformed for query: " + rawQuery, e);
+        } catch (IOException e) {
+            throw new FetcherException(rawQuery, e);
+        } catch (ParseException e) {
+            throw new FetcherException("IEEE raw search parse error for query: " + rawQuery, e);
+        }
+    }
+
+    /// Builds the IEEE search API URL for the given raw query string and page number.
+    /// The caller is responsible for setting {@link #transformer} before invoking {@link #getParser()}.
+    ///
+    /// @param rawQuery   the query string to pass directly as the {@code querytext} parameter
+    /// @param pageNumber zero indexed page number; converted to a 1 indexed {@code start_record} value
+    private URL buildSearchURL(String rawQuery, int pageNumber) throws URISyntaxException, MalformedURLException {
+        URIBuilder uriBuilder = new URIBuilder("https://ieeexploreapi.ieee.org/api/v1/search/articles");
+        importerPreferences.getApiKey(FETCHER_NAME).ifPresent(apiKey -> uriBuilder.addParameter("apikey", apiKey));
+        if (!rawQuery.isBlank()) {
+            uriBuilder.addParameter("querytext", rawQuery);
+        }
+        uriBuilder.addParameter("max_records", String.valueOf(getPageSize()));
         uriBuilder.addParameter("start_record", String.valueOf(getPageSize() * pageNumber + 1));
 
         return uriBuilder.build().toURL();

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/IEEETest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/IEEETest.java
@@ -16,6 +16,7 @@ import org.jabref.logic.util.URLUtil;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.paging.Page;
 import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -168,6 +169,12 @@ class IEEETest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherTe
         // Abstract should not be included in JabRef tests
         fetchedEntries.forEach(entry -> entry.clearField(StandardField.ABSTRACT));
         assertEquals(List.of(IGOR_NEWCOMERS), fetchedEntries);
+    }
+
+    @Test
+    void performRawSearchQueryPagedWithBlankQueryReturnsEmptyPage() throws FetcherException {
+        Page<BibEntry> result = fetcher.performRawSearchQueryPaged("", 0);
+        assertEquals(List.of(), result.getContent());
     }
 
     @Override


### PR DESCRIPTION
### Related issues and pull requests

Part of SLR query routing.

### PR Description

This is the first fetcher migration and IEEE now implements `performRawSearchQueryPaged(String, int)` to send raw queries directly to the IEEE Xplore API without transformation. This should make it easy for the other fetchers to follow and set a pattern.

### Steps to test

### AI usage

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
