### PR TITLE
Select and focus newly added entry from the New Entry dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where an entry added through the "New entry" dialog (by ID/DOI, plain-text citation, or BibTeX) was not selected and scrolled to in the main table after being added. [#16035](https://github.com/JabRef/jabref/issues/16035)
 - We fixed an issue where the global search dialog kept showing the previous entry preview when the search returned no results. [#15613](https://github.com/JabRef/jabref/issues/15613)
 - We fixed an issue where preferences referencing removed cleanup steps are now ignored instead of failing to load. [#15948](https://github.com/JabRef/jabref/pull/15948)
 - We fixed an issue where keyboard navigation shortcuts <kbd>Alt</kbd>+<kbd>Up</kbd>/<kbd>Alt</kbd>+<kbd>Down</kbd> in the entry editor did not preserve focus on the current field when switching between entries. [#14943](https://github.com/JabRef/jabref/issues/14943)

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
@@ -21,6 +21,7 @@ import javafx.concurrent.Task;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.LibraryTab;
 import org.jabref.gui.StateManager;
+import org.jabref.gui.externalfiles.EntryImportHandlerTracker;
 import org.jabref.gui.externalfiles.ImportHandler;
 import org.jabref.gui.importer.BookCoverFetcher;
 import org.jabref.gui.preferences.GuiPreferences;
@@ -52,6 +53,7 @@ import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
 import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
 import de.saxsys.mvvmfx.utils.validation.Validator;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -248,6 +250,22 @@ public class NewEntryViewModel {
         return entry;
     }
 
+    /// Imports the given entries and, once the (asynchronous) import has finished, selects and
+    /// scrolls to them in the main table so the user does not have to hunt for the new entry.
+    private void importEntriesAndSelect(@Nullable TransferInformation transferInformation, List<BibEntry> entries) {
+        final ImportHandler handler = new ImportHandler(
+                libraryTab.getBibDatabaseContext(),
+                preferences,
+                fileUpdateMonitor,
+                libraryTab.getUndoManager(),
+                stateManager,
+                dialogService,
+                taskExecutor);
+        final EntryImportHandlerTracker tracker = new EntryImportHandlerTracker(stateManager, entries.size());
+        tracker.setOnFinish(() -> UiTaskExecutor.runInJavaFXThread(() -> libraryTab.clearAndSelect(entries)));
+        handler.importEntriesWithDuplicateCheck(transferInformation, entries, tracker);
+    }
+
     private class WorkerLookupId extends Task<Optional<BibEntry>> {
         @Override
         protected Optional<BibEntry> call() throws FetcherException {
@@ -349,15 +367,9 @@ public class NewEntryViewModel {
                 return;
             }
 
-            final ImportHandler handler = new ImportHandler(
-                    libraryTab.getBibDatabaseContext(),
-                    preferences,
-                    fileUpdateMonitor,
-                    libraryTab.getUndoManager(),
-                    stateManager,
-                    dialogService,
-                    taskExecutor);
-            handler.importEntryWithDuplicateCheck(new TransferInformation(libraryTab.getBibDatabaseContext(), TransferMode.NONE), result.get());
+            importEntriesAndSelect(
+                    new TransferInformation(libraryTab.getBibDatabaseContext(), TransferMode.NONE),
+                    List.of(result.get()));
 
             executedSuccessfully.set(true);
             executing.set(false);
@@ -447,15 +459,7 @@ public class NewEntryViewModel {
                 return;
             }
 
-            final ImportHandler handler = new ImportHandler(
-                    libraryTab.getBibDatabaseContext(),
-                    preferences,
-                    fileUpdateMonitor,
-                    libraryTab.getUndoManager(),
-                    stateManager,
-                    dialogService,
-                    taskExecutor);
-            handler.importEntriesWithDuplicateCheck(null, result.get());
+            importEntriesAndSelect(null, result.get());
 
             executedSuccessfully.set(true);
             executing.set(false);
@@ -532,15 +536,7 @@ public class NewEntryViewModel {
                 return;
             }
 
-            final ImportHandler handler = new ImportHandler(
-                    libraryTab.getBibDatabaseContext(),
-                    preferences,
-                    fileUpdateMonitor,
-                    libraryTab.getUndoManager(),
-                    stateManager,
-                    dialogService,
-                    taskExecutor);
-            handler.importEntriesWithDuplicateCheck(null, result.get());
+            importEntriesAndSelect(null, result.get());
 
             executedSuccessfully.set(true);
             executing.set(false);


### PR DESCRIPTION
Fixes #16035.

The "New entry" dialog (Add entry by ID/DOI, by plain-text citation, or by Bib(La)TeX) imported entries but never selected them, so a newly added entry was not highlighted or scrolled into view in the main table — the user had to find it manually.

### Change
All three tabs now route their import through a small helper (`NewEntryViewModel#importEntriesAndSelect`) that passes an `EntryImportHandlerTracker` whose `onFinish` selects and scrolls to the imported entries via `LibraryTab#clearAndSelect`, marshalled onto the JavaFX thread once the asynchronous import has completed. This reuses the existing selection/tracker machinery rather than adding anything new.

Citation keys are already generated during import, so the entries have keys by the time the tracker fires and `clearAndSelect(List)` resolves them.

### Verification
- `./gradlew :jabgui:compileJava` — green (JDK 25).
- `./gradlew :jabgui:checkstyleMain` — green.

I did not add an automated test: the select-and-scroll behaviour is bound to the live `MainTable` / JavaFX `TableView` and isn't unit-testable without a TestFX harness. I have not exercised it in a running instance interactively. Glad to add a test or adjust if you'd prefer.

### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user.
- [ ] Tests created for changes (UI-bound selection — see note above).
- [ ] Manually tested in a running JabRef (verified via compile + checkstyle, not run interactively).
- [x] Checked documentation: no behavioural docs affected.