### PR TITLE
Fix: grant pull-requests:write for PR label mutations

### DIFF
--- a/.github/workflows/on-pr-opened-updated.yml
+++ b/.github/workflows/on-pr-opened-updated.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -28,7 +28,7 @@ jobs:
       actions: read
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     timeout-minutes: 10
     steps:
       - name: Show GitHub context


### PR DESCRIPTION
Follow-up to #15881

If PR lables need an update - `write` permissions are needed.

Current status

<img width="1279" height="201" alt="grafik" src="https://github.com/user-attachments/assets/e57291d9-e80a-4456-a7d4-38183095daf3" />

<img width="1298" height="314" alt="grafik" src="https://github.com/user-attachments/assets/f1c27e0b-0f07-4550-8a75-1be1f30961ff" />

Should be fixed by this PR

### AI usage

Claude just updated permissions

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
