### PR TITLE
CI: add Windows ARM (windows-11-arm) binaries build

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -34,6 +34,10 @@ inputs:
     required: true
   subdir:
     required: true
+  additionalGradleParameter:
+    description: 'Extra gradle args appended to jpackage/smoke-test calls, e.g. "-PuseLibericaJdkFull" for Windows ARM'
+    required: false
+    default: ''
 
   secretsPresent:
     required: true
@@ -53,7 +57,7 @@ runs:
   steps:
     - name: jpackage ${{ inputs.component }}
       shell: bash
-      run: gradle -i :${{ inputs.component }}:jpackage
+      run: gradle -i :${{ inputs.component }}:jpackage ${{ inputs.additionalGradleParameter }}
       env:
         VERSION: ${{ inputs.AssemblySemVer }}
         VERSION_INFO: ${{ inputs.InformationalVersion }}
@@ -71,7 +75,7 @@ runs:
     - name: Smoke test ${{ inputs.component }}
       shell: bash
       run: |
-        gradle -i :${{ inputs.component }}:run --args="--help"
+        gradle -i :${{ inputs.component }}:run --args="--help" ${{ inputs.additionalGradleParameter }}
       env:
         VERSION: ${{ inputs.AssemblySemVer }}
         VERSION_INFO: ${{ inputs.InformationalVersion }}
@@ -120,7 +124,7 @@ runs:
     - name: Upload ${{ inputs.component }} to builds.jabref.org (Windows)
       # background: true
       # jabsrv-cli doesn't have any installer and no archivePortable; thus we do not upload
-      if: ${{ (inputs.diskSpaceAvailable == 'true') && (inputs.os == 'windows-latest') && (inputs.archivePortable != 'NONE') }}
+      if: ${{ (inputs.diskSpaceAvailable == 'true') && (startsWith(inputs.os, 'windows')) && (inputs.archivePortable != 'NONE') }}
       shell: cmd
       # for rsync installed by chocolatey, we need the ssh.exe delivered with that installation
       run: |

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -10,6 +10,11 @@ inputs:
     description: Java version
     required: false
     default: '25'
+  javaPackage:
+    # 'jdk+fx' pulls a JavaFX-bundling JDK (e.g. BellSoft Liberica Full), required for the -PuseLibericaJdkFull build (Windows ARM)
+    description: Java package (jdk or jdk+fx)
+    required: false
+    default: jdk
 
 runs:
   using: composite
@@ -19,6 +24,7 @@ runs:
       with:
         java-version: ${{ inputs.javaVersion }}
         distribution: ${{ inputs.distribution }}
+        java-package: ${{ inputs.javaPackage }}
         check-latest: true
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -386,6 +386,18 @@ jobs:
                 "archForDebianRepack": ""
               },
               {
+                "os": "windows-11-arm",
+                "displayName": "windows-arm",
+                "archivePortable": "7z a -r jabgui/build/packages/windows-11-arm/JabRef-portable_windows_arm64.zip ./jabgui/build/packages/windows-11-arm/JabRef && rm -R jabgui/build/packages/windows-11-arm/JabRef",
+                "archivePortableJabKit": "7z a -r jabkit/build/packages/windows-11-arm/jabkit-portable_windows_arm64.zip ./jabkit/build/packages/windows-11-arm/jabkit && rm -R jabkit/build/packages/windows-11-arm/jabkit",
+                "archivePortableJabLS": "7z a -r jabls-cli/build/packages/windows-11-arm/jabls-portable_windows_arm64.zip ./jabls-cli/build/packages/windows-11-arm/jabls && rm -R jabls-cli/build/packages/windows-11-arm/jabls",
+                "suffix": "_arm64",
+                "archForDebianRepack": "",
+                "jvmDistribution": "liberica",
+                "javaPackage": "jdk+fx",
+                "additionalGradleParameter": "-PuseLibericaJdkFull"
+              },
+              {
                 "os": "macos-15-intel",
                 "displayName": "macOS-intel",
                 "archivePortable": "7z a -r jabgui/build/packages/macos-15-intel/JabRef-portable_macos-intel.zip ./jabgui/build/packages/macos-15-intel/JabRef.app && rm -R jabgui/build/packages/macos-15-intel/JabRef.app",
@@ -509,7 +521,7 @@ jobs:
         if: ${{ (needs.disk-space-check.outputs.available == 'true') && (startsWith(matrix.os, 'macos')) }}
         run: brew install rsync
       - name: Setup rsync (Windows)
-        if: ${{ (needs.disk-space-check.outputs.available == 'true') && (matrix.os == 'windows-latest') }}
+        if: ${{ (needs.disk-space-check.outputs.available == 'true') && (startsWith(matrix.os, 'windows')) }}
         # We want to have rsync available at this place to avoid uploading and downloading from GitHub artifact store (taking > 5 minutes in total)
         # We cannot use "action-rsyncer", because that requires Docker which is unavailable on Windows
         # We cannot use "setup-rsync", because that does not work on Windows
@@ -551,7 +563,10 @@ jobs:
 
       - uses: ./.github/actions/setup-gradle
         with:
-          distribution: ${{ needs.conditions.outputs.jvmDistribution }}
+          # matrix.jvmDistribution (e.g. "liberica" for Windows ARM) overrides the workflow-wide default
+          distribution: ${{ matrix.jvmDistribution || needs.conditions.outputs.jvmDistribution }}
+          # "jdk+fx" for the Liberica Full path (Windows ARM); "jdk" everywhere else
+          javaPackage: ${{ matrix.javaPackage || 'jdk' }}
       - name: Output current Java environment
         shell: bash
         run: |
@@ -569,7 +584,7 @@ jobs:
         id: jablib-jar
         # wait: gitversion
         # background: true
-        run: gradle :jablib:jar
+        run: gradle :jablib:jar ${{ matrix.additionalGradleParameter }}
         env:
           VERSION: ${{ needs.pre-build.outputs.AssemblySemVer }}
           VERSION_INFO: ${{ needs.pre-build.outputs.InformationalVersion }}
@@ -592,14 +607,14 @@ jobs:
       - name: jabls jar
         # background: true
         id: jabls-jar
-        run: gradle :jabls:jar
+        run: gradle :jabls:jar ${{ matrix.additionalGradleParameter }}
         env:
           VERSION: ${{ needs.pre-build.outputs.AssemblySemVer }}
           VERSION_INFO: ${{ needs.pre-build.outputs.InformationalVersion }}
       - name: jabsrv jar
         # background: true
         id: jabsrv-jar
-        run: gradle :jabsrv:jar
+        run: gradle :jabsrv:jar ${{ matrix.additionalGradleParameter }}
         env:
           VERSION: ${{ needs.pre-build.outputs.AssemblySemVer }}
           VERSION_INFO: ${{ needs.pre-build.outputs.InformationalVersion }}
@@ -665,6 +680,7 @@ jobs:
           archivePortable: ${{ matrix.archivePortableJabLS }}
           archForDebianRepack: ${{ matrix.archForDebianRepack }}
           suffix: ${{ matrix.suffix }}
+          additionalGradleParameter: ${{ matrix.additionalGradleParameter }}
           shouldJbundle: ${{ needs.conditions.outputs.should-jbundle }}
           uploadAsArtifact: "${{ github.event.inputs.upload-as-artifact }}"
           subdir: "/tools"
@@ -690,6 +706,7 @@ jobs:
           archivePortable: 'NONE'
           archForDebianRepack: ${{ matrix.archForDebianRepack }}
           suffix: ${{ matrix.suffix }}
+          additionalGradleParameter: ${{ matrix.additionalGradleParameter }}
           shouldJbundle: ${{ needs.conditions.outputs.should-jbundle }}
           uploadAsArtifact: "${{ github.event.inputs.upload-as-artifact }}"
           subdir: "/tools"
@@ -716,6 +733,7 @@ jobs:
           archivePortable: ${{ matrix.archivePortable }}
           archForDebianRepack: ${{ matrix.archForDebianRepack }}
           suffix: ${{ matrix.suffix }}
+          additionalGradleParameter: ${{ matrix.additionalGradleParameter }}
           shouldJbundle: ${{ needs.conditions.outputs.should-jbundle }}
           uploadAsArtifact: "${{ github.event.inputs.upload-as-artifact }}"
           subdir: ""
@@ -741,6 +759,7 @@ jobs:
           archivePortable: ${{ matrix.archivePortableJabKit }}
           archForDebianRepack: ${{ matrix.archForDebianRepack }}
           suffix: ${{ matrix.suffix }}
+          additionalGradleParameter: ${{ matrix.additionalGradleParameter }}
           shouldJbundle: ${{ needs.conditions.outputs.should-jbundle }}
           uploadAsArtifact: "${{ github.event.inputs.upload-as-artifact }}"
           subdir: "/tools"


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/16031

Enablilng Windows ARM builds.

### Steps to test

Have Windows ARM

Download binary

Run

### AI usage

Claude did the changes. I guided it.

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
