### PR TITLE
Include citation key and field in github-actions check messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
+- The `jabkit check` `github-actions` output now embeds the citation key and field name in each finding's message, so the plain workflow log lines are self-describing (not only the pull request annotations). [#16065](https://github.com/JabRef/jabref/pull/16065)
 - We extended the per-fetcher timeout for fulltext PDF lookups from 10 to 120 seconds so fetchers that bounce through an institutional sign-in or a slow publisher CDN have a chance to complete. [#15877](https://github.com/JabRef/jabref/pull/15877)
 - When an imported entry has an empty citation key, it is generated. [#15624](https://github.com/JabRef/jabref/pull/15624)
 - We made the `Move file to directory` operation for Linked Files show every configured JabRef directory as possible options. [#12287](https://github.com/JabRef/jabref/issues/12287)

--- a/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultGitHubActionsWriter.java
+++ b/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultGitHubActionsWriter.java
@@ -38,16 +38,19 @@ public class BibliographyConsistencyCheckResultGitHubActionsWriter extends Bibli
     @Override
     protected void writeBibEntry(BibEntry bibEntry, String entryType, Set<Field> requiredFields, Set<Field> optionalFields) throws IOException {
         String citationKey = bibEntry.getCitationKey().orElse("");
+        // The citation key and field name go into the message itself (not just the annotation
+        // title), so the plain GitHub Actions log line is self-describing.
+        String keyPrefix = citationKey.isEmpty() ? "" : citationKey + ": ";
         for (Field field : allReportedFields) {
             Optional<String> value = bibEntry.getField(field);
             if (value.isPresent()) {
                 if (!requiredFields.contains(field) && !optionalFields.contains(field)) {
                     write(parserResult.getFieldRange(bibEntry, field), citationKey, field,
-                            "unknown field for entry type %s".formatted(entryType));
+                            "%sunknown field '%s' for entry type %s".formatted(keyPrefix, field.getName(), entryType));
                 }
             } else {
                 write(parserResult.getCompleteEntryIndicator(bibEntry), citationKey, field,
-                        "field is absent but used by other entries of entry type %s".formatted(entryType));
+                        "%sfield '%s' is absent but used by other entries of entry type %s".formatted(keyPrefix, field.getName(), entryType));
             }
         }
     }

--- a/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultGitHubActionsWriterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultGitHubActionsWriterTest.java
@@ -62,8 +62,10 @@ class BibliographyConsistencyCheckResultGitHubActionsWriterTest {
         assertTrue(lines.stream().allMatch(line -> line.startsWith("::error file=")), lines.toString());
         // Each annotation carries line, column, title (citation key + field), and the message.
         assertTrue(lines.stream().allMatch(line -> line.contains(",line=") && line.contains(",col=") && line.contains(",title=")), lines.toString());
-        assertTrue(lines.stream().anyMatch(line -> line.endsWith("::field is absent but used by other entries of entry type Article")), lines.toString());
-        assertTrue(lines.stream().anyMatch(line -> line.endsWith("::unknown field for entry type Article")), lines.toString());
+        // The message embeds the citation key and field name so the plain log line is self-describing.
+        assertTrue(lines.stream().anyMatch(line -> line.endsWith("::first: field 'publisher' is absent but used by other entries of entry type Article")), lines.toString());
+        assertTrue(lines.stream().anyMatch(line -> line.endsWith("::second: field 'pages' is absent but used by other entries of entry type Article")), lines.toString());
+        assertTrue(lines.stream().anyMatch(line -> line.endsWith("::second: unknown field 'publisher' for entry type Article")), lines.toString());
         // Windows drive-letter colon and the ":" between citation key and field name must be URL-encoded inside properties.
         assertTrue(lines.stream().noneMatch(line -> line.matches(".*title=[^:]+:[^:]+::.*")), "title must not contain raw ':' separator: " + lines);
     }


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref-action-demo/pull/1

<img width="866" height="559" alt="grafik" src="https://github.com/user-attachments/assets/7b6936f8-6b90-461d-b9be-ad2d731c479e" />

I found this output not good - wanted to have more information.

### What

The `jabkit check` `github-actions` output format put the distinguishing information (citation key and field name) only in the annotation `title=` property. GitHub shows that on the pull request annotations panel, but the plain workflow **log** prints just the message body — so every finding looked identical:

```
Error: field is absent but used by other entries of entry type Article
Error: field is absent but used by other entries of entry type Article
...
```

This embeds the citation key and field name in the message itself, so each log line is self-describing:

```
Error: second: field 'pages' is absent but used by other entries of entry type Article
Error: second: unknown field 'publisher' for entry type Article
```

The annotation `title=` (and its URL-encoding) is unchanged.

### Context

Surfaced while running [`jabref-action`](https://github.com/JabRef/jabref-action) over a whole library collection with `--output-format=github-actions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### AI usage

Claude on auto pilot

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required) (CLI/library output change; covered by unit test — JabRef GUI not involved)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user) (not visible in the GUI)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number (no associated issue)
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en) (no user-documentation impact)