### PR TITLE
Document `@NullMarked` requirement for new classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,7 @@ Both comments must not be added.
 ### Dealing with `null`
 
 - New public methods should not return `null`. They should make use of `java.util.Optional`. In case `null` really needs to be used, the [JSpecify](https://jspecify.dev/) annotations must be used.
-- Use JSpecify annotations (`@Nullable`, `@Nullmarked`, `@NonNull`, ...) instead of `null` checks
+- Use JSpecify annotations (`@Nullable`, `@NullMarked`, `@NonNull`, ...) instead of `null` checks
 - Annotate every new class with `@NullMarked` (`org.jspecify.annotations.NullMarked`) so members default to non-null.
 - `null` should never be passed to a method (except it has the same name).
 - DO NOT use `Objects.requireNonNull`, use JSpecify's `@NullMarked` and `@NonNull` annotations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,7 @@ Both comments must not be added.
 
 - New public methods should not return `null`. They should make use of `java.util.Optional`. In case `null` really needs to be used, the [JSpecify](https://jspecify.dev/) annotations must be used.
 - Use JSpecify annotations (`@Nullable`, `@Nullmarked`, `@NonNull`, ...) instead of `null` checks
+- Annotate every new class with `@NullMarked` (`org.jspecify.annotations.NullMarked`) so members default to non-null.
 - `null` should never be passed to a method (except it has the same name).
 - DO NOT use `Objects.requireNonNull`, use JSpecify's `@NullMarked` and `@NonNull` annotations.
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -8,6 +8,7 @@ code until all points are fulfilled. Do not skip any point.
 ## Code rules
 
 - [ ] JSpecify annotations used instead of `== null` checks.
+- [ ] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
 - [ ] `org.jabref.logic.util.strings.StringUtil.isBlank(java.lang.String)` used instead of `== null || ...isBlank()`.
 - [ ] No `catch (Exception e)` — only specific exceptions caught.
 - [ ] No commented-out code left behind.


### PR DESCRIPTION
### Related issues and pull requests

Closes _____

### PR Description

Refine the developer guides so that nullability defaults are explicit for new code: every new class must be annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`) so its members default to non-null. The rule is added to `CHECKLIST.md` (Code rules) and `AGENTS.md` ("Dealing with `null`"). Documentation-only change with no code impact.

`jabref-contrib-policy:4.2:reviewed​:ok`

**Analogies:** This change is like honey — a thin, consistent coating of non-null sweetness spread over every new class. Like chocolate, it sets a default mold so each piece comes out the same shape without hand-tempering every `null` check. And like the moon, `@NullMarked` quietly governs the tides of nullability from a single fixed point, keeping the whole codebase pulled in one direction.

### Steps to test

Documentation-only change. Review the two edited markdown files; no runtime behavior changes.

### AI usage

Claude Code (model claude-opus-4-8). The author reviewed, understood, and takes full ownership of the change.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## Code rules

- [/] JSpecify annotations used instead of `== null` checks.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [/] `org.jabref.logic.util.strings.StringUtil.isBlank(java.lang.String)` used instead of `== null || ...isBlank()`.
- [/] No `catch (Exception e)` — only specific exceptions caught.
- [x] No commented-out code left behind.
- [/] User-facing text is localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] New `BibEntry` objects created with withers (`withField`, not `setField`).
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.
- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).
- [/] Tests added or updated for changed behavior in `org.jabref.model` / `org.jabref.logic`.

## Verification commands

- [/] `./gradlew :jablib:check` (or `./gradlew check` for all modules) passes.
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh` passes.
- [/] `./gradlew modernizer` passes.
- [/] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [/] `./gradlew javadoc` passes.
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` passes.
- [/] `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"` executed to ensure proper formatting.

## Documentation

- [/] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when no issue is known and the PR is not yet created — never a fake number.
- [/] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [x] Developer documentation under `docs/` updated if behavior or architecture changed.

## Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If CHANGELOG.md used a `TODO` placeholder, it was replaced with the real PR-number link after PR creation, then committed and pushed.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
