### PR TITLE
SLR: result limit per catalog

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/crawler/Crawler.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/Crawler.java
@@ -46,7 +46,8 @@ public class Crawler {
                 preferences.getImporterPreferences());
         this.studyFetcher = new StudyFetcher(
                 studyCatalogToFetcherConverter.getActiveFetchers(),
-                studyRepository.getStudyQueries());
+                studyRepository.getStudyQueries(),
+                studyRepository.getResultLimitsPerCatalog());
     }
 
     /// This methods performs the crawling of the active libraries defined in the study definition file.

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
 /// and aggregates the results returned by the fetchers by query and E-Library.
 class StudyFetcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(StudyFetcher.class);
-    private static final int MAX_AMOUNT_OF_RESULTS_PER_FETCHER = 100;
 
     private final List<SearchBasedFetcher> activeFetchers;
     private final List<StudyQuery> searchQueries;
@@ -61,8 +60,8 @@ class StudyFetcher {
         try {
             List<BibEntry> fetchResult = new ArrayList<>();
             if (fetcher instanceof PagedSearchBasedFetcher basedFetcher) {
-                int limit = resolveLimit(fetcher.getName());
-                int pages = (int) Math.ceil(((double) limit) / basedFetcher.getPageSize());
+                int limit = resultLimits.getOrDefault(fetcher.getName(), StudyRepository.DEFAULT_RESULT_LIMIT);
+                int pages = (int) Math.ceil((double) limit / basedFetcher.getPageSize());
                 for (int page = 0; page < pages; page++) {
                     fetchResult.addAll(basedFetcher.performSearchPaged(searchQuery.getQuery(), page).getContent());
                 }
@@ -74,15 +73,5 @@ class StudyFetcher {
             LOGGER.warn("{} API request failed", fetcher.getName(), e);
             return null;
         }
-    }
-
-    /// returns the result limit for the given fetcher, matched case insensitively by name,
-    /// falls back to [#MAX_AMOUNT_OF_RESULTS_PER_FETCHER] when the study defines none
-    private int resolveLimit(String fetcherName) {
-        return resultLimits.entrySet().stream()
-                           .filter(e -> e.getKey().equalsIgnoreCase(fetcherName))
-                           .map(Map.Entry::getValue)
-                           .findFirst()
-                           .orElse(MAX_AMOUNT_OF_RESULTS_PER_FETCHER);
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
@@ -2,6 +2,7 @@ package org.jabref.logic.crawler;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.jabref.logic.importer.FetcherException;
@@ -24,10 +25,12 @@ class StudyFetcher {
 
     private final List<SearchBasedFetcher> activeFetchers;
     private final List<StudyQuery> searchQueries;
+    private final Map<String, Integer> resultLimits;
 
-    StudyFetcher(List<SearchBasedFetcher> activeFetchers, List<StudyQuery> searchQueries) throws IllegalArgumentException {
+    StudyFetcher(List<SearchBasedFetcher> activeFetchers, List<StudyQuery> searchQueries, Map<String, Integer> resultLimits) throws IllegalArgumentException {
         this.searchQueries = searchQueries;
         this.activeFetchers = activeFetchers;
+        this.resultLimits = resultLimits;
     }
 
     /// Each Map Entry contains the results for one search term for all libraries.
@@ -58,7 +61,8 @@ class StudyFetcher {
         try {
             List<BibEntry> fetchResult = new ArrayList<>();
             if (fetcher instanceof PagedSearchBasedFetcher basedFetcher) {
-                int pages = (int) Math.ceil(((double) MAX_AMOUNT_OF_RESULTS_PER_FETCHER) / basedFetcher.getPageSize());
+                int limit = resolveLimit(fetcher.getName());
+                int pages = (int) Math.ceil(((double) limit) / basedFetcher.getPageSize());
                 for (int page = 0; page < pages; page++) {
                     fetchResult.addAll(basedFetcher.performSearchPaged(searchQuery.getQuery(), page).getContent());
                 }
@@ -70,5 +74,15 @@ class StudyFetcher {
             LOGGER.warn("{} API request failed", fetcher.getName(), e);
             return null;
         }
+    }
+
+    /// returns the result limit for the given fetcher, matched case insensitively by name,
+    /// falls back to [#MAX_AMOUNT_OF_RESULTS_PER_FETCHER] when the study defines none
+    private int resolveLimit(String fetcherName) {
+        return resultLimits.entrySet().stream()
+                           .filter(e -> e.getKey().equalsIgnoreCase(fetcherName))
+                           .map(Map.Entry::getValue)
+                           .findFirst()
+                           .orElse(MAX_AMOUNT_OF_RESULTS_PER_FETCHER);
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
@@ -65,6 +65,9 @@ class StudyFetcher {
                 for (int page = 0; page < pages; page++) {
                     fetchResult.addAll(basedFetcher.performSearchPaged(searchQuery.getQuery(), page).getContent());
                 }
+                if (fetchResult.size() > limit) {
+                    fetchResult = new ArrayList<>(fetchResult.subList(0, limit));
+                }
             } else {
                 fetchResult = fetcher.performSearch(searchQuery.getQuery());
             }

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -8,11 +8,11 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -62,6 +62,7 @@ import org.slf4j.LoggerFactory;
 public class StudyRepository {
     // Tests work with study.yml
     public static final String STUDY_DEFINITION_FILE_NAME = "study.yml";
+    public static final int DEFAULT_RESULT_LIMIT = 100;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StudyRepository.class);
 
@@ -202,17 +203,15 @@ public class StudyRepository {
                     .toList();
     }
 
-    /// returns the effective result limit per catalog, applying each catalog's own
-    /// override over the study wide default, catalogs with neither set are deleted
+    /// returns the effective result limit per catalog: its own override, else the study wide
+    /// default, else [#DEFAULT_RESULT_LIMIT], keys match catalog names case-insensitively
     public Map<String, Integer> getResultLimitsPerCatalog() {
-        Map<String, Integer> limits = new LinkedHashMap<>();
+        Map<String, Integer> limits = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (StudyCatalog catalog : study.getCatalogs()) {
             Integer limit = catalog.getMaxResults() != null
                             ? catalog.getMaxResults()
                             : study.getMaxResultsPerCatalog();
-            if (limit != null) {
-                limits.put(catalog.getName(), limit);
-            }
+            limits.put(catalog.getName(), limit != null ? limit : DEFAULT_RESULT_LIMIT);
         }
         return limits;
     }

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -8,8 +8,10 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -198,6 +200,21 @@ public class StudyRepository {
                     .parallelStream()
                     .filter(StudyCatalog::isEnabled)
                     .toList();
+    }
+
+    /// returns the effective result limit per catalog, applying each catalog's own
+    /// override over the study wide default, catalogs with neither set are deleted
+    public Map<String, Integer> getResultLimitsPerCatalog() {
+        Map<String, Integer> limits = new LinkedHashMap<>();
+        for (StudyCatalog catalog : study.getCatalogs()) {
+            Integer limit = catalog.getMaxResults() != null
+                            ? catalog.getMaxResults()
+                            : study.getMaxResultsPerCatalog();
+            if (limit != null) {
+                limits.put(catalog.getName(), limit);
+            }
+        }
+        return limits;
     }
 
     public Study getStudy() {

--- a/jablib/src/main/java/org/jabref/model/study/Study.java
+++ b/jablib/src/main/java/org/jabref/model/study/Study.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.jspecify.annotations.NonNull;
@@ -14,7 +15,7 @@ import org.jspecify.annotations.NonNull;
 /// This class defines all aspects of a scientific study relevant to the application. It is a proxy for the file based study definition.
 ///
 /// The file is parsed using by {@link org.jabref.logic.crawler.StudyYamlParser}
-@JsonPropertyOrder({"version", "authors", "title", "research-questions", "queries", "catalogs"})
+@JsonPropertyOrder({"version", "authors", "title", "research-questions", "queries", "catalogs", "max-results-per-catalog"})
 // The user might add arbitrary content to the YAML
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Study {
@@ -34,6 +35,10 @@ public class Study {
 
     @JsonProperty("catalogs")
     private List<StudyCatalog> catalogs;
+
+    @JsonProperty("max-results-per-catalog")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer maxResultsPerCatalog;
 
     public Study(List<String> authors, String title, List<String> researchQuestions, List<StudyQuery> queryEntries, List<StudyCatalog> catalogs) {
         this.version = CURRENT_SCHEMA_VERSION;
@@ -101,6 +106,14 @@ public class Study {
         this.researchQuestions = researchQuestions;
     }
 
+    public Integer getMaxResultsPerCatalog() {
+        return maxResultsPerCatalog;
+    }
+
+    public void setMaxResultsPerCatalog(Integer maxResultsPerCatalog) {
+        this.maxResultsPerCatalog = maxResultsPerCatalog;
+    }
+
     @Override
     public String toString() {
         return "Study{" +
@@ -110,6 +123,7 @@ public class Study {
                 ", researchQuestions=" + researchQuestions +
                 ", queries=" + queries +
                 ", catalogs=" + catalogs +
+                ", maxResultsPerCatalog=" + maxResultsPerCatalog +
                 '}';
     }
 
@@ -129,11 +143,12 @@ public class Study {
                 Objects.equals(title, otherStudy.title) &&
                 Objects.equals(researchQuestions, otherStudy.researchQuestions) &&
                 Objects.equals(queries, otherStudy.queries) &&
-                Objects.equals(catalogs, otherStudy.catalogs);
+                Objects.equals(catalogs, otherStudy.catalogs) &&
+                Objects.equals(maxResultsPerCatalog, otherStudy.maxResultsPerCatalog);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(version, authors, title, researchQuestions, queries, catalogs);
+        return Objects.hash(version, authors, title, researchQuestions, queries, catalogs, maxResultsPerCatalog);
     }
 }

--- a/jablib/src/main/java/org/jabref/model/study/Study.java
+++ b/jablib/src/main/java/org/jabref/model/study/Study.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /// This class represents a scientific study.
 ///
@@ -106,7 +107,7 @@ public class Study {
         this.researchQuestions = researchQuestions;
     }
 
-    public Integer getMaxResultsPerCatalog() {
+    public @Nullable Integer getMaxResultsPerCatalog() {
         return maxResultsPerCatalog;
     }
 

--- a/jablib/src/main/java/org/jabref/model/study/StudyCatalog.java
+++ b/jablib/src/main/java/org/jabref/model/study/StudyCatalog.java
@@ -2,6 +2,7 @@ package org.jabref.model.study;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class StudyCatalog {
@@ -13,6 +14,10 @@ public class StudyCatalog {
 
     @JsonProperty("reason")
     private String reason;
+
+    @JsonProperty("max-results")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer maxResults;
 
     public StudyCatalog(String name, boolean enabled, String reason) {
         this.name = name;
@@ -55,6 +60,14 @@ public class StudyCatalog {
         this.reason = reason;
     }
 
+    public Integer getMaxResults() {
+        return maxResults;
+    }
+
+    public void setMaxResults(Integer maxResults) {
+        this.maxResults = maxResults;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -72,12 +85,15 @@ public class StudyCatalog {
         if (!Objects.equals(getName(), that.getName())) {
             return false;
         }
-        return Objects.equals(getReason(), that.getReason());
+        if (!Objects.equals(getReason(), that.getReason())) {
+            return false;
+        }
+        return Objects.equals(getMaxResults(), that.getMaxResults());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, enabled, reason);
+        return Objects.hash(name, enabled, reason, maxResults);
     }
 
     @Override
@@ -86,6 +102,7 @@ public class StudyCatalog {
                 "name='" + name + '\'' +
                 ", enabled=" + enabled +
                 ", reason='" + reason + '\'' +
+                ", maxResults=" + maxResults +
                 '}';
     }
 }

--- a/jablib/src/main/java/org/jabref/model/study/StudyCatalog.java
+++ b/jablib/src/main/java/org/jabref/model/study/StudyCatalog.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
 
 public class StudyCatalog {
     @JsonProperty("name")
@@ -60,7 +61,7 @@ public class StudyCatalog {
         this.reason = reason;
     }
 
-    public Integer getMaxResults() {
+    public @Nullable Integer getMaxResults() {
         return maxResults;
     }
 

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -242,7 +242,7 @@ class StudyRepositoryTest {
         study.getCatalogs().getFirst().setMaxResults(500);
 
         Map<String, Integer> limits = studyRepository.getResultLimitsPerCatalog();
-        
+
         assertEquals(500, limits.get(catalogName.toUpperCase(Locale.ROOT)));
     }
 

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -235,9 +235,10 @@ class StudyRepositoryTest {
     }
 
     @Test
-    void omitsCatalogsWithNoLimitSet() {
-        // no study default, no catalog override -> empty map -> StudyFetcher falls back to its constant
-        assertTrue(studyRepository.getResultLimitsPerCatalog().isEmpty());
+    void resolvesToDefaultWhenNoLimitSet() {
+        Map<String, Integer> limits = studyRepository.getResultLimitsPerCatalog();
+        // no study default, no catalog override -> every catalog resolves to the default
+        assertTrue(limits.values().stream().allMatch(limit -> limit == StudyRepository.DEFAULT_RESULT_LIMIT));
     }
 
     private StudyRepository getTestStudyRepository() throws IOException, URISyntaxException, JabRefException {

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import javafx.collections.FXCollections;
@@ -33,6 +34,7 @@ import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.study.FetchResult;
 import org.jabref.model.study.QueryResult;
+import org.jabref.model.study.Study;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -217,6 +219,25 @@ class StudyRepositoryTest {
         List<QueryResult> mockResults = getMockResults();
         studyRepository.persist(mockResults);
         assertEquals(new HashSet<>(getNonDuplicateBibEntryResult().getEntries()), new HashSet<>(getTestStudyRepository().getStudyResultEntries().getEntries()));
+    }
+
+    @Test
+    void resolvesResultLimitsWithCatalogOverrideAndStudyDefault() {
+        Study study = studyRepository.getStudy();
+        study.setMaxResultsPerCatalog(100);
+        study.getCatalogs().getFirst().setMaxResults(500);
+
+        Map<String, Integer> limits = studyRepository.getResultLimitsPerCatalog();
+
+        String overriddenCatalog = study.getCatalogs().getFirst().getName();
+        assertEquals(500, limits.get(overriddenCatalog));
+        assertEquals(100, limits.get(study.getCatalogs().get(1).getName()));
+    }
+
+    @Test
+    void omitsCatalogsWithNoLimitSet() {
+        // no study default, no catalog override -> empty map -> StudyFetcher falls back to its constant
+        assertTrue(studyRepository.getResultLimitsPerCatalog().isEmpty());
     }
 
     private StudyRepository getTestStudyRepository() throws IOException, URISyntaxException, JabRefException {

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -235,10 +236,23 @@ class StudyRepositoryTest {
     }
 
     @Test
+    void resolvesResultLimitCaseInsensitively() {
+        Study study = studyRepository.getStudy();
+        String catalogName = study.getCatalogs().getFirst().getName();
+        study.getCatalogs().getFirst().setMaxResults(500);
+
+        Map<String, Integer> limits = studyRepository.getResultLimitsPerCatalog();
+        
+        assertEquals(500, limits.get(catalogName.toUpperCase(Locale.ROOT)));
+    }
+
+    @Test
     void resolvesToDefaultWhenNoLimitSet() {
         Map<String, Integer> limits = studyRepository.getResultLimitsPerCatalog();
         // no study default, no catalog override -> every catalog resolves to the default
-        assertTrue(limits.values().stream().allMatch(limit -> limit == StudyRepository.DEFAULT_RESULT_LIMIT));
+        limits.forEach((catalog, limit) ->
+                assertEquals(StudyRepository.DEFAULT_RESULT_LIMIT, limit,
+                        () -> "Catalog '" + catalog + "' did not resolve to the default"));
     }
 
     private StudyRepository getTestStudyRepository() throws IOException, URISyntaxException, JabRefException {

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyYamlParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyYamlParserTest.java
@@ -91,6 +91,8 @@ class StudyYamlParserTest {
                      .findFirst()
                      .orElseThrow()
                      .getReason());
+        assertEquals(100, study.getMaxResultsPerCatalog());
+        assertEquals(500, study.getCatalogs().getFirst().getMaxResults());
     }
 
     @Test
@@ -111,5 +113,26 @@ class StudyYamlParserTest {
         Study roundTripped = new StudyYamlParser().parseStudyYamlFile(destination);
 
         assertEquals(original, roundTripped);
+    }
+
+    @Test
+    void writeAndReadStudyWithResultLimitsPreservesData() throws IOException {
+        StudyCatalog catalogWithLimit = new StudyCatalog("Springer", true, "Primary source");
+        catalogWithLimit.setMaxResults(500);
+        Study original = new Study(
+                List.of("Oscar Wilde"),
+                "Limit Study",
+                List.of("Q1"),
+                List.of(new StudyQuery("Quantum")),
+                List.of(catalogWithLimit));
+        original.setMaxResultsPerCatalog(100);
+        Path destination = testDirectory.resolve("limit-study.yml");
+
+        new StudyYamlParser().writeStudyYamlFile(original, destination);
+        Study roundTripped = new StudyYamlParser().parseStudyYamlFile(destination);
+
+        assertEquals(original, roundTripped);
+        assertEquals(100, roundTripped.getMaxResultsPerCatalog());
+        assertEquals(500, roundTripped.getCatalogs().getFirst().getMaxResults());
     }
 }

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study-v2-full.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study-v2-full.yml
@@ -17,6 +17,7 @@ catalogs:
   - name: Springer
     enabled: true
     reason: Primary source
+    max-results: 500
   - name: ArXiv
     enabled: true
     reason: ""
@@ -26,4 +27,5 @@ catalogs:
   - name: IEEEXplore
     enabled: false
     reason: ""
+max-results-per-catalog: 100
 


### PR DESCRIPTION
### Related issues and pull requests


### PR Description

Makes the per-fetcher result limit configurable in the study definition, max-results-per-catalog sets a study-wide default, and an optional max-results on a catalog overrides it, the limit applies to the paged path, non-paged fetchers (ACM) stay as before.

### Steps to test


### AI usage

claude-opus-4.6 to investigate files and review my code


### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
