### PR TITLE
Add file notification to OCRed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added support to the JabKit commands `get-cited-works` and `get-citing-works` to output to files in various export formats. [#15913](https://github.com/JabRef/jabref/pull/15913)
 - We added generic CSV export filter that exports all standard BibTeX fields. [#15711](https://github.com/JabRef/jabref/issues/15711)
 - We added OCR engine's executable path as the first OCR preference to let users specify the exact path of the engine they are using. [#15990](https://github.com/JabRef/jabref/pull/15990)
+- We added file notification to OCRed file to let users open the directory and show the new file. [#16082](https://github.com/JabRef/jabref/pull/16082)
 
 ### Changed
 

--- a/jabgui/src/main/java/org/jabref/gui/linkedfile/OcrLinkedFileAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/linkedfile/OcrLinkedFileAction.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.linkedfile;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -7,8 +8,10 @@ import java.util.Optional;
 import javax.swing.undo.UndoManager;
 
 import org.jabref.gui.DialogService;
+import org.jabref.gui.Notifications;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.gui.desktop.os.NativeDesktop;
 import org.jabref.gui.externalfiles.ImportHandler;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.logic.l10n.Localization;
@@ -22,6 +25,7 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.util.FileUpdateMonitor;
 
+import com.dlsc.gemsfx.infocenter.NotificationAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,6 +84,7 @@ public class OcrLinkedFileAction extends SimpleCommand {
                 case OcrResult.Success success -> {
                     dialogService.notify(Localization.lang("OCR succeeded"));
                     Path ocredPdf = success.outputFile();
+                    dialogService.notify(new OcredFileSuccessNotification(ocredPdf));
                     for (BibEntry entry : linkedEntries) {
                         importHandler.getFileLinker().linkFilesToEntry(entry, List.of(ocredPdf));
                     }
@@ -110,5 +115,22 @@ public class OcrLinkedFileAction extends SimpleCommand {
             case INTERRUPTED ->
                     Localization.lang("OCR was cancelled");
         };
+    }
+
+    private class OcredFileSuccessNotification extends Notifications.FileNotification {
+        public OcredFileSuccessNotification(Path path) {
+            super(Localization.lang("OCR finished successfully."), path.toString());
+
+            NotificationAction<Path> action = new NotificationAction<>(Localization.lang("Show file"), _ -> {
+                try {
+                    NativeDesktop.openFolderAndSelectFile(path, preferences.getExternalApplicationsPreferences(), dialogService);
+                } catch (IOException e) {
+                    LOGGER.error("Could not open OCRed file.", e);
+                }
+                return OnClickBehaviour.REMOVE;
+            });
+
+            getActions().add(action);
+        }
     }
 }

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -804,6 +804,8 @@ Copy\ linked\ file(s)=Copy linked file(s)
 # TODO: "folder" vs. "directory" consistency
 OCR\ failed=OCR failed
 OCR\ succeeded=OCR succeeded
+OCR\ finished\ successfully.=OCR finished successfully.
+Show\ file=Show file
 Perform\ OCR=Perform OCR
 Performing\ OCR=Performing OCR
 Perform\ OCR\ and\ embed\ text\ into\ a\ new\ PDF\ file=Perform OCR and embed text into a new PDF file


### PR DESCRIPTION
### Related issues and pull requests

Part of https://github.com/JabRef/jabref/issues/13267

### PR Description

Add file notification so that users can open and see where the file is created

### Steps to test

1. Open an entry with a file linked to it 
<img width="2002" height="1328" alt="image" src="https://github.com/user-attachments/assets/9e798a25-8415-4a23-8fc0-e6b76da76418" />
2. Right click on the file and click on `Perform OCR and embed text into a new PDF file` 
<img width="2002" height="1328" alt="image" src="https://github.com/user-attachments/assets/ddaf54ed-96d1-4a7b-94a4-4d7d1ca52789" />
3. Now there is a notification to let users jump to the OCRed file 
<img width="2002" height="1328" alt="image" src="https://github.com/user-attachments/assets/0c872c5a-857b-4474-96a2-4d1773a66c90" />
4. On clicking Show file
<img width="2262" height="1556" alt="image" src="https://github.com/user-attachments/assets/ddaf109b-1086-47fd-8e68-6a7548168ea9" />


### AI usage

No AI usage

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
