### PR TITLE
limit aissignments globally

### DIFF
--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -33,17 +33,12 @@ jobs:
             It will also guide you in other aspects of contributing to JabRef.
           # 2: One person could have one PR opened and while waiting for feedback working on another one.
           max_assignments: 3
-          max_overall_assignment_labels: "good first issue"
           max_overall_assignment_text: >
-            ### ⚠️ Assignment Limit Reached for Good First Issues
+            ### ⚠️ Assignment Limit Reached
 
 
-            Hi @{{ handle }}, you've already reached the limit of **{{ max_overall_assignment_count }}** active assignments for good first issues.
-            Good first issues are a great way to get started with contributing to JabRef, and we want to ensure that all newcomers have the opportunity to work on them.
-
-
-            While waiting for feedback on your current assignments, you are invited to move on to more advanced issues.
-            Start at checking the [good second issues](https://github.com/JabRef/jabref/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20label%3A%22good%20second%20issue%22%20no%3Aassignee).
+            Hi @{{ handle }}, you've already reached the limit of **{{ max_overall_assignment_count }}** active assignments.
+            Issues are a great way to work on opensource, and we want to ensure that all contributors have the opportunity to work on issues.
           assigned_newcomer_text: >
             👋 Hey @{{ handle }}, thank you for your interest in this issue! 🎉
 


### PR DESCRIPTION
Refs https://github.com/JabRef/jabref/issues/16075#issuecomment-4792831861

But why was https://github.com/JabRef/jabref/issues/16049#issuecomment-4791399681 triggered?

I think, the number 3 is still OK, and the text, too.

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
