### PR TITLE
Fix force-push detection in Check PR Modifications workflow

### DIFF
--- a/.github/workflows/pr-modifications.yml
+++ b/.github/workflows/pr-modifications.yml
@@ -60,7 +60,11 @@ jobs:
             echo "✅ New PR created."
             exit 0
           fi
-          if git cat-file -e ${{ github.event.before }} 2>/dev/null; then
+          # A regular push leaves `before` as an ancestor of the new head;
+          # a rebase/amend force-push does not. Checking ancestry (instead of
+          # mere object existence via `git cat-file -e`) is reliable even when
+          # the orphaned `before` commit is still fetched locally.
+          if git merge-base --is-ancestor "${{ github.event.before }}" HEAD 2>/dev/null; then
             echo "✅ Regular push detected."
             exit 0
           else


### PR DESCRIPTION
### Related issues and pull requests

Context: https://github.com/JabRef/jabref/pull/16074#issuecomment-4792227001

### PR Description

The `no-force-push` job in the `Check PR Modifications` workflow decided force-push vs. regular push with `git cat-file -e <before>`, assuming the pre-push commit is unfetchable after a force-push. Because `actions/checkout` runs with `fetch-depth: 0` against GitHub (which retains unreachable objects and serves arbitrary SHAs), the `before` commit is frequently still present locally, so the check reported "Regular push detected" for genuine force-pushes — the job passed and `ghprcomment` never posted the force-push notice. This switches detection to an ancestry check (`git merge-base --is-ancestor <before> HEAD`), which is reliable regardless of whether the orphaned `before` object was fetched.

### Steps to test

This is a CI workflow change. To verify: on a PR, push normally (job stays green, "Regular push detected") and then force-push (job fails with "Force push detected", and `ghprcomment` posts the force-push notice). Empirically, PR #16074 had 15+ `head_ref_force_pushed` events on 2026-06-24 where every run wrongly reported "Regular push detected"; the new ancestry check fails in that scenario.

#### Analogies

Like honey, this fix is a small, sticky one-liner that sweetens an otherwise sour contributor experience. Like chocolate, it melts away a subtle bitterness — the silent passing of force-pushes — that was easy to miss until you tasted it. And like the moon, the orphaned `before` commit was still up there, visible to `git cat-file` long after it should have set; checking ancestry instead simply stops mistaking moonlight for daylight.

`jabref-contrib-policy:4.2:reviewed​:ok`

### AI usage

Claude Code (model claude-opus-4-8). Investigation and the one-line workflow fix were AI-assisted; reviewed and owned by the contributor.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

This change touches only `.github/workflows/pr-modifications.yml` (a CI workflow). No Java, FXML, Markdown, or build inputs changed, so the Java/build/docs items below are not applicable.

## Code rules

- [/] JSpecify annotations used instead of `== null` checks.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [/] `org.jabref.logic.util.strings.StringUtil.isBlank(java.lang.String)` used instead of `== null || ...isBlank()`.
- [/] No `catch (Exception e)` — only specific exceptions caught.
- [x] No commented-out code left behind.
- [/] User-facing text is localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] New `BibEntry` objects created with withers (`withField`, not `setField`).
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.
- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).
- [/] Tests added or updated for changed behavior in `org.jabref.model` / `org.jabref.logic`.

## Verification commands

- [/] `./gradlew :jablib:check` (or `./gradlew check` for all modules) passes.
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh` passes.
- [/] `./gradlew modernizer` passes.
- [/] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [/] `./gradlew javadoc` passes.
- [/] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` passes.
- [/] `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"` executed to ensure proper formatting.

## Documentation

- [/] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when no issue is known and the PR is not yet created — never a fake number.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [/] Developer documentation under `docs/` updated if behavior or architecture changed.

## Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If CHANGELOG.md used a `TODO` placeholder, it was replaced with the real PR-number link after PR creation, then committed and pushed.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required) — CI workflow change; not testable in the running app
- [/] I added JUnit tests for changes (if applicable) — not applicable to a CI workflow change
- [/] I added screenshots in the PR description (if change is visible to the user) — not user-visible
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number — not user-visible
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user) — not user-visible
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness — no user-facing behavior changed
</content>
</invoke>
