### PR TITLE
Remove duplicate notification

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/linkedfile/OcrLinkedFileAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/linkedfile/OcrLinkedFileAction.java
@@ -82,7 +82,6 @@ public class OcrLinkedFileAction extends SimpleCommand {
         ocrTask.onSuccess(result -> {
             switch (result) {
                 case OcrResult.Success success -> {
-                    dialogService.notify(Localization.lang("OCR succeeded"));
                     Path ocredPdf = success.outputFile();
                     dialogService.notify(new OcredFileSuccessNotification(ocredPdf));
                     for (BibEntry entry : linkedEntries) {

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -803,7 +803,6 @@ Redownload\ file(s)=Redownload file(s)
 Copy\ linked\ file(s)=Copy linked file(s)
 # TODO: "folder" vs. "directory" consistency
 OCR\ failed=OCR failed
-OCR\ succeeded=OCR succeeded
 OCR\ finished\ successfully.=OCR finished successfully.
 Show\ file=Show file
 Perform\ OCR=Perform OCR


### PR DESCRIPTION
### Related issues and pull requests

Follow up for https://github.com/JabRef/jabref/pull/16082

### PR Description

Remove duplicate notification found here https://github.com/JabRef/jabref/pull/16082#issuecomment-4791016342

### Steps to test

Performing OCR will show one notification on success
<img width="2048" height="480" alt="image" src="https://github.com/user-attachments/assets/0d3fe93d-9e09-43fa-ad37-44d4cf5b780d" />


### AI usage

NA

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
