### PR TITLE
fix(preview): fix initial text for preview combobox

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/preview/PreviewPanel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preview/PreviewPanel.java
@@ -23,6 +23,7 @@ import javafx.scene.input.TransferMode;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.util.Duration;
+import javafx.util.StringConverter;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.Notifications;
@@ -103,6 +104,17 @@ public class PreviewPanel extends VBox implements PreviewControls {
                 .install(previewLayoutComboBox);
         previewLayoutComboBox.setItems(previewPreferences.getLayoutCycle());
         previewLayoutComboBox.setValue(previewPreferences.getSelectedPreviewLayout());
+        previewLayoutComboBox.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(@Nullable PreviewLayout layout) {
+                return layout == null ? "" : layout.getDisplayName();
+            }
+
+            @Override
+            public @Nullable PreviewLayout fromString(String s) {
+                return null;
+            }
+        });
 
         BindingsHelper.bindBidirectional(
                 previewPreferences.layoutCyclePositionProperty(),


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/JabRef/jabref-issue-melting-pot/issues/1322

### PR Description

Just fixes the bug. Adds a string converter.

I would really like to move this string converter to the `install` method, but I'm not sure if it will work 100% correctly.

### Steps to test

1. Open JabRef and some library.
2. Open an entry.
3. You should see the entry editor with a preview. At the bottom there will be the preview style combobox, which should contain correct text (and not `Object::toString`).

### AI usage

I have used ChatGPT to discuss and summarize one StackOverflow thread.

Then I used Claude to propose the solutions to the problem (because one of the answers on stack overflow was already used in the view model factory, but it didn't help).

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
