### PR TITLE
SLR: springer raw query

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcher.java
@@ -13,8 +13,10 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.jabref.logic.help.HelpFile;
+import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.importer.PagedSearchBasedParserFetcher;
+import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.fetcher.transformers.SpringerQueryTransformer;
 import org.jabref.logic.net.URLDownload;
@@ -26,6 +28,7 @@ import org.jabref.model.entry.Month;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.paging.Page;
 import org.jabref.model.search.query.BaseQueryNode;
 
 import com.google.common.base.Strings;
@@ -191,8 +194,37 @@ public class SpringerNatureWebFetcher implements PagedSearchBasedParserFetcher, 
     /// @return URL
     @Override
     public URL getURLForQuery(BaseQueryNode queryNode, int pageNumber) throws URISyntaxException, MalformedURLException {
+        String transformedQuery = new SpringerQueryTransformer().transformSearchQuery(queryNode).orElse("");
+        return buildSearchURL(transformedQuery, pageNumber);
+    }
+
+    @Override
+    public Page<BibEntry> performRawSearchQueryPaged(String rawQuery, int pageNumber) throws FetcherException {
+        if (rawQuery.isBlank()) {
+            return new Page<>(rawQuery, pageNumber, List.of());
+        }
+        try {
+            URL url = buildSearchURL(rawQuery, pageNumber);
+            try (var stream = getUrlDownload(url).asInputStream()) {
+                return new Page<>(rawQuery, pageNumber, getParser().parseEntries(stream));
+            }
+        } catch (URISyntaxException e) {
+            throw new FetcherException("Springer raw search URL is malformed for query: " + rawQuery, e);
+        } catch (IOException e) {
+            throw new FetcherException(rawQuery, e);
+        } catch (ParseException e) {
+            throw new FetcherException("Springer raw search parse error for query: " + rawQuery, e);
+        }
+    }
+
+    /// Builds the Springer Nature search API URL for the given raw query string and page number.
+    /// The raw query is sent verbatim as the `q` parameter, bypassing [SpringerQueryTransformer].
+    ///
+    /// @param rawQuery   the query string to pass directly as the `q` parameter
+    /// @param pageNumber zero based page number; converted to a one based `s` start value.
+    private URL buildSearchURL(String rawQuery, int pageNumber) throws URISyntaxException, MalformedURLException {
         URIBuilder uriBuilder = new URIBuilder(API_URL);
-        uriBuilder.addParameter("q", new SpringerQueryTransformer().transformSearchQuery(queryNode).orElse("")); // Search query
+        uriBuilder.addParameter("q", rawQuery); // Search query
         importerPreferences.getApiKey(getName()).ifPresent(key -> uriBuilder.addParameter("api_key", key)); // API key
         uriBuilder.addParameter("s", String.valueOf(getPageSize() * pageNumber + 1)); // Start entry, starts indexing at 1
         uriBuilder.addParameter("p", String.valueOf(getPageSize())); // Page size

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcher.java
@@ -2,6 +2,7 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -205,7 +206,7 @@ public class SpringerNatureWebFetcher implements PagedSearchBasedParserFetcher, 
         }
         try {
             URL url = buildSearchURL(rawQuery, pageNumber);
-            try (var stream = getUrlDownload(url).asInputStream()) {
+            try (InputStream stream = getUrlDownload(url).asInputStream()) {
                 return new Page<>(rawQuery, pageNumber, getParser().parseEntries(stream));
             }
         } catch (URISyntaxException e) {

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcherTest.java
@@ -13,6 +13,7 @@ import org.jabref.logic.util.BuildInfo;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.paging.Page;
 import org.jabref.testutils.category.FetcherTest;
 
 import com.airhacks.afterburner.injection.Injector;
@@ -240,6 +241,12 @@ class SpringerNatureWebFetcherTest implements SearchBasedFetcherCapabilityTest, 
                           .map(bibEntry -> bibEntry.getField(StandardField.AUTHOR))
                           .filter(Optional::isPresent)
                           .map(Optional::get).forEach(authorField -> assertTrue(authorField.contains("Redmiles")));
+    }
+
+    @Test
+    void performRawSearchQueryPagedWithBlankQueryReturnsEmptyPage() throws FetcherException {
+        Page<BibEntry> result = fetcher.performRawSearchQueryPaged("", 0);
+        assertEquals(List.of(), result.getContent());
     }
 
     @Override


### PR DESCRIPTION
### Related issues and pull requests

related to SLR raw-query support work.

### PR Description
performRawSearchQueryPaged sends the query string as Springer's q parameter, bypassing SpringerQueryTransformer, so SLR researchers can use catalog-native syntax. 
URL building is extracted into a shared buildSearchURL helper used by both the translated and raw paths.

### Steps to test


### AI usage
claude-opus-4.6 to investigate files and review my code

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
