### PR TITLE
SLR: migrate ArXiv fetcher

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -612,6 +612,7 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
 
             return new Page<>(transformedQuery, pageNumber, filterYears(searchResult, transformer));
         }
+
         @Override
         public Page<BibEntry> performRawSearchQueryPaged(String rawQuery, int pageNumber) throws FetcherException {
             if (rawQuery.isBlank()) {

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -336,6 +336,34 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
     }
 
     @Override
+    public Page<BibEntry> performRawSearchQueryPaged(String rawQuery, int pageNumber) throws FetcherException {
+        if (rawQuery.isBlank()) {
+            return new Page<>(rawQuery, pageNumber, List.of());
+        }
+        Page<BibEntry> result = arXiv.performRawSearchQueryPaged(rawQuery, pageNumber);
+        if (this.doiFetcher == null) {
+            return result;
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(getPageSize() * 2);
+
+        Collection<CompletableFuture<BibEntry>> futureSearchResult = result.getContent()
+                                                                           .stream()
+                                                                           .map(bibEntry ->
+                                                                                   CompletableFuture.supplyAsync(() -> {
+                                                                                       this.inplaceAsyncInfuseArXivWithDoi(bibEntry);
+                                                                                       return bibEntry;
+                                                                                   }, executor))
+                                                                           .toList();
+
+        Collection<BibEntry> modifiedSearchResult = futureSearchResult.stream()
+                                                                      .map(CompletableFuture::join)
+                                                                      .collect(Collectors.toList());
+
+        return new Page<>(result.getQuery(), result.getPageNumber(), modifiedSearchResult);
+    }
+
+    @Override
     public Optional<BibEntry> performSearchById(String identifier) throws FetcherException {
         CompletableFuture<Optional<BibEntry>> arXivBibEntryPromise = arXiv.asyncPerformSearchById(identifier);
         if (this.doiFetcher != null) {
@@ -583,6 +611,17 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
                     .collect(Collectors.toList());
 
             return new Page<>(transformedQuery, pageNumber, filterYears(searchResult, transformer));
+        }
+        @Override
+        public Page<BibEntry> performRawSearchQueryPaged(String rawQuery, int pageNumber) throws FetcherException {
+            if (rawQuery.isBlank()) {
+                return new Page<>(rawQuery, pageNumber, List.of());
+            }
+            List<BibEntry> searchResult = searchForEntries(rawQuery, pageNumber)
+                    .stream()
+                    .map(arXivEntry -> arXivEntry.toBibEntry(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()))
+                    .collect(Collectors.toList());
+            return new Page<>(rawQuery, pageNumber, searchResult);
         }
 
         private List<BibEntry> filterYears(List<BibEntry> searchResult, ArXivQueryTransformer transformer) {

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -317,22 +317,22 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
             return result;
         }
 
-        ExecutorService executor = Executors.newFixedThreadPool(getPageSize() * 2);
+        try (ExecutorService executor = Executors.newFixedThreadPool(getPageSize() * 2)) {
+            Collection<CompletableFuture<BibEntry>> futureSearchResult = result.getContent()
+                                                                               .stream()
+                                                                               .map(bibEntry ->
+                                                                                       CompletableFuture.supplyAsync(() -> {
+                                                                                           this.inplaceAsyncInfuseArXivWithDoi(bibEntry);
+                                                                                           return bibEntry;
+                                                                                       }, executor))
+                                                                               .toList();
 
-        Collection<CompletableFuture<BibEntry>> futureSearchResult = result.getContent()
-                                                                           .stream()
-                                                                           .map(bibEntry ->
-                                                                                   CompletableFuture.supplyAsync(() -> {
-                                                                                       this.inplaceAsyncInfuseArXivWithDoi(bibEntry);
-                                                                                       return bibEntry;
-                                                                                   }, executor))
-                                                                           .toList();
+            Collection<BibEntry> modifiedSearchResult = futureSearchResult.stream()
+                                                                          .map(CompletableFuture::join)
+                                                                          .toList();
 
-        Collection<BibEntry> modifiedSearchResult = futureSearchResult.stream()
-                                                                      .map(CompletableFuture::join)
-                                                                      .collect(Collectors.toList());
-
-        return new Page<>(result.getQuery(), result.getPageNumber(), modifiedSearchResult);
+            return new Page<>(result.getQuery(), result.getPageNumber(), modifiedSearchResult);
+        }
     }
 
     @Override
@@ -345,22 +345,22 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
             return result;
         }
 
-        ExecutorService executor = Executors.newFixedThreadPool(getPageSize() * 2);
+        try (ExecutorService executor = Executors.newFixedThreadPool(getPageSize() * 2)) {
+            Collection<CompletableFuture<BibEntry>> futureSearchResult = result.getContent()
+                                                                               .stream()
+                                                                               .map(bibEntry ->
+                                                                                       CompletableFuture.supplyAsync(() -> {
+                                                                                           this.inplaceAsyncInfuseArXivWithDoi(bibEntry);
+                                                                                           return bibEntry;
+                                                                                       }, executor))
+                                                                               .toList();
 
-        Collection<CompletableFuture<BibEntry>> futureSearchResult = result.getContent()
-                                                                           .stream()
-                                                                           .map(bibEntry ->
-                                                                                   CompletableFuture.supplyAsync(() -> {
-                                                                                       this.inplaceAsyncInfuseArXivWithDoi(bibEntry);
-                                                                                       return bibEntry;
-                                                                                   }, executor))
-                                                                           .toList();
+            Collection<BibEntry> modifiedSearchResult = futureSearchResult.stream()
+                                                                          .map(CompletableFuture::join)
+                                                                          .toList();
 
-        Collection<BibEntry> modifiedSearchResult = futureSearchResult.stream()
-                                                                      .map(CompletableFuture::join)
-                                                                      .collect(Collectors.toList());
-
-        return new Page<>(result.getQuery(), result.getPageNumber(), modifiedSearchResult);
+            return new Page<>(result.getQuery(), result.getPageNumber(), modifiedSearchResult);
+        }
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -331,9 +331,10 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
     }
 
     /// Enriches each entry in the page with additional metadata from ArXiv-issued and user-issued DOIs using parallel async requests.
-    /// The page size times two thread pool size matches the pattern used before extraction.
     private Page<BibEntry> enrichPageWithDoi(Page<BibEntry> result) {
-        try (ExecutorService executor = Executors.newFixedThreadPool(getPageSize() * 2)) {
+        try (ExecutorService executor = Executors.newFixedThreadPool(getPageSize())) {
+            // All futures must be submitted before any .join() is called, so that tasks run in parallel.
+            // Collecting to a list here forces full submission before the join step below.
             Collection<CompletableFuture<BibEntry>> futureSearchResult = result.getContent()
                                                                                .stream()
                                                                                .map(bibEntry ->

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -330,6 +330,8 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
         return enrichPageWithDoi(result);
     }
 
+    /// Enriches each entry in the page with additional metadata from ArXiv-issued and user-issued DOIs using parallel async requests.
+    /// The page size times two thread pool size matches the pattern used before extraction.
     private Page<BibEntry> enrichPageWithDoi(Page<BibEntry> result) {
         try (ExecutorService executor = Executors.newFixedThreadPool(getPageSize() * 2)) {
             Collection<CompletableFuture<BibEntry>> futureSearchResult = result.getContent()

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -607,7 +607,7 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
             List<BibEntry> searchResult = searchForEntries(rawQuery, pageNumber)
                     .stream()
                     .map(arXivEntry -> arXivEntry.toBibEntry(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()))
-                    .collect(Collectors.toList());
+                    .toList();
             return new Page<>(rawQuery, pageNumber, searchResult);
         }
 

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -311,28 +311,11 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
     /// @return A list of entries matching the complex query
     @Override
     public Page<BibEntry> performSearchPaged(BaseQueryNode queryNode, int pageNumber) throws FetcherException {
-
         Page<BibEntry> result = arXiv.performSearchPaged(queryNode, pageNumber);
         if (this.doiFetcher == null) {
             return result;
         }
-
-        try (ExecutorService executor = Executors.newFixedThreadPool(getPageSize() * 2)) {
-            Collection<CompletableFuture<BibEntry>> futureSearchResult = result.getContent()
-                                                                               .stream()
-                                                                               .map(bibEntry ->
-                                                                                       CompletableFuture.supplyAsync(() -> {
-                                                                                           this.inplaceAsyncInfuseArXivWithDoi(bibEntry);
-                                                                                           return bibEntry;
-                                                                                       }, executor))
-                                                                               .toList();
-
-            Collection<BibEntry> modifiedSearchResult = futureSearchResult.stream()
-                                                                          .map(CompletableFuture::join)
-                                                                          .toList();
-
-            return new Page<>(result.getQuery(), result.getPageNumber(), modifiedSearchResult);
-        }
+        return enrichPageWithDoi(result);
     }
 
     @Override
@@ -344,7 +327,10 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
         if (this.doiFetcher == null) {
             return result;
         }
+        return enrichPageWithDoi(result);
+    }
 
+    private Page<BibEntry> enrichPageWithDoi(Page<BibEntry> result) {
         try (ExecutorService executor = Executors.newFixedThreadPool(getPageSize() * 2)) {
             Collection<CompletableFuture<BibEntry>> futureSearchResult = result.getContent()
                                                                                .stream()

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
@@ -578,7 +578,7 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
 
     @Test
     void performRawSearchQueryPagedWithBlankQueryReturnsEmptyPage() throws FetcherException {
-        assertTrue(fetcher.performRawSearchQueryPaged("", 0).getContent().isEmpty());
+        assertEquals(List.of(), fetcher.performRawSearchQueryPaged("", 0).getContent());
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
@@ -35,7 +35,6 @@ import org.mockito.Mockito;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -585,7 +584,7 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
     @Test
     void performRawSearchQueryPagedWithNullDoiFetcherReturnsResults() throws FetcherException {
         ArXivFetcher fetcherWithoutDoi = new ArXivFetcher(importFormatPreferences, null);
-        assertNotNull(fetcherWithoutDoi.performRawSearchQueryPaged("machine learning", 0).getContent());
+        assertFalse(fetcherWithoutDoi.performRawSearchQueryPaged("machine learning", 0).getContent().isEmpty());
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mockito;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -579,6 +580,12 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
     @Test
     void performRawSearchQueryPagedWithBlankQueryReturnsEmptyPage() throws FetcherException {
         assertTrue(fetcher.performRawSearchQueryPaged("", 0).getContent().isEmpty());
+    }
+
+    @Test
+    void performRawSearchQueryPagedWithNullDoiFetcherReturnsResults() throws FetcherException {
+        ArXivFetcher fetcherWithoutDoi = new ArXivFetcher(importFormatPreferences, null);
+        assertNotNull(fetcherWithoutDoi.performRawSearchQueryPaged("machine learning", 0).getContent());
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
@@ -577,6 +577,11 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
     }
 
     @Test
+    void performRawSearchQueryPagedWithBlankQueryReturnsEmptyPage() throws FetcherException {
+        assertTrue(fetcher.performRawSearchQueryPaged("", 0).getContent().isEmpty());
+    }
+
+    @Test
     void abstractIsCleanedUp() throws FetcherException {
         Optional<BibEntry> entry = fetcher.performSearchById("2407.02238");
         String escaped = "{One of the primary areas of interest in High Performance Computing is the improvement of performance of parallel workloads. Nowadays, compilable source code-based optimization tasks that employ deep learning often exploit LLVM Intermediate Representations (IRs) for extracting features from source code. Most such works target specific tasks, or are designed with a pre-defined set of heuristics. So far, pre-trained models are rare in this domain, but the possibilities have been widely discussed. Especially approaches mimicking large-language models (LLMs) have been proposed. But these have prohibitively large training costs. In this paper, we propose MIREncoder, a M}ulti-modal IR-based Auto-Encoder that can be pre-trained to generate a learned embedding space to be used for downstream tasks by machine learning-based approaches. A multi-modal approach enables us to better extract features from compilable programs. It allows us to better model code syntax, semantics and structure. For code-based performance optimizations, these features are very important while making optimization decisions. A pre-trained model/embedding implicitly enables the usage of transfer learning, and helps move away from task-specific trained models. Additionally, a pre-trained model used for downstream performance optimization should itself have reduced overhead, and be easily usable. These considerations have led us to propose a modeling approach that i) understands code semantics and structure, ii) enables use of transfer learning, and iii) is small and simple enough to be easily re-purposed or reused even with low resource availability. Our evaluations will show that our proposed approach can outperform the state of the art while reducing overhead.";

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
@@ -578,7 +578,7 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
 
     @Test
     void performRawSearchQueryPagedWithBlankQueryReturnsEmptyPage() throws FetcherException {
-        assertEquals(List.of(), fetcher.performRawSearchQueryPaged("", 0).getContent());
+        assertTrue(fetcher.performRawSearchQueryPaged("", 0).getContent().isEmpty());
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
@@ -582,9 +582,8 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
     }
 
     @Test
-    void performRawSearchQueryPagedWithNullDoiFetcherReturnsResults() throws FetcherException {
-        ArXivFetcher fetcherWithoutDoi = new ArXivFetcher(importFormatPreferences, null);
-        assertFalse(fetcherWithoutDoi.performRawSearchQueryPaged("machine learning", 0).getContent().isEmpty());
+    void performRawSearchQueryPagedReturnsResults() throws FetcherException {
+        assertFalse(fetcher.performRawSearchQueryPaged("machine learning", 0).getContent().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
### Related issues and pull requests

SLR related migration work

### PR Description

`ArXiv` Fetcher now implements `performRawSearchQueryPaged`, bypassing `ArXivQueryTransformer`.

### Steps to test

### AI usage

Claude Sonnet 4.6

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
