### PR TITLE
Add batch lookup and cache

### DIFF
--- a/.jbang/JabSrvLauncher.java
+++ b/.jbang/JabSrvLauncher.java
@@ -61,6 +61,7 @@
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/BibEntryDTO.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/cayw/SimpleJson.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/GlobalExceptionMapper.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/UncheckedFetcherException.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/GsonFactory.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/GroupDTO.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/GsonMessageBodyReader.java

--- a/.jbang/JabSrvLauncher.java
+++ b/.jbang/JabSrvLauncher.java
@@ -61,9 +61,8 @@
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/BibEntryDTO.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/cayw/SimpleJson.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/GlobalExceptionMapper.java
-//SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/UncheckedFetcherException.java
-//SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/GsonFactory.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/GroupDTO.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/GsonFactory.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/GsonMessageBodyReader.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/GsonMessageBodyWriter.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/LibraryQueryMatch.java
@@ -71,6 +70,7 @@
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/LibraryQueryResponse.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/LibraryQueryResult.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/LinkedPdfFileDTO.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/UncheckedFetcherException.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/JabrefMediaType.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/AbstractSrvStateManager.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/JabRefSrvStateManager.java

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,7 @@ Both comments must not be added.
 
 #### Testing / JUnit
 
+- Name test classes `...Test` (singular), not `...Tests` — e.g. `JabSrvArchitectureTest`, not `JabSrvArchitectureTests`. This holds even for ArchUnit classes that bundle several `@ArchTest` rules.
 - In JabRef, we don't use `@DisplayName`, we typically just write method name as is. The method name itself should be comprehensive enough.
 - Instead of `Files.createTempDirectory` `@TempDir` JUnit5 annotation should be used.
 - If `@TempDir` is used, there is no need to clean it up

--- a/jabgui/src/test/java/org/jabref/gui/JabGuiArchitectureTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/JabGuiArchitectureTest.java
@@ -6,5 +6,5 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 
 @AnalyzeClasses(packages = "org.jabref", importOptions = ImportOption.DoNotIncludeTests.class)
-public class JabGuiArchitectureTests extends CommonArchitectureTest {
+public class JabGuiArchitectureTest extends CommonArchitectureTest {
 }

--- a/jablib/src/test/java/org/jabref/logic/JabLibArchitectureTest.java
+++ b/jablib/src/test/java/org/jabref/logic/JabLibArchitectureTest.java
@@ -6,5 +6,5 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 
 @AnalyzeClasses(packages = "org.jabref", importOptions = ImportOption.DoNotIncludeTests.class)
-public class JabLibArchitectureTests extends CommonArchitectureTest {
+public class JabLibArchitectureTest extends CommonArchitectureTest {
 }

--- a/jabsrv/build.gradle.kts
+++ b/jabsrv/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 testModuleInfo {
+    requires("org.jabref.testsupport")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
     requires("org.mockito")

--- a/jabsrv/build.gradle.kts
+++ b/jabsrv/build.gradle.kts
@@ -6,12 +6,14 @@ plugins {
 }
 
 testModuleInfo {
-    requires("org.jabref.testsupport")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
     requires("org.mockito")
     requires("org.glassfish.jersey.tests.framework.core")
     requires("jul.to.slf4j")
+    requires("com.tngtech.archunit")
+    requires("com.tngtech.archunit.junit5.api")
+    runtimeOnly("com.tngtech.archunit.junit5.engine")
     runtimeOnly("org.glassfish.jersey.tests.framework.provider.grizzly")
     runtimeOnly("org.tinylog.api")
     runtimeOnly("org.tinylog.impl")

--- a/jabsrv/build.gradle.kts
+++ b/jabsrv/build.gradle.kts
@@ -11,6 +11,7 @@ testModuleInfo {
     requires("org.mockito")
     requires("org.glassfish.jersey.tests.framework.core")
     requires("jul.to.slf4j")
+    requires("org.jabref.testsupport")
     requires("com.tngtech.archunit")
     requires("com.tngtech.archunit.junit5.api")
     runtimeOnly("com.tngtech.archunit.junit5.engine")

--- a/jabsrv/src/main/java/module-info.java
+++ b/jabsrv/src/main/java/module-info.java
@@ -22,7 +22,6 @@ module org.jabref.jabsrv {
     // For CAYW feature
     requires transitive javafx.graphics;
     requires transitive javafx.controls;
-    requires afterburner.fx;
     requires java.desktop;
 
     requires transitive org.jabref.jablib;

--- a/jabsrv/src/main/java/org/jabref/http/dto/GlobalExceptionMapper.java
+++ b/jabsrv/src/main/java/org/jabref/http/dto/GlobalExceptionMapper.java
@@ -15,6 +15,15 @@ public class GlobalExceptionMapper implements ExceptionMapper<Throwable> {
 
     @Override
     public Response toResponse(Throwable exception) {
+        if (exception instanceof UncheckedFetcherException ufe) {
+            // Unwrap to the original FetcherException's message so callers see
+            // the actual fetch failure, not the carrier's identity.
+            LOGGER.warn("Plain-citation fetcher failed", ufe.getCause());
+            return Response.serverError()
+                           .entity(ufe.getCause().getLocalizedMessage())
+                           .type(MediaType.TEXT_PLAIN)
+                           .build();
+        }
         if (exception instanceof WebApplicationException webex) {
             Response response = webex.getResponse();
             // Preserve responses that already carry their own body and content type — e.g. the

--- a/jabsrv/src/main/java/org/jabref/http/dto/GlobalExceptionMapper.java
+++ b/jabsrv/src/main/java/org/jabref/http/dto/GlobalExceptionMapper.java
@@ -16,11 +16,13 @@ public class GlobalExceptionMapper implements ExceptionMapper<Throwable> {
     @Override
     public Response toResponse(Throwable exception) {
         if (exception instanceof UncheckedFetcherException ufe) {
-            // Unwrap to the original FetcherException's message so callers see
-            // the actual fetch failure, not the carrier's identity.
+            // FetcherException#getLocalizedMessage embeds the upstream URL,
+            // HTTP status line, and full response body — none of which are
+            // safe to send back to the HTTP client. Log the full chain for
+            // operators, return a generic body to the caller.
             LOGGER.warn("Plain-citation fetcher failed", ufe.getCause());
             return Response.serverError()
-                           .entity(ufe.getCause().getLocalizedMessage())
+                           .entity("Plain-citation fetcher failed.")
                            .type(MediaType.TEXT_PLAIN)
                            .build();
         }

--- a/jabsrv/src/main/java/org/jabref/http/dto/UncheckedFetcherException.java
+++ b/jabsrv/src/main/java/org/jabref/http/dto/UncheckedFetcherException.java
@@ -1,0 +1,22 @@
+package org.jabref.http.dto;
+
+import org.jabref.logic.importer.FetcherException;
+
+/// Unchecked carrier for [FetcherException] so JAX-RS resources can let it
+/// propagate through `Optional.orElseGet`-style lambdas (whose `Supplier`
+/// signature cannot declare a checked exception).
+///
+/// `GlobalExceptionMapper` unwraps the cause and surfaces its message in the
+/// HTTP response, so behaviour is equivalent to throwing the original
+/// `FetcherException` straight from the resource method.
+public class UncheckedFetcherException extends RuntimeException {
+
+    public UncheckedFetcherException(FetcherException cause) {
+        super(cause);
+    }
+
+    @Override
+    public synchronized FetcherException getCause() {
+        return (FetcherException) super.getCause();
+    }
+}

--- a/jabsrv/src/main/java/org/jabref/http/dto/UncheckedFetcherException.java
+++ b/jabsrv/src/main/java/org/jabref/http/dto/UncheckedFetcherException.java
@@ -2,6 +2,8 @@ package org.jabref.http.dto;
 
 import org.jabref.logic.importer.FetcherException;
 
+import org.jspecify.annotations.NullMarked;
+
 /// Unchecked carrier for [FetcherException] so JAX-RS resources can let it
 /// propagate through `Optional.orElseGet`-style lambdas (whose `Supplier`
 /// signature cannot declare a checked exception).
@@ -9,6 +11,7 @@ import org.jabref.logic.importer.FetcherException;
 /// `GlobalExceptionMapper` unwraps the cause and surfaces its message in the
 /// HTTP response, so behaviour is equivalent to throwing the original
 /// `FetcherException` straight from the resource method.
+@NullMarked
 public class UncheckedFetcherException extends RuntimeException {
 
     public UncheckedFetcherException(FetcherException cause) {

--- a/jabsrv/src/main/java/org/jabref/http/server/Server.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/Server.java
@@ -118,8 +118,7 @@ public class Server {
         ServiceLocatorUtilities.addOneConstant(serviceLocator, preferences, "preferences", CliPreferences.class);
         ServiceLocatorUtilities.addOneConstant(serviceLocator, new CitationCacheService());
         ServiceLocatorUtilities.addOneConstant(serviceLocator, new FormatterService());
-        ServiceLocatorUtilities.addOneConstant(
-                serviceLocator, preferences.getCustomEntryTypesRepository(), "entrytypesmanager", BibEntryTypesManager.class);
+        ServiceLocatorUtilities.addOneConstant(serviceLocator, preferences.getCustomEntryTypesRepository(), "entrytypesmanager", BibEntryTypesManager.class);
         ServiceLocatorUtilities.addFactoryConstants(serviceLocator, new GsonFactory());
 
         // see https://stackoverflow.com/a/33794265/873282

--- a/jabsrv/src/main/java/org/jabref/http/server/Server.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/Server.java
@@ -33,7 +33,9 @@ import org.jabref.logic.UiMessageHandler;
 import org.jabref.logic.os.OS;
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.model.database.BibDatabase;
+import org.jabref.model.entry.BibEntryTypesManager;
 
+import com.airhacks.afterburner.injection.Injector;
 import net.harawata.appdirs.AppDirsFactory;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.ssl.SSLContextConfigurator;
@@ -117,6 +119,9 @@ public class Server {
         ServiceLocatorUtilities.addOneConstant(serviceLocator, preferences, "preferences", CliPreferences.class);
         ServiceLocatorUtilities.addOneConstant(serviceLocator, new CitationCacheService());
         ServiceLocatorUtilities.addOneConstant(serviceLocator, new FormatterService());
+        ServiceLocatorUtilities.addOneConstant(serviceLocator,
+                Injector.instantiateModelOrService(BibEntryTypesManager.class),
+                "entrytypesmanager", BibEntryTypesManager.class);
         ServiceLocatorUtilities.addFactoryConstants(serviceLocator, new GsonFactory());
 
         // see https://stackoverflow.com/a/33794265/873282

--- a/jabsrv/src/main/java/org/jabref/http/server/Server.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/Server.java
@@ -35,7 +35,6 @@ import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntryTypesManager;
 
-import com.airhacks.afterburner.injection.Injector;
 import net.harawata.appdirs.AppDirsFactory;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.ssl.SSLContextConfigurator;
@@ -120,7 +119,7 @@ public class Server {
         ServiceLocatorUtilities.addOneConstant(serviceLocator, new CitationCacheService());
         ServiceLocatorUtilities.addOneConstant(serviceLocator, new FormatterService());
         ServiceLocatorUtilities.addOneConstant(serviceLocator,
-                Injector.instantiateModelOrService(BibEntryTypesManager.class),
+                preferences.getCustomEntryTypesRepository(),
                 "entrytypesmanager", BibEntryTypesManager.class);
         ServiceLocatorUtilities.addFactoryConstants(serviceLocator, new GsonFactory());
 

--- a/jabsrv/src/main/java/org/jabref/http/server/Server.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/Server.java
@@ -118,9 +118,8 @@ public class Server {
         ServiceLocatorUtilities.addOneConstant(serviceLocator, preferences, "preferences", CliPreferences.class);
         ServiceLocatorUtilities.addOneConstant(serviceLocator, new CitationCacheService());
         ServiceLocatorUtilities.addOneConstant(serviceLocator, new FormatterService());
-        ServiceLocatorUtilities.addOneConstant(serviceLocator,
-                preferences.getCustomEntryTypesRepository(),
-                "entrytypesmanager", BibEntryTypesManager.class);
+        ServiceLocatorUtilities.addOneConstant(
+                serviceLocator, preferences.getCustomEntryTypesRepository(), "entrytypesmanager", BibEntryTypesManager.class);
         ServiceLocatorUtilities.addFactoryConstants(serviceLocator, new GsonFactory());
 
         // see https://stackoverflow.com/a/33794265/873282

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.jabref.http.SrvStateManager;
+import org.jabref.http.dto.UncheckedFetcherException;
 import org.jabref.http.server.services.CitationCacheService;
 import org.jabref.http.server.services.ServerUtils;
 import org.jabref.logic.UiCommand;
@@ -126,7 +127,7 @@ public class CitationsResource {
     @Path("lookup")
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.APPLICATION_JSON)
-    public LookupResponse lookup(@PathParam("id") String id, String citationText) throws FetcherException {
+    public LookupResponse lookup(@PathParam("id") String id, String citationText) {
         if (StringUtil.isBlank(citationText)) {
             throw new BadRequestException("Citation text must not be empty.");
         }
@@ -161,7 +162,7 @@ public class CitationsResource {
     @Path("lookup:batch")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public BatchLookupResponse lookupBatch(@PathParam("id") String id, BatchLookupRequest request) throws FetcherException {
+    public BatchLookupResponse lookupBatch(@PathParam("id") String id, BatchLookupRequest request) {
         if (request == null || request.citations() == null || request.citations().isEmpty()) {
             throw new BadRequestException("Citations list must not be empty.");
         }
@@ -179,7 +180,7 @@ public class CitationsResource {
             }
             try {
                 results.add(doLookup(citationText, targetContext, openDatabases, duplicateCheck));
-            } catch (FetcherException e) {
+            } catch (UncheckedFetcherException e) {
                 // One citation failing to parse shouldn't fail the batch.
                 // Surface as an empty response so the client paints "no match"
                 // (= gray ring) for that slot; the others still resolve.
@@ -196,18 +197,10 @@ public class CitationsResource {
     private LookupResponse doLookup(String citationText,
                                     BibDatabaseContext targetContext,
                                     List<BibDatabaseContext> openDatabases,
-                                    DuplicateCheck duplicateCheck) throws FetcherException {
-        // Text cache first: lets a re-scan of the same PDF page (or two
-        // distinct PDFs that cite the same paper) reuse the prior parse and
-        // skip the LLM call entirely.
+                                    DuplicateCheck duplicateCheck) {
         BibEntry parsed = citationCacheService.getByText(citationText)
                                               .map(CitationCacheService.CachedCitation::parsed)
-                                              .orElse(null);
-        if (parsed == null) {
-            parsed = ServerUtils.parsePlainCitation(preferences, citationText)
-                                 .orElseThrow(() -> new BadRequestException("Could not parse a bibliography entry from the given text."));
-            citationCacheService.putByText(parsed, citationText);
-        }
+                                              .orElseGet(() -> parseAndCache(citationText));
 
         // Cross-library lookup: walk every open library so we can tell the
         // client whether the citation is in the *target* library (Ctrl+J
@@ -229,6 +222,24 @@ public class CitationsResource {
 
         String cacheKey = citationCacheService.put(parsed, citationText);
         return new LookupResponse(matches, matchScope, cacheKey, parsed.getType().getName());
+    }
+
+    /// Cache miss → invoke the configured plain-citation parser and stash the
+    /// result by text-hash. `FetcherException` is wrapped in
+    /// [UncheckedFetcherException] so this method fits an `Optional.orElseGet`
+    /// supplier; `lookupBatch` unwraps it per-citation to surface "no match"
+    /// for the failing slot, and `GlobalExceptionMapper` translates uncaught
+    /// occurrences back to the original fetch failure response.
+    private BibEntry parseAndCache(String citationText) {
+        BibEntry parsed;
+        try {
+            parsed = ServerUtils.parsePlainCitation(preferences, citationText)
+                                .orElseThrow(() -> new BadRequestException("Could not parse a bibliography entry from the given text."));
+        } catch (FetcherException e) {
+            throw new UncheckedFetcherException(e);
+        }
+        citationCacheService.putByText(parsed, citationText);
+        return parsed;
     }
 
     /// Stable-ish library identifier for response bodies. Saved libraries use

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -157,10 +157,6 @@ public class CitationsResource {
             throw new BadRequestException("Citations list must not be empty.");
         }
         BibDatabaseContext targetContext = resolveTargetContext(id);
-        // Resolve once and reuse across every citation in the batch: the
-        // open-database list and DuplicateCheck are independent of the
-        // individual citation text, so re-creating per iteration would burn
-        // CPU for no benefit.
         List<BibDatabaseContext> openDatabases = srvStateManager.getOpenDatabases();
         DuplicateCheck duplicateCheck = new DuplicateCheck(new BibEntryTypesManager());
 

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -98,18 +98,94 @@ public class CitationsResource {
         // The target library is the one Ctrl+J would add to: "current" -> active
         // library, any other id -> that open library (404 if unknown/closed).
         BibDatabaseContext targetContext = resolveTargetContext(id);
+        return doLookup(citationText, targetContext,
+                        srvStateManager.getOpenDatabases(),
+                        new DuplicateCheck(new BibEntryTypesManager()));
+    }
 
-        BibEntry parsed = ServerUtils.parsePlainCitation(preferences, citationText)
-                                     .orElseThrow(() -> new BadRequestException("Could not parse a bibliography entry from the given text."));
+    /// Wrapper for the batched lookup payload. Plain `List<String>` would work
+    /// too, but a named record makes the JSON self-describing and leaves room
+    /// to add per-request options (e.g. include-snippets) without breaking the
+    /// schema.
+    public record BatchLookupRequest(List<String> citations) {
+    }
+
+    /// Aligned-by-index with the request: `results[i]` corresponds to
+    /// `citations[i]`. Blank input slots yield an empty `LookupResponse`
+    /// (matches=[], matchScope="none") rather than failing the whole batch.
+    public record BatchLookupResponse(List<LookupResponse> results) {
+    }
+
+    /// Batched variant of [#lookup] for the SumatraPDF page-scan flow: when
+    /// the reader lands on a new page we extract every citation link's
+    /// extracted bibliography text in one shot, fire one POST, and paint the
+    /// returned per-citation `matchScope` as in-PDF dots. Single round-trip
+    /// + JabRef-side [CitationCacheService#getByText] hits mean repeat
+    /// scans of the same page are O(1) per citation with no LLM cost.
+    @POST
+    @Path("lookup:batch")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public BatchLookupResponse lookupBatch(@PathParam("id") String id, BatchLookupRequest request) throws FetcherException {
+        if (request == null || request.citations() == null || request.citations().isEmpty()) {
+            throw new BadRequestException("Citations list must not be empty.");
+        }
+        BibDatabaseContext targetContext = resolveTargetContext(id);
+        // Resolve once and reuse across every citation in the batch: the
+        // open-database list and DuplicateCheck are independent of the
+        // individual citation text, so re-creating per iteration would burn
+        // CPU for no benefit.
+        List<BibDatabaseContext> openDatabases = srvStateManager.getOpenDatabases();
+        DuplicateCheck duplicateCheck = new DuplicateCheck(new BibEntryTypesManager());
+
+        List<LookupResponse> results = new ArrayList<>(request.citations().size());
+        for (String citationText : request.citations()) {
+            if (StringUtil.isBlank(citationText)) {
+                // Empty slot — return a "none" response so client indexing
+                // stays aligned. Skipping would shift downstream results.
+                results.add(new LookupResponse(List.of(), "none", null, null));
+                continue;
+            }
+            try {
+                results.add(doLookup(citationText, targetContext, openDatabases, duplicateCheck));
+            } catch (FetcherException e) {
+                // One citation failing to parse shouldn't fail the batch.
+                // Surface as an empty response so the client paints "no match"
+                // (= gray ring) for that slot; the others still resolve.
+                results.add(new LookupResponse(List.of(), "none", null, null));
+            }
+        }
+        return new BatchLookupResponse(results);
+    }
+
+    /// Shared body of single + batched lookup. Resolves the citation text to
+    /// a `BibEntry` (via the text-hash cache when possible, else the
+    /// LLM/fetcher), walks every open library for duplicates, mints a fresh
+    /// token for the add-from-cache flow, and assembles the response.
+    private LookupResponse doLookup(String citationText,
+                                    BibDatabaseContext targetContext,
+                                    List<BibDatabaseContext> openDatabases,
+                                    DuplicateCheck duplicateCheck) throws FetcherException {
+        // Text cache first: lets a re-scan of the same PDF page (or two
+        // distinct PDFs that cite the same paper) reuse the prior parse and
+        // skip the LLM call entirely.
+        Optional<CitationCacheService.CachedCitation> cachedByText = citationCacheService.getByText(citationText);
+        BibEntry parsed;
+        if (cachedByText.isPresent()) {
+            parsed = cachedByText.get().parsed();
+        } else {
+            parsed = ServerUtils.parsePlainCitation(preferences, citationText)
+                    .orElseThrow(() -> new BadRequestException("Could not parse a bibliography entry from the given text."));
+            citationCacheService.putByText(parsed, citationText);
+        }
 
         // Cross-library lookup: walk every open library so we can tell the
         // client whether the citation is in the *target* library (Ctrl+J
         // would create a duplicate → mint) vs an *other* open library (still
         // worth surfacing — the user may want to switch libraries or copy
         // across → olive, AnchorHub's related-match colour).
-        DuplicateCheck duplicateCheck = new DuplicateCheck(new BibEntryTypesManager());
         List<LookupMatch> matches = new ArrayList<>();
-        for (BibDatabaseContext ctx : srvStateManager.getOpenDatabases()) {
+        for (BibDatabaseContext ctx : openDatabases) {
             boolean isActive = ctx == targetContext;
             duplicateCheck.containsDuplicate(ctx.getDatabase(), parsed, ctx.getMode())
                           .ifPresent(existing -> matches.add(new LookupMatch(

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -23,6 +23,7 @@ import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryTypesManager;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ClientErrorException;
@@ -71,14 +72,39 @@ public class CitationsResource {
     public record LookupMatch(String libraryId, String entryId, boolean inActiveLibrary) {
     }
 
+    /// Categorisation of a [LookupResponse]'s `matches` list. Surfaced as a
+    /// dedicated field so clients can colour the hover badge without walking
+    /// the array themselves.
+    public enum MatchScope {
+        /// At least one match in the currently-active library — Ctrl+J would
+        /// create a duplicate. Mint badge.
+        ACTIVE("active"),
+        /// Match(es) only in *other* open libraries — Ctrl+J would still
+        /// create a new entry in the active library. Olive badge.
+        OTHER("other"),
+        /// No match in any open library. Gray badge.
+        NONE("none");
+
+        private final String jsonValue;
+
+        MatchScope(String jsonValue) {
+            this.jsonValue = jsonValue;
+        }
+
+        @JsonValue
+        public String jsonValue() {
+            return jsonValue;
+        }
+    }
+
     /// Result of a single plain-citation lookup.
     ///
     /// @param matches duplicate hits across every open library. Empty list when no library contains the parsed entry, or when the parse itself failed (batch-lookup blank-slot / parser-failure rows).
-    /// @param matchScope derived from `matches`, surfaced separately so clients can colour the hover badge without walking the array: `"active"` — at least one match in the currently-active library (the one Ctrl+J would add to → duplicate, mint badge); `"other"` — match(es) only in *other* open libraries (Ctrl+J would still create a new entry → related, olive badge); `"none"` — no match in any open library (gray badge).
+    /// @param matchScope categorisation of `matches` — see [MatchScope].
     /// @param parserCacheKey opaque token redeemable at `POST /libraries/{id}/citations/{parserCacheKey}` to append the already-parsed `BibEntry` without paying for the LLM parse again. Null when no entry was parsed.
     /// @param parsedEntryType BibTeX entry-type name of the parsed entry (e.g. `"article"`, `"inproceedings"`) — lets the client preview the type before redeeming the cache key. Null when no entry was parsed.
     @NullMarked
-    public record LookupResponse(List<LookupMatch> matches, String matchScope,
+    public record LookupResponse(List<LookupMatch> matches, MatchScope matchScope,
                                  @Nullable String parserCacheKey, @Nullable String parsedEntryType) {
     }
 
@@ -147,7 +173,7 @@ public class CitationsResource {
             if (StringUtil.isBlank(citationText)) {
                 // Empty slot — return a "none" response so client indexing
                 // stays aligned. Skipping would shift downstream results.
-                results.add(new LookupResponse(List.of(), "none", null, null));
+                results.add(new LookupResponse(List.of(), MatchScope.NONE, null, null));
                 continue;
             }
             try {
@@ -156,7 +182,7 @@ public class CitationsResource {
                 // One citation failing to parse shouldn't fail the batch.
                 // Surface as an empty response so the client paints "no match"
                 // (= gray ring) for that slot; the others still resolve.
-                results.add(new LookupResponse(List.of(), "none", null, null));
+                results.add(new LookupResponse(List.of(), MatchScope.NONE, null, null));
             }
         }
         return new BatchLookupResponse(results);
@@ -196,9 +222,9 @@ public class CitationsResource {
                                   existing.getCitationKey().orElse(""),
                                   isActive)));
         }
-        String matchScope = matches.stream()
-                                   .anyMatch(LookupMatch::inActiveLibrary) ? "active"
-                                                                           : matches.isEmpty() ? "none" : "other";
+        MatchScope matchScope = matches.stream()
+                                       .anyMatch(LookupMatch::inActiveLibrary) ? MatchScope.ACTIVE
+                                                                               : matches.isEmpty() ? MatchScope.NONE : MatchScope.OTHER;
 
         String cacheKey = citationCacheService.put(parsed, citationText);
         return new LookupResponse(matches, matchScope, cacheKey, parsed.getType().getName());

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -35,6 +35,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /// Cached plain-citation lookup + later add.
@@ -66,6 +67,7 @@ public class CitationsResource {
     @Inject
     CitationCacheService citationCacheService;
 
+    @NullMarked
     public record LookupMatch(String libraryId, String entryId, boolean inActiveLibrary) {
     }
 
@@ -77,10 +79,15 @@ public class CitationsResource {
     ///   "none"   — no match in any open library.
     /// Clients use this to colour the hover badge without having to walk the
     /// matches array themselves (mint vs olive vs grey).
+    ///
+    /// `parserCacheKey` and `parsedEntryType` are null when no entry was
+    /// parsed (blank-slot or parser-failure paths in batch lookup).
+    @NullMarked
     public record LookupResponse(List<LookupMatch> matches, String matchScope,
-                                 String parserCacheKey, String parsedEntryType) {
+                                 @Nullable String parserCacheKey, @Nullable String parsedEntryType) {
     }
 
+    @NullMarked
     public record AlreadyExistsResponse(String status, String entryId) {
         public AlreadyExistsResponse(String entryId) {
             this("already-exists", entryId);
@@ -107,12 +114,14 @@ public class CitationsResource {
     /// too, but a named record makes the JSON self-describing and leaves room
     /// to add per-request options (e.g. include-snippets) without breaking the
     /// schema.
+    @NullMarked
     public record BatchLookupRequest(List<String> citations) {
     }
 
     /// Aligned-by-index with the request: `results[i]` corresponds to
     /// `citations[i]`. Blank input slots yield an empty `LookupResponse`
     /// (matches=[], matchScope="none") rather than failing the whole batch.
+    @NullMarked
     public record BatchLookupResponse(List<LookupResponse> results) {
     }
 
@@ -169,13 +178,12 @@ public class CitationsResource {
         // Text cache first: lets a re-scan of the same PDF page (or two
         // distinct PDFs that cite the same paper) reuse the prior parse and
         // skip the LLM call entirely.
-        Optional<CitationCacheService.CachedCitation> cachedByText = citationCacheService.getByText(citationText);
-        BibEntry parsed;
-        if (cachedByText.isPresent()) {
-            parsed = cachedByText.get().parsed();
-        } else {
+        BibEntry parsed = citationCacheService.getByText(citationText)
+                                              .map(CitationCacheService.CachedCitation::parsed)
+                                              .orElse(null);
+        if (parsed == null) {
             parsed = ServerUtils.parsePlainCitation(preferences, citationText)
-                    .orElseThrow(() -> new BadRequestException("Could not parse a bibliography entry from the given text."));
+                                 .orElseThrow(() -> new BadRequestException("Could not parse a bibliography entry from the given text."));
             citationCacheService.putByText(parsed, citationText);
         }
 

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -23,6 +23,7 @@ import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryTypesManager;
 
+import com.airhacks.afterburner.injection.Injector;
 import com.fasterxml.jackson.annotation.JsonValue;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
@@ -126,7 +127,7 @@ public class CitationsResource {
         BibDatabaseContext targetContext = resolveTargetContext(id);
         return doLookup(citationText, targetContext,
                         srvStateManager.getOpenDatabases(),
-                        new DuplicateCheck(new BibEntryTypesManager()));
+                        new DuplicateCheck(Injector.instantiateModelOrService(BibEntryTypesManager.class)));
     }
 
     /// Wrapper for the batched lookup payload. Plain `List<String>` would work
@@ -158,7 +159,7 @@ public class CitationsResource {
         }
         BibDatabaseContext targetContext = resolveTargetContext(id);
         List<BibDatabaseContext> openDatabases = srvStateManager.getOpenDatabases();
-        DuplicateCheck duplicateCheck = new DuplicateCheck(new BibEntryTypesManager());
+        DuplicateCheck duplicateCheck = new DuplicateCheck(Injector.instantiateModelOrService(BibEntryTypesManager.class));
 
         List<LookupResponse> results = new ArrayList<>(request.citations().size());
         for (String citationText : request.citations()) {
@@ -261,7 +262,7 @@ public class CitationsResource {
         // of 201 so the client can show a "Citation is already in library"
         // notification without treating it as a hard error.
         BibDatabaseMode mode = context.getMode();
-        DuplicateCheck duplicateCheck = new DuplicateCheck(new BibEntryTypesManager());
+        DuplicateCheck duplicateCheck = new DuplicateCheck(Injector.instantiateModelOrService(BibEntryTypesManager.class));
         return duplicateCheck.containsDuplicate(context.getDatabase(), parsed, mode)
                              .map(existingEntry -> alreadyExistsResponse(parserCacheKey, existingEntry))
                              .orElseGet(() -> appendParsedAndRespond(parsed, targetLibrary, group, parserCacheKey));
@@ -288,7 +289,7 @@ public class CitationsResource {
         BibWriter bibWriter = new BibWriter(rawEntry, "\n");
         BibEntryWriter entryWriter = new BibEntryWriter(
                 new FieldWriter(preferences.getFieldPreferences()),
-                new BibEntryTypesManager());
+                Injector.instantiateModelOrService(BibEntryTypesManager.class));
         try {
             entryWriter.write(parsed, bibWriter, BibDatabaseMode.BIBTEX);
         } catch (IOException e) {

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -108,6 +108,12 @@ public class CitationsResource {
     /// @param parsedEntryType BibTeX entry-type name of the parsed entry (e.g. `"article"`, `"inproceedings"`) — lets the client preview the type before redeeming the cache key. Null when no entry was parsed.
     public record LookupResponse(List<LookupMatch> matches, MatchScope matchScope,
                                  @Nullable String parserCacheKey, @Nullable String parsedEntryType) {
+
+        /// Convenience constructor for blank-slot and parser-failure rows in
+        /// batch lookup — no entry was parsed, so neither key nor type apply.
+        public LookupResponse(List<LookupMatch> matches, MatchScope matchScope) {
+            this(matches, matchScope, null, null);
+        }
     }
 
     public record AlreadyExistsResponse(String status, String entryId) {
@@ -168,7 +174,7 @@ public class CitationsResource {
             if (StringUtil.isBlank(citationText)) {
                 // Empty slot — return a "none" response so client indexing
                 // stays aligned. Skipping would shift downstream results.
-                results.add(new LookupResponse(List.of(), MatchScope.NONE, null, null));
+                results.add(new LookupResponse(List.of(), MatchScope.NONE));
                 continue;
             }
             try {
@@ -177,7 +183,7 @@ public class CitationsResource {
                 // One citation failing to parse shouldn't fail the batch.
                 // Surface as an empty response so the client paints "no match"
                 // (= gray ring) for that slot; the others still resolve.
-                results.add(new LookupResponse(List.of(), MatchScope.NONE, null, null));
+                results.add(new LookupResponse(List.of(), MatchScope.NONE));
             }
         }
         return new BatchLookupResponse(results);

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -96,9 +96,9 @@ public class CitationsResource {
 
     /// Result of a single plain-citation lookup.
     ///
-    /// @param matches duplicate hits across every open library. Empty list when no library contains the parsed entry, or when the parse itself failed (batch-lookup blank-slot / parser-failure rows).
-    /// @param matchScope categorisation of `matches` — see [MatchScope].
-    /// @param parserCacheKey opaque token redeemable at `POST /libraries/{id}/citations/{parserCacheKey}` to append the already-parsed `BibEntry` without paying for the LLM parse again. Null when no entry was parsed.
+    /// @param matches         duplicate hits across every open library. Empty list when no library contains the parsed entry, or when the parse itself failed (batch-lookup blank-slot / parser-failure rows).
+    /// @param matchScope      categorisation of `matches` — see [MatchScope].
+    /// @param parserCacheKey  opaque token redeemable at `POST /libraries/{id}/citations/{parserCacheKey}` to append the already-parsed `BibEntry` without paying for the LLM parse again. Null when no entry was parsed.
     /// @param parsedEntryType BibTeX entry-type name of the parsed entry (e.g. `"article"`, `"inproceedings"`) — lets the client preview the type before redeeming the cache key. Null when no entry was parsed.
     public record LookupResponse(List<LookupMatch> matches, MatchScope matchScope,
                                  @Nullable String parserCacheKey, @Nullable String parsedEntryType) {
@@ -127,9 +127,11 @@ public class CitationsResource {
         // The target library is the one Ctrl+J would add to: "current" -> active
         // library, any other id -> that open library (404 if unknown/closed).
         BibDatabaseContext targetContext = resolveTargetContext(id);
-        return doLookup(citationText, targetContext,
-                        srvStateManager.getOpenDatabases(),
-                        new DuplicateCheck(entryTypesManager));
+        return doLookup(
+                citationText,
+                targetContext,
+                srvStateManager.getOpenDatabases(),
+                new DuplicateCheck(entryTypesManager));
     }
 
     /// Wrapper for the batched lookup payload. Plain `List<String>` would work

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -23,7 +23,6 @@ import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryTypesManager;
 
-import com.airhacks.afterburner.injection.Injector;
 import com.fasterxml.jackson.annotation.JsonValue;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
@@ -69,6 +68,9 @@ public class CitationsResource {
 
     @Inject
     CitationCacheService citationCacheService;
+
+    @Inject
+    BibEntryTypesManager entryTypesManager;
 
     public record LookupMatch(String libraryId, String entryId, boolean inActiveLibrary) {
     }
@@ -127,7 +129,7 @@ public class CitationsResource {
         BibDatabaseContext targetContext = resolveTargetContext(id);
         return doLookup(citationText, targetContext,
                         srvStateManager.getOpenDatabases(),
-                        new DuplicateCheck(Injector.instantiateModelOrService(BibEntryTypesManager.class)));
+                        new DuplicateCheck(entryTypesManager));
     }
 
     /// Wrapper for the batched lookup payload. Plain `List<String>` would work
@@ -159,7 +161,7 @@ public class CitationsResource {
         }
         BibDatabaseContext targetContext = resolveTargetContext(id);
         List<BibDatabaseContext> openDatabases = srvStateManager.getOpenDatabases();
-        DuplicateCheck duplicateCheck = new DuplicateCheck(Injector.instantiateModelOrService(BibEntryTypesManager.class));
+        DuplicateCheck duplicateCheck = new DuplicateCheck(entryTypesManager);
 
         List<LookupResponse> results = new ArrayList<>(request.citations().size());
         for (String citationText : request.citations()) {
@@ -262,7 +264,7 @@ public class CitationsResource {
         // of 201 so the client can show a "Citation is already in library"
         // notification without treating it as a hard error.
         BibDatabaseMode mode = context.getMode();
-        DuplicateCheck duplicateCheck = new DuplicateCheck(Injector.instantiateModelOrService(BibEntryTypesManager.class));
+        DuplicateCheck duplicateCheck = new DuplicateCheck(entryTypesManager);
         return duplicateCheck.containsDuplicate(context.getDatabase(), parsed, mode)
                              .map(existingEntry -> alreadyExistsResponse(parserCacheKey, existingEntry))
                              .orElseGet(() -> appendParsedAndRespond(parsed, targetLibrary, group, parserCacheKey));
@@ -289,7 +291,7 @@ public class CitationsResource {
         BibWriter bibWriter = new BibWriter(rawEntry, "\n");
         BibEntryWriter entryWriter = new BibEntryWriter(
                 new FieldWriter(preferences.getFieldPreferences()),
-                Injector.instantiateModelOrService(BibEntryTypesManager.class));
+                entryTypesManager);
         try {
             entryWriter.write(parsed, bibWriter, BibDatabaseMode.BIBTEX);
         } catch (IOException e) {

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -24,7 +24,7 @@ import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryTypesManager;
 
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.gson.annotations.SerializedName;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ClientErrorException;
@@ -79,26 +79,19 @@ public class CitationsResource {
     /// Categorisation of a [LookupResponse]'s `matches` list. Surfaced as a
     /// dedicated field so clients can colour the hover badge without walking
     /// the array themselves.
+    ///
+    /// `@SerializedName` pins the wire format because Gson (this module's
+    /// JSON writer, see `GsonMessageBodyWriter`) otherwise emits the upper-
+    /// case enum constant name. Jackson's `@JsonValue` would be ignored here.
     public enum MatchScope {
         /// At least one match in the currently-active library — Ctrl+J would
         /// create a duplicate. Mint badge.
-        ACTIVE("active"),
+        @SerializedName("active") ACTIVE,
         /// Match(es) only in *other* open libraries — Ctrl+J would still
         /// create a new entry in the active library. Olive badge.
-        OTHER("other"),
+        @SerializedName("other") OTHER,
         /// No match in any open library. Gray badge.
-        NONE("none");
-
-        private final String jsonValue;
-
-        MatchScope(String jsonValue) {
-            this.jsonValue = jsonValue;
-        }
-
-        @JsonValue
-        public String jsonValue() {
-            return jsonValue;
-        }
+        @SerializedName("none") NONE
     }
 
     /// Result of a single plain-citation lookup.

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -230,6 +230,9 @@ public class CitationsResource {
     /// supplier; `lookupBatch` unwraps it per-citation to surface "no match"
     /// for the failing slot, and `GlobalExceptionMapper` translates uncaught
     /// occurrences back to the original fetch failure response.
+    ///
+    /// @throws BadRequestException if the parser returns an empty result (the citation text could not be parsed into a BibEntry).
+    /// @throws UncheckedFetcherException if the parser itself failed (network, LLM, or backend error). The cause is the original `FetcherException`.
     private BibEntry parseAndCache(String citationText) {
         BibEntry parsed;
         try {

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -227,7 +227,7 @@ public class CitationsResource {
     /// for the failing slot, and `GlobalExceptionMapper` translates uncaught
     /// occurrences back to the original fetch failure response.
     ///
-    /// @throws BadRequestException if the parser returns an empty result (the citation text could not be parsed into a BibEntry).
+    /// @throws BadRequestException       if the parser returns an empty result (the citation text could not be parsed into a BibEntry).
     /// @throws UncheckedFetcherException if the parser itself failed (network, LLM, or backend error). The cause is the original `FetcherException`.
     private BibEntry parseAndCache(String citationText) {
         BibEntry parsed;

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -54,6 +54,7 @@ import org.jspecify.annotations.Nullable;
 ///    token. Returns 410 Gone when the token expired so the client can fall
 ///    back to `POST /libraries/current/entries` and pay for the parse again.
 @Path("libraries/{id}/citations")
+@NullMarked
 public class CitationsResource {
 
     @Inject
@@ -68,7 +69,6 @@ public class CitationsResource {
     @Inject
     CitationCacheService citationCacheService;
 
-    @NullMarked
     public record LookupMatch(String libraryId, String entryId, boolean inActiveLibrary) {
     }
 
@@ -103,12 +103,10 @@ public class CitationsResource {
     /// @param matchScope categorisation of `matches` — see [MatchScope].
     /// @param parserCacheKey opaque token redeemable at `POST /libraries/{id}/citations/{parserCacheKey}` to append the already-parsed `BibEntry` without paying for the LLM parse again. Null when no entry was parsed.
     /// @param parsedEntryType BibTeX entry-type name of the parsed entry (e.g. `"article"`, `"inproceedings"`) — lets the client preview the type before redeeming the cache key. Null when no entry was parsed.
-    @NullMarked
     public record LookupResponse(List<LookupMatch> matches, MatchScope matchScope,
                                  @Nullable String parserCacheKey, @Nullable String parsedEntryType) {
     }
 
-    @NullMarked
     public record AlreadyExistsResponse(String status, String entryId) {
         public AlreadyExistsResponse(String entryId) {
             this("already-exists", entryId);
@@ -135,14 +133,12 @@ public class CitationsResource {
     /// too, but a named record makes the JSON self-describing and leaves room
     /// to add per-request options (e.g. include-snippets) without breaking the
     /// schema.
-    @NullMarked
     public record BatchLookupRequest(List<String> citations) {
     }
 
     /// Aligned-by-index with the request: `results[i]` corresponds to
     /// `citations[i]`. Blank input slots yield an empty `LookupResponse`
     /// (matches=[], matchScope="none") rather than failing the whole batch.
-    @NullMarked
     public record BatchLookupResponse(List<LookupResponse> results) {
     }
 

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -73,30 +73,10 @@ public class CitationsResource {
 
     /// Result of a single plain-citation lookup.
     ///
-    /// @param matches          duplicate hits across every open library.
-    ///                         Empty list when no library contains the parsed
-    ///                         entry, or when the parse itself failed
-    ///                         (batch-lookup blank-slot / parser-failure rows).
-    /// @param matchScope       derived from `matches`, surfaced separately so
-    ///                         clients can colour the hover badge without
-    ///                         walking the array:
-    ///                         `"active"` — at least one match in the
-    ///                         currently-active library (the one Ctrl+J would
-    ///                         add to → duplicate, mint badge);
-    ///                         `"other"` — match(es) only in *other* open
-    ///                         libraries (Ctrl+J would still create a new
-    ///                         entry → related, olive badge);
-    ///                         `"none"` — no match in any open library
-    ///                         (gray badge).
-    /// @param parserCacheKey   opaque token redeemable at
-    ///                         `POST /libraries/{id}/citations/{parserCacheKey}`
-    ///                         to append the already-parsed `BibEntry` without
-    ///                         paying for the LLM parse again. Null when no
-    ///                         entry was parsed.
-    /// @param parsedEntryType  BibTeX entry-type name of the parsed entry
-    ///                         (e.g. `"article"`, `"inproceedings"`) — lets
-    ///                         the client preview the type before redeeming
-    ///                         the cache key. Null when no entry was parsed.
+    /// @param matches duplicate hits across every open library. Empty list when no library contains the parsed entry, or when the parse itself failed (batch-lookup blank-slot / parser-failure rows).
+    /// @param matchScope derived from `matches`, surfaced separately so clients can colour the hover badge without walking the array: `"active"` — at least one match in the currently-active library (the one Ctrl+J would add to → duplicate, mint badge); `"other"` — match(es) only in *other* open libraries (Ctrl+J would still create a new entry → related, olive badge); `"none"` — no match in any open library (gray badge).
+    /// @param parserCacheKey opaque token redeemable at `POST /libraries/{id}/citations/{parserCacheKey}` to append the already-parsed `BibEntry` without paying for the LLM parse again. Null when no entry was parsed.
+    /// @param parsedEntryType BibTeX entry-type name of the parsed entry (e.g. `"article"`, `"inproceedings"`) — lets the client preview the type before redeeming the cache key. Null when no entry was parsed.
     @NullMarked
     public record LookupResponse(List<LookupMatch> matches, String matchScope,
                                  @Nullable String parserCacheKey, @Nullable String parsedEntryType) {

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -71,17 +71,32 @@ public class CitationsResource {
     public record LookupMatch(String libraryId, String entryId, boolean inActiveLibrary) {
     }
 
-    /// matchScope is derived from `matches`:
-    ///   "active" — at least one match is in the currently-active library
-    ///              (the library Ctrl+J would add to — so duplicate);
-    ///   "other"  — match(es) exist only in *other* open libraries
-    ///              (related, but Ctrl+J would still add to the active one);
-    ///   "none"   — no match in any open library.
-    /// Clients use this to colour the hover badge without having to walk the
-    /// matches array themselves (mint vs olive vs grey).
+    /// Result of a single plain-citation lookup.
     ///
-    /// `parserCacheKey` and `parsedEntryType` are null when no entry was
-    /// parsed (blank-slot or parser-failure paths in batch lookup).
+    /// @param matches          duplicate hits across every open library.
+    ///                         Empty list when no library contains the parsed
+    ///                         entry, or when the parse itself failed
+    ///                         (batch-lookup blank-slot / parser-failure rows).
+    /// @param matchScope       derived from `matches`, surfaced separately so
+    ///                         clients can colour the hover badge without
+    ///                         walking the array:
+    ///                         `"active"` — at least one match in the
+    ///                         currently-active library (the one Ctrl+J would
+    ///                         add to → duplicate, mint badge);
+    ///                         `"other"` — match(es) only in *other* open
+    ///                         libraries (Ctrl+J would still create a new
+    ///                         entry → related, olive badge);
+    ///                         `"none"` — no match in any open library
+    ///                         (gray badge).
+    /// @param parserCacheKey   opaque token redeemable at
+    ///                         `POST /libraries/{id}/citations/{parserCacheKey}`
+    ///                         to append the already-parsed `BibEntry` without
+    ///                         paying for the LLM parse again. Null when no
+    ///                         entry was parsed.
+    /// @param parsedEntryType  BibTeX entry-type name of the parsed entry
+    ///                         (e.g. `"article"`, `"inproceedings"`) — lets
+    ///                         the client preview the type before redeeming
+    ///                         the cache key. Null when no entry was parsed.
     @NullMarked
     public record LookupResponse(List<LookupMatch> matches, String matchScope,
                                  @Nullable String parserCacheKey, @Nullable String parsedEntryType) {

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/CitationsResource.java
@@ -173,10 +173,11 @@ public class CitationsResource {
             }
             try {
                 results.add(doLookup(citationText, targetContext, openDatabases, duplicateCheck));
-            } catch (UncheckedFetcherException e) {
-                // One citation failing to parse shouldn't fail the batch.
-                // Surface as an empty response so the client paints "no match"
-                // (= gray ring) for that slot; the others still resolve.
+            } catch (UncheckedFetcherException | BadRequestException e) {
+                // One citation failing — fetcher error (UncheckedFetcherException) or
+                // parser-returned-empty (BadRequestException) — must not fail the batch.
+                // Surface as a "no match" slot so the client paints a gray ring there;
+                // the rest of the batch still resolves.
                 results.add(new LookupResponse(List.of(), MatchScope.NONE));
             }
         }

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/EntriesResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/EntriesResource.java
@@ -61,6 +61,9 @@ public class EntriesResource {
     @Inject
     UiMessageHandler uiMessageHandler;
 
+    @Inject
+    BibEntryTypesManager entryTypesManager;
+
     /// Appends BibTeX entries to the currently selected library.
     ///
     /// [impl->req~jabsrv.import.group~1]
@@ -107,7 +110,7 @@ public class EntriesResource {
         BibWriter bibWriter = new BibWriter(rawEntry, "\n");
         BibEntryWriter entryWriter = new BibEntryWriter(
                 new FieldWriter(preferences.getFieldPreferences()),
-                new BibEntryTypesManager());
+                entryTypesManager);
         entryWriter.write(parsed, bibWriter, BibDatabaseMode.BIBTEX);
 
         uiMessageHandler.handleUiCommands(List.of(targetLibrary

--- a/jabsrv/src/main/java/org/jabref/http/server/resources/LibraryResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/resources/LibraryResource.java
@@ -16,7 +16,6 @@ import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntryTypesManager;
 
-import com.airhacks.afterburner.injection.Injector;
 import com.google.gson.Gson;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -44,6 +43,9 @@ public class LibraryResource {
     @Inject
     Gson gson;
 
+    @Inject
+    BibEntryTypesManager entryTypesManager;
+
     /// At http://localhost:23119/libraries/{id}
     ///
     /// @param id The specified library
@@ -53,7 +55,6 @@ public class LibraryResource {
     @Produces(MediaType.APPLICATION_JSON)
     public String getJson(@PathParam("id") String id) throws IOException {
         BibDatabaseContext databaseContext = getDatabaseContext(id);
-        BibEntryTypesManager entryTypesManager = Injector.instantiateModelOrService(BibEntryTypesManager.class);
         List<BibEntryDTO> list = databaseContext.getDatabase().getEntries().stream()
                                                 .peek(bibEntry -> bibEntry.getSharedBibEntryData().setSharedID(Objects.hash(bibEntry)))
                                                 .map(entry -> new BibEntryDTO(entry, databaseContext.getMode(), preferences.getFieldPreferences(), entryTypesManager))
@@ -66,7 +67,7 @@ public class LibraryResource {
     public String getClsItemJson(@PathParam("id") String id) throws IOException {
         BibDatabaseContext databaseContext = getDatabaseContext(id);
         JabRefItemDataProvider jabRefItemDataProvider = new JabRefItemDataProvider();
-        jabRefItemDataProvider.setData(databaseContext, new BibEntryTypesManager());
+        jabRefItemDataProvider.setData(databaseContext, entryTypesManager);
         return jabRefItemDataProvider.toJson();
     }
 

--- a/jabsrv/src/main/java/org/jabref/http/server/services/CitationCacheService.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/services/CitationCacheService.java
@@ -13,17 +13,26 @@ import jakarta.inject.Singleton;
 
 /// Caches the result of a plain-citation → BibEntry conversion so a hover
 /// existence check and a subsequent add-to-library don't both pay the LLM /
-/// fetcher cost. Cache keys are server-issued CUID2 strings returned from the
-/// lookup endpoint; the matching add endpoint consumes the key.
+/// fetcher cost.
 ///
-/// Bounded to keep memory tight (256 entries, ~5 KB each ≈ 1.25 MB worst case)
-/// and time-bounded to 1 hour so a stale token left over from a previous
-/// session can't resurrect an unrelated citation.
+/// Two complementary maps:
+///
+/// 1. **Token cache** — keyed by a server-issued CUID2 returned from the
+///    lookup endpoint. The matching add endpoint consumes the key. Short TTL
+///    so a stale token can't resurrect an unrelated citation across sessions.
+/// 2. **Text cache** — keyed by the raw citation text itself. Lets a repeat
+///    `/lookup` (or batched `/lookup:batch`) skip the LLM / fetcher parse
+///    entirely when the same citation string has been parsed recently (e.g.
+///    SumatraPDF re-scans a visible PDF page after the user jumps back to it).
+///    Longer TTL than the token cache because the parsed BibEntry stays valid
+///    as long as the citation text does.
 @Singleton
 public class CitationCacheService {
 
-    private static final int MAX_ENTRIES = 256;
-    private static final Duration TTL = Duration.ofHours(1);
+    private static final int TOKEN_MAX_ENTRIES = 256;
+    private static final Duration TOKEN_TTL = Duration.ofHours(1);
+    private static final int TEXT_MAX_ENTRIES = 1024;
+    private static final Duration TEXT_TTL = Duration.ofHours(24);
     /// Token length picked to match the CUID2 size already used by
     /// [BibFieldsIndexer]: long enough to be collision-resistant in a 256-slot
     /// cache without being noisy in HTTP responses.
@@ -32,16 +41,21 @@ public class CitationCacheService {
     public record CachedCitation(BibEntry parsed, String rawCitation, Instant createdAt) {
     }
 
-    private final Cache<String, CachedCitation> cache = Caffeine.newBuilder()
-                                                                .maximumSize(MAX_ENTRIES)
-                                                                .expireAfterWrite(TTL)
-                                                                .build();
+    private final Cache<String, CachedCitation> tokenCache = Caffeine.newBuilder()
+                                                                     .maximumSize(TOKEN_MAX_ENTRIES)
+                                                                     .expireAfterWrite(TOKEN_TTL)
+                                                                     .build();
+
+    private final Cache<String, CachedCitation> textCache = Caffeine.newBuilder()
+                                                                    .maximumSize(TEXT_MAX_ENTRIES)
+                                                                    .expireAfterWrite(TEXT_TTL)
+                                                                    .build();
 
     /// Stores a parsed citation and returns the token the client should send
     /// back to the add endpoint.
     public String put(BibEntry parsed, String rawCitation) {
         String key = CUID.randomCUID2(CUID_LENGTH).toString();
-        cache.put(key, new CachedCitation(parsed, rawCitation, Instant.now()));
+        tokenCache.put(key, new CachedCitation(parsed, rawCitation, Instant.now()));
         return key;
     }
 
@@ -49,12 +63,24 @@ public class CitationCacheService {
     /// was never issued. Does **not** evict on read so the same lookup result
     /// can be added more than once (idempotent across retries).
     public Optional<CachedCitation> get(String key) {
-        return Optional.ofNullable(cache.getIfPresent(key));
+        return Optional.ofNullable(tokenCache.getIfPresent(key));
     }
 
     /// Drops the cache entry; called by the add endpoint after a successful
     /// import so a stale token can't be re-used to add a duplicate.
     public void invalidate(String key) {
-        cache.invalidate(key);
+        tokenCache.invalidate(key);
+    }
+
+    /// Stashes a parsed citation under its raw text so a later `/lookup` for
+    /// the same text can skip the LLM parse. The token-keyed cache is left
+    /// untouched — callers mint a fresh token via [#put] for each lookup.
+    public void putByText(BibEntry parsed, String rawCitation) {
+        textCache.put(rawCitation, new CachedCitation(parsed, rawCitation, Instant.now()));
+    }
+
+    /// Returns the cached parse for the given citation text, or empty on miss.
+    public Optional<CachedCitation> getByText(String citationText) {
+        return Optional.ofNullable(textCache.getIfPresent(citationText));
     }
 }

--- a/jabsrv/src/main/java/org/jabref/http/server/services/CitationCacheService.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/services/CitationCacheService.java
@@ -32,7 +32,7 @@ public class CitationCacheService {
     private static final int TOKEN_MAX_ENTRIES = 256;
     private static final Duration TOKEN_TTL = Duration.ofHours(1);
     private static final int TEXT_MAX_ENTRIES = 1024;
-    private static final Duration TEXT_TTL = Duration.ofHours(24);
+    private static final Duration TEXT_TTL = Duration.ofDays(1);
     /// Token length picked to match the CUID2 size already used by
     /// [BibFieldsIndexer]: long enough to be collision-resistant in a 256-slot
     /// cache without being noisy in HTTP responses.

--- a/jabsrv/src/test/import.http
+++ b/jabsrv/src/test/import.http
@@ -138,6 +138,22 @@ Smith, J. (2020). On the nature of chocolate. Journal of Sweets, 12(3), 45-67.
 
 POST http://localhost:23119/libraries/current/citations/{{cacheKey}}
 
+### Batched citation lookup (SumatraPDF page-scan flow)
+
+// One round-trip for every citation on a PDF page. Each `results[i]` aligns with `citations[i]`;
+// blank slots and parser failures come back as `matchScope: "none"` without failing the batch.
+
+POST http://localhost:23119/libraries/{{libraryId}}/citations/lookup:batch
+Content-Type: application/json
+
+{
+  "citations": [
+    "Smith, J. (2020). On the nature of chocolate. Journal of Sweets, 12(3), 45-67.",
+    "Doe, J. (2019). Cocoa cultivation. Plant Sci, 5(1), 1-10.",
+    ""
+  ]
+}
+
 ### Lookup against an unknown library id -> 404 Not Found
 
 POST http://localhost:23119/libraries/does-not-exist/citations/lookup

--- a/jabsrv/src/test/java/org/jabref/http/JabSrvArchitectureTest.java
+++ b/jabsrv/src/test/java/org/jabref/http/JabSrvArchitectureTest.java
@@ -1,5 +1,7 @@
 package org.jabref.http;
 
+import org.jabref.support.CommonArchitectureTest;
+
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
@@ -7,7 +9,7 @@ import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 @AnalyzeClasses(packages = "org.jabref.http", importOptions = ImportOption.DoNotIncludeTests.class)
-public class JabSrvArchitectureTests {
+public class JabSrvArchitectureTest extends CommonArchitectureTest {
 
     /// jabsrv is a JAX-RS / HK2 module — resources receive collaborators via
     /// `@Inject`, not via the afterburner DI used by the GUI. Smuggling in

--- a/jabsrv/src/test/java/org/jabref/http/JabSrvArchitectureTests.java
+++ b/jabsrv/src/test/java/org/jabref/http/JabSrvArchitectureTests.java
@@ -1,0 +1,24 @@
+package org.jabref.http;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+
+@AnalyzeClasses(packages = "org.jabref.http", importOptions = ImportOption.DoNotIncludeTests.class)
+public class JabSrvArchitectureTests {
+
+    /// jabsrv is a JAX-RS / HK2 module — resources receive collaborators via
+    /// `@Inject`, not via the afterburner DI used by the GUI. Smuggling in
+    /// `Injector.instantiateModelOrService(...)` bypasses HK2 bindings and
+    /// hides hidden coupling on the GUI bootstrap path. Register the
+    /// collaborator as an HK2 constant in `Server` instead.
+    @ArchTest
+    public void doNotUseAfterburnerInjector(JavaClasses classes) {
+        ArchRuleDefinition.noClasses()
+                          .should().dependOnClassesThat().resideInAPackage("com.airhacks.afterburner.injection..")
+                          .because("jabsrv must inject via HK2 (@Inject) — afterburner Injector belongs to the GUI module")
+                          .check(classes);
+    }
+}

--- a/jabsrv/src/test/java/org/jabref/http/JabSrvArchitectureTests.java
+++ b/jabsrv/src/test/java/org/jabref/http/JabSrvArchitectureTests.java
@@ -21,4 +21,21 @@ public class JabSrvArchitectureTests {
                           .because("jabsrv must inject via HK2 (@Inject) — afterburner Injector belongs to the GUI module")
                           .check(classes);
     }
+
+    /// `application/json` resources are written by `GsonMessageBodyWriter`, so
+    /// Jackson annotations (`@JsonValue`, `@JsonProperty`, …) silently no-op
+    /// and produce the wrong wire format. The only place Jackson is allowed
+    /// is `org.jabref.http.server.command`, which still uses
+    /// `tools.jackson.databind.ObjectMapper` directly for its WebSocket-style
+    /// command dispatch.
+    @ArchTest
+    public void doNotUseJacksonOutsideCommand(JavaClasses classes) {
+        ArchRuleDefinition.noClasses()
+                          .that().resideOutsideOfPackage("org.jabref.http.server.command..")
+                          .should().dependOnClassesThat().resideInAnyPackage(
+                                  "com.fasterxml.jackson..",
+                                  "tools.jackson..")
+                          .because("Gson writes the wire format for resources/DTOs; Jackson annotations are silently ignored. Only org.jabref.http.server.command may use Jackson directly.")
+                          .check(classes);
+    }
 }

--- a/jabsrv/src/test/java/org/jabref/http/server/CitationsResourceTest.java
+++ b/jabsrv/src/test/java/org/jabref/http/server/CitationsResourceTest.java
@@ -3,7 +3,6 @@ package org.jabref.http.server;
 import org.jabref.http.server.resources.CitationsResource;
 import org.jabref.http.server.services.CitationCacheService;
 import org.jabref.logic.UiMessageHandler;
-import org.jabref.model.entry.BibEntryTypesManager;
 
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Application;
@@ -38,12 +37,12 @@ class CitationsResourceTest extends ServerTest {
         addGsonToResourceConfig(resourceConfig);
         addPreferencesToResourceConfig(resourceConfig);
         addGlobalExceptionMapperToResourceConfig(resourceConfig);
+        addEntryTypesManagerToResourceConfig(resourceConfig);
         resourceConfig.register(new AbstractBinder() {
             @Override
             protected void configure() {
                 bind(uiMessageHandler).to(UiMessageHandler.class);
                 bind(new CitationCacheService()).to(CitationCacheService.class);
-                bind(new BibEntryTypesManager()).to(BibEntryTypesManager.class);
             }
         });
         return resourceConfig.getApplication();

--- a/jabsrv/src/test/java/org/jabref/http/server/CitationsResourceTest.java
+++ b/jabsrv/src/test/java/org/jabref/http/server/CitationsResourceTest.java
@@ -3,6 +3,7 @@ package org.jabref.http.server;
 import org.jabref.http.server.resources.CitationsResource;
 import org.jabref.http.server.services.CitationCacheService;
 import org.jabref.logic.UiMessageHandler;
+import org.jabref.model.entry.BibEntryTypesManager;
 
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Application;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CitationsResourceTest extends ServerTest {
 
@@ -41,6 +43,7 @@ class CitationsResourceTest extends ServerTest {
             protected void configure() {
                 bind(uiMessageHandler).to(UiMessageHandler.class);
                 bind(new CitationCacheService()).to(CitationCacheService.class);
+                bind(new BibEntryTypesManager()).to(BibEntryTypesManager.class);
             }
         });
         return resourceConfig.getApplication();
@@ -76,5 +79,45 @@ class CitationsResourceTest extends ServerTest {
         Response response = postAddFromCache(TestBibFile.GENERAL_SERVER_TEST.id, "expired-or-unknown");
 
         assertEquals(Response.Status.GONE.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void lookupBlankTextReturns400() {
+        Response response = target("/libraries/" + TestBibFile.GENERAL_SERVER_TEST.id + "/citations/lookup")
+                .request()
+                .post(Entity.text("   "));
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void lookupOnUnknownLibraryReturns404() {
+        Response response = target("/libraries/does-not-exist/citations/lookup")
+                .request()
+                .post(Entity.text("Smith, J. (2020). Chocolate. J. Sweets, 12, 45."));
+
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void batchLookupEmptyListReturns400() {
+        Response response = target("/libraries/" + TestBibFile.GENERAL_SERVER_TEST.id + "/citations/lookup:batch")
+                .request()
+                .post(Entity.json("{\"citations\":[]}"));
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void batchLookupBlankSlotReturnsNoneScope() {
+        // All-blank batch never invokes the parser; each slot short-circuits to a "none" response,
+        // exercising the batch wiring + JSON serialization without needing a real plain-citation parser.
+        Response response = target("/libraries/" + TestBibFile.GENERAL_SERVER_TEST.id + "/citations/lookup:batch")
+                .request()
+                .post(Entity.json("{\"citations\":[\"\",\"   \"]}"));
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        String body = response.readEntity(String.class);
+        assertTrue(body.contains("\"matchScope\":\"none\""), body);
     }
 }

--- a/jabsrv/src/test/java/org/jabref/http/server/CitationsResourceTest.java
+++ b/jabsrv/src/test/java/org/jabref/http/server/CitationsResourceTest.java
@@ -117,6 +117,6 @@ class CitationsResourceTest extends ServerTest {
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         String body = response.readEntity(String.class);
-        assertTrue(body.contains("\"matchScope\":\"none\""), body);
+        assertTrue(body.contains("\"matchScope\": \"none\""), body);
     }
 }

--- a/jabsrv/src/test/java/org/jabref/http/server/EntriesResourceTest.java
+++ b/jabsrv/src/test/java/org/jabref/http/server/EntriesResourceTest.java
@@ -46,6 +46,7 @@ class EntriesResourceTest extends ServerTest {
         addGsonToResourceConfig(resourceConfig);
         addPreferencesToResourceConfig(resourceConfig);
         addGlobalExceptionMapperToResourceConfig(resourceConfig);
+        addEntryTypesManagerToResourceConfig(resourceConfig);
         resourceConfig.register(new AbstractBinder() {
             @Override
             protected void configure() {

--- a/jabsrv/src/test/java/org/jabref/http/server/LibraryResourceTest.java
+++ b/jabsrv/src/test/java/org/jabref/http/server/LibraryResourceTest.java
@@ -18,6 +18,7 @@ class LibraryResourceTest extends ServerTest {
         addGuiBridgeToResourceConfig(resourceConfig);
         addPreferencesToResourceConfig(resourceConfig);
         addGsonToResourceConfig(resourceConfig);
+        addEntryTypesManagerToResourceConfig(resourceConfig);
         return resourceConfig.getApplication();
     }
 

--- a/jabsrv/src/test/java/org/jabref/http/server/ServerTest.java
+++ b/jabsrv/src/test/java/org/jabref/http/server/ServerTest.java
@@ -19,6 +19,7 @@ import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.preferences.LastFilesOpenedPreferences;
 import org.jabref.model.entry.BibEntryPreferences;
+import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.metadata.UserHostInfo;
 
 import com.google.gson.Gson;
@@ -101,6 +102,15 @@ public abstract class ServerTest extends JerseyTest {
             @Override
             protected void configure() {
                 bind(preferences).to(CliPreferences.class).ranked(2);
+            }
+        });
+    }
+
+    protected void addEntryTypesManagerToResourceConfig(ResourceConfig resourceConfig) {
+        resourceConfig.register(new AbstractBinder() {
+            @Override
+            protected void configure() {
+                bind(new BibEntryTypesManager()).to(BibEntryTypesManager.class);
             }
         });
     }

--- a/jabsrv/src/test/resources/archunit.properties
+++ b/jabsrv/src/test/resources/archunit.properties
@@ -1,0 +1,4 @@
+# jabsrv's architecture test analyzes only `org.jabref.http`. The logic/model rules
+# inherited from CommonArchitectureTest (e.g. doNotUseGuiInLogic, restrictUsagesInModel)
+# legitimately match no classes in this scope, so an empty `should` is not a failure here.
+archRule.failOnEmptyShould=false


### PR DESCRIPTION
### Related issues and pull requests

https://github.com/JabRef/jabref-koppor/issues/730

### PR Description

Adds a batch-lookup of references

### Steps to test

- `import.http`: ### Batched citation lookup (SumatraPDF page-scan flow)

### AI usage

🤖 - Claude. But I directed.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
