### PR TITLE
Persist default queries in study lock files

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
@@ -58,18 +58,19 @@ class StudyFetcher {
 
     private FetchResult performSearchOnQueryForFetcher(StudyQuery searchQuery, SearchBasedFetcher fetcher) {
         try {
+            String effectiveQuery = searchQuery.getCatalogSpecific().getOrDefault(fetcher.getName(), searchQuery.getQuery());
             List<BibEntry> fetchResult = new ArrayList<>();
             if (fetcher instanceof PagedSearchBasedFetcher basedFetcher) {
                 int limit = resultLimits.getOrDefault(fetcher.getName(), StudyRepository.DEFAULT_RESULT_LIMIT);
                 int pages = (int) Math.ceil((double) limit / basedFetcher.getPageSize());
                 for (int page = 0; page < pages; page++) {
-                    fetchResult.addAll(basedFetcher.performSearchPaged(searchQuery.getQuery(), page).getContent());
+                    fetchResult.addAll(basedFetcher.performSearchPaged(effectiveQuery, page).getContent());
                 }
                 if (fetchResult.size() > limit) {
                     fetchResult = new ArrayList<>(fetchResult.subList(0, limit));
                 }
             } else {
-                fetchResult = fetcher.performSearch(searchQuery.getQuery());
+                fetchResult = fetcher.performSearch(effectiveQuery);
             }
             return new FetchResult(fetcher.getName(), new BibDatabase(fetchResult));
         } catch (FetcherException e) {

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -63,6 +64,7 @@ public class StudyRepository {
     // Tests work with study.yml
     public static final String STUDY_DEFINITION_FILE_NAME = "study.yml";
     public static final int DEFAULT_RESULT_LIMIT = 100;
+    public static final String STUDY_LOCK_FILE_NAME = "study-lock.yml";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StudyRepository.class);
 
@@ -245,6 +247,11 @@ public class StudyRepository {
             }
             // Patch new results into work branch
             gitHandler.appendLatestSearchResultsOntoCurrentBranch(commitMessage + " - Patch", SEARCH_BRANCH);
+            // Copy study-lock.yml from search branch into the work branch working directory
+            Study studyLock = buildStudyLock(crawlResults);
+            new StudyYamlParser().writeStudyYamlFile(studyLock, repositoryPath.resolve(STUDY_LOCK_FILE_NAME));
+            // Commit study-lock before push
+            gitHandler.createCommitOnCurrentBranch("Update study-lock.yml on work branch", false);
             // Update both remote tracked branches
             updateRemoteSearchAndWorkBranch();
         } catch (GitAPIException e) {
@@ -434,6 +441,9 @@ public class StudyRepository {
             addFetcherGroupToMetaData(existingStudyResultEntries, fetcherName);
         }
         writeResultToFile(getPathToStudyResultFile(), existingStudyResultEntries);
+
+        Study studyLock = buildStudyLock(crawlResults);
+        new StudyYamlParser().writeStudyYamlFile(studyLock, repositoryPath.resolve(STUDY_LOCK_FILE_NAME));
     }
 
     private void generateCiteKeys(BibDatabaseContext existingEntries, BibDatabase targetEntries) {
@@ -495,6 +505,37 @@ public class StudyRepository {
                     preferences.getBibEntryPreferences().getKeywordSeparator());
             rootNode.addSubgroup(fetcherGroup);
         }
+    }
+
+    /// Builds a lock representation of the study recording the effective query sent to each catalog.
+    ///
+    /// For every (query, catalog) pair that was actually executed the effective query is:
+    /// the catalog-specific override if one is defined in the study definition, or the general query string otherwise.
+    private Study buildStudyLock(List<QueryResult> crawlResults) {
+        Map<String, QueryResult> resultsByQuery = crawlResults.stream()
+                                                              .collect(Collectors.toMap(QueryResult::getQuery, r -> r));
+
+        List<StudyQuery> lockQueries = study.getQueries().stream()
+                                            .map(originalQuery -> getStudyQuery(originalQuery, resultsByQuery))
+                                            .toList();
+
+        return new Study(study.getAuthors(), study.getTitle(), study.getResearchQuestions(), lockQueries, study.getCatalogs());
+    }
+
+    private StudyQuery getStudyQuery(StudyQuery originalQuery, Map<String, QueryResult> resultsByQuery) {
+        String queryString = originalQuery.getQuery();
+        Map<String, String> lockedCatalogSpecific = new LinkedHashMap<>(originalQuery.getCatalogSpecific());
+
+        if (resultsByQuery.containsKey(queryString)) {
+            QueryResult queryResult = resultsByQuery.get(queryString);
+            for (FetchResult fetchResult : queryResult.getResultsPerFetcher()) {
+                lockedCatalogSpecific.putIfAbsent(fetchResult.getFetcherName(), queryString);
+            }
+        }
+
+        StudyQuery lockQuery = new StudyQuery(queryString);
+        lockQuery.setCatalogSpecific(lockedCatalogSpecific);
+        return lockQuery;
     }
 
     private Path getPathToFetcherResultFile(String query, String fetcherName) {

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -14,8 +14,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jabref.logic.JabRefException;
 import org.jabref.logic.citationkeypattern.CitationKeyGenerator;
@@ -238,21 +240,16 @@ public class StudyRepository {
         gitHandler.checkoutBranch(SEARCH_BRANCH);
         persistResults(crawlResults);
         try {
-            // First commit changes to search branch and update remote
             String commitMessage = "Conducted search: " + LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
             boolean newSearchResults = gitHandler.createCommitOnCurrentBranch(commitMessage, false);
             gitHandler.checkoutBranch(WORK_BRANCH);
             if (!newSearchResults) {
                 return;
             }
-            // Patch new results into work branch
             gitHandler.appendLatestSearchResultsOntoCurrentBranch(commitMessage + " - Patch", SEARCH_BRANCH);
-            // Copy study-lock.yml from search branch into the work branch working directory
             Study studyLock = buildStudyLock(crawlResults);
             new StudyYamlParser().writeStudyYamlFile(studyLock, repositoryPath.resolve(STUDY_LOCK_FILE_NAME));
-            // Commit study-lock before push
             gitHandler.createCommitOnCurrentBranch("Update study-lock.yml on work branch", false);
-            // Update both remote tracked branches
             updateRemoteSearchAndWorkBranch();
         } catch (GitAPIException e) {
             LOGGER.error("Updating remote repository failed", e);
@@ -513,7 +510,15 @@ public class StudyRepository {
     /// the catalog-specific override if one is defined in the study definition, or the general query string otherwise.
     private Study buildStudyLock(List<QueryResult> crawlResults) {
         Map<String, QueryResult> resultsByQuery = crawlResults.stream()
-                                                              .collect(Collectors.toMap(QueryResult::getQuery, r -> r));
+                                                              .collect(Collectors.toMap(
+                                                                      QueryResult::getQuery,
+                                                                      Function.identity(),
+                                                                      (a, b) -> new QueryResult(a.getQuery(),
+                                                                              Stream.concat(
+                                                                                      a.getResultsPerFetcher().stream(),
+                                                                                      b.getResultsPerFetcher().stream()
+                                                                              ).toList()),
+                                                                      LinkedHashMap::new));
 
         List<StudyQuery> lockQueries = study.getQueries().stream()
                                             .map(originalQuery -> getStudyQuery(originalQuery, resultsByQuery))

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -36,6 +36,7 @@ import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.study.FetchResult;
 import org.jabref.model.study.QueryResult;
 import org.jabref.model.study.Study;
+import org.jabref.model.study.StudyQuery;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -253,6 +254,52 @@ class StudyRepositoryTest {
         limits.forEach((catalog, limit) ->
                 assertEquals(StudyRepository.DEFAULT_RESULT_LIMIT, limit,
                         () -> "Catalog '" + catalog + "' did not resolve to the default"));
+    }
+
+    @Test
+    void studyLockFileIsCreatedAfterPersist() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        studyRepository.persist(getMockResults());
+        assertTrue(Files.exists(tempRepositoryDirectory.resolve(StudyRepository.STUDY_LOCK_FILE_NAME)));
+    }
+
+    @Test
+    void studyLockFileContainsEffectiveQueryPerCatalog() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        studyRepository.persist(getMockResults());
+
+        Study lock = new StudyYamlParser().parseStudyYamlFile(
+                tempRepositoryDirectory.resolve(StudyRepository.STUDY_LOCK_FILE_NAME));
+
+        List<StudyQuery> lockQueries = lock.getQueries();
+        assertEquals(3, lockQueries.size());
+
+        StudyQuery quantumLock = lockQueries.get(0);
+        assertEquals("Quantum", quantumLock.getQuery());
+        assertEquals(Map.of("ArXiv", "Quantum", "Springer", "Quantum"), quantumLock.getCatalogSpecific());
+
+        StudyQuery cloudLock = lockQueries.get(1);
+        assertEquals("Cloud Computing", cloudLock.getQuery());
+        assertEquals(Map.of("Springer", "Cloud Computing"), cloudLock.getCatalogSpecific());
+    }
+
+    @Test
+    void studyLockFilePreservesCatalogSpecificOverrides() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        // Override the Quantum query catalog-specific entry for ArXiv before persisting
+        studyRepository.getStudy().getQueries().stream()
+             .filter(q -> "Quantum".equals(q.getQuery()))
+             .findFirst()
+             .ifPresent(q -> q.getCatalogSpecific().put("ArXiv", "ti:Quantum"));
+
+        studyRepository.persist(getMockResults());
+
+        Study lock = new StudyYamlParser().parseStudyYamlFile(
+                tempRepositoryDirectory.resolve(StudyRepository.STUDY_LOCK_FILE_NAME));
+
+        StudyQuery quantumLock = lock.getQueries().stream()
+                                     .filter(q -> "Quantum".equals(q.getQuery()))
+                                     .findFirst()
+                                     .orElseThrow();
+        assertEquals("ti:Quantum", quantumLock.getCatalogSpecific().get("ArXiv"));
+        assertEquals("Quantum", quantumLock.getCatalogSpecific().get("Springer"));
     }
 
     private StudyRepository getTestStudyRepository() throws IOException, URISyntaxException, JabRefException {

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -289,7 +289,7 @@ class StudyRepositoryTest {
         List<StudyQuery> lockQueries = lock.getQueries();
         assertEquals(3, lockQueries.size());
 
-        StudyQuery quantumLock = lockQueries.get(0);
+        StudyQuery quantumLock = lockQueries.getFirst();
         assertEquals("Quantum", quantumLock.getQuery());
         assertEquals(Map.of("ArXiv", "Quantum", "Springer", "Quantum"), quantumLock.getCatalogSpecific());
 

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -53,6 +53,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -263,6 +265,21 @@ class StudyRepositoryTest {
     }
 
     @Test
+    void persistUpdatesStudyLockOnWorkBranchWhenNewResultsExist() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        when(gitHandler.createCommitOnCurrentBranch(anyString(), anyBoolean())).thenReturn(true);
+
+        studyRepository.persist(getMockResults());
+
+        Study lock = new StudyYamlParser().parseStudyYamlFile(
+                tempRepositoryDirectory.resolve(StudyRepository.STUDY_LOCK_FILE_NAME));
+        StudyQuery quantumLock = lock.getQueries().stream()
+                                     .filter(q -> "Quantum".equals(q.getQuery()))
+                                     .findFirst()
+                                     .orElseThrow();
+        assertEquals(Map.of("ArXiv", "Quantum", "Springer", "Quantum"), quantumLock.getCatalogSpecific());
+    }
+
+    @Test
     void studyLockFileContainsEffectiveQueryPerCatalog() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
         studyRepository.persist(getMockResults());
 
@@ -285,9 +302,9 @@ class StudyRepositoryTest {
     void studyLockFilePreservesCatalogSpecificOverrides() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
         // Override the Quantum query catalog-specific entry for ArXiv before persisting
         studyRepository.getStudy().getQueries().stream()
-             .filter(q -> "Quantum".equals(q.getQuery()))
-             .findFirst()
-             .ifPresent(q -> q.getCatalogSpecific().put("ArXiv", "ti:Quantum"));
+                       .filter(q -> "Quantum".equals(q.getQuery()))
+                       .findFirst()
+                       .ifPresent(q -> q.getCatalogSpecific().put("ArXiv", "ti:Quantum"));
 
         studyRepository.persist(getMockResults());
 
@@ -300,6 +317,25 @@ class StudyRepositoryTest {
                                      .orElseThrow();
         assertEquals("ti:Quantum", quantumLock.getCatalogSpecific().get("ArXiv"));
         assertEquals("Quantum", quantumLock.getCatalogSpecific().get("Springer"));
+    }
+
+    @Test
+    void studyLockHandlesDuplicateQueryResults() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        QueryResult quantumFromArXiv = new QueryResult("Quantum", List.of(
+                new FetchResult("ArXiv", new BibDatabase(stripCitationKeys(getArXivQuantumMockResults())))));
+        QueryResult quantumFromSpringer = new QueryResult("Quantum", List.of(
+                new FetchResult("Springer", new BibDatabase(stripCitationKeys(getSpringerQuantumMockResults())))));
+
+        studyRepository.persist(List.of(quantumFromArXiv, quantumFromSpringer));
+
+        Study lock = new StudyYamlParser().parseStudyYamlFile(
+                tempRepositoryDirectory.resolve(StudyRepository.STUDY_LOCK_FILE_NAME));
+
+        StudyQuery quantumLock = lock.getQueries().stream()
+                                     .filter(q -> "Quantum".equals(q.getQuery()))
+                                     .findFirst()
+                                     .orElseThrow();
+        assertEquals(Map.of("ArXiv", "Quantum", "Springer", "Quantum"), quantumLock.getCatalogSpecific());
     }
 
     private StudyRepository getTestStudyRepository() throws IOException, URISyntaxException, JabRefException {


### PR DESCRIPTION
## Summary

This PR changes the study lock generation so that default queries are persisted instead of being omitted.

## Motivation

Previously, when a catalog relied on the generic/default query from a block, the generated study lock file did not explicitly record that query.

Persisting default queries makes the search history fully transparent, reproducible, and easier to audit.

## Changes

- Persist default queries when generating study lock files.
- Preserve the original query information in the generated lock.
- Add a regression test covering the new behavior.

Fixes #12640