### PR TITLE
SLR: ACM raw query

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/PagedSearchBasedParserFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/PagedSearchBasedParserFetcher.java
@@ -61,4 +61,27 @@ public interface PagedSearchBasedParserFetcher extends SearchBasedParserFetcher,
     default List<BibEntry> performRawSearchQuery(String rawQuery) throws FetcherException {
         return PagedSearchBasedFetcher.super.performRawSearchQuery(rawQuery);
     }
+
+    /// Default implementation: builds the URL via {@link #getURLForRawQuery(String, int)}, then downloads, parses, and post-cleans the result.
+    @Override
+    default Page<BibEntry> performRawSearchQueryPaged(String rawQuery, int pageNumber) throws FetcherException {
+        if (rawQuery.isBlank()) {
+            return new Page<>(rawQuery, pageNumber, List.of());
+        }
+        URL urlForQuery;
+        try {
+            urlForQuery = getURLForRawQuery(rawQuery, pageNumber);
+        } catch (URISyntaxException | MalformedURLException | FetcherException e) {
+            throw new FetcherException("Search URI crafted from raw search query is malformed: " + rawQuery, e);
+        }
+        return new Page<>(rawQuery, pageNumber, getBibEntries(urlForQuery));
+    }
+
+    /// Constructs a URL that sends the raw, catalog-native query verbatim to the catalog (bypassing the query transformer).
+    ///
+    /// @param rawQuery   catalog-native query string sent verbatim to the catalog
+    /// @param pageNumber requested page number indexed from 0
+    default URL getURLForRawQuery(String rawQuery, int pageNumber) throws URISyntaxException, MalformedURLException, FetcherException {
+        throw new UnsupportedOperationException(getName() + " has not yet been migrated to performRawSearchQueryPaged");
+    }
 }

--- a/jablib/src/main/java/org/jabref/logic/importer/PagedSearchBasedParserFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/PagedSearchBasedParserFetcher.java
@@ -54,15 +54,15 @@ public interface PagedSearchBasedParserFetcher extends SearchBasedParserFetcher,
     }
 
     /// Resolves the diamond inheritance of `performRawSearchQuery`: this interface inherits one default from
-    /// {@link SearchBasedParserFetcher} (single-page, via `getURLForRawQuery`) and another from
-    /// {@link PagedSearchBasedFetcher} (paged, via `performRawSearchQueryPaged`). Paged fetchers implement the paged
+    /// [SearchBasedParserFetcher] (single-page, via `getURLForRawQuery`) and another from
+    /// [PagedSearchBasedFetcher] (paged, via `performRawSearchQueryPaged`). Paged fetchers implement the paged
     /// hook, so we route through the paged default.
     @Override
     default List<BibEntry> performRawSearchQuery(String rawQuery) throws FetcherException {
         return PagedSearchBasedFetcher.super.performRawSearchQuery(rawQuery);
     }
 
-    /// Default implementation: builds the URL via {@link #getURLForRawQuery(String, int)}, then downloads, parses, and post-cleans the result.
+    /// Default implementation: builds the URL via [#getURLForRawQuery(String, int)], then downloads, parses, and post-cleans the result.
     @Override
     default Page<BibEntry> performRawSearchQueryPaged(String rawQuery, int pageNumber) throws FetcherException {
         if (rawQuery.isBlank()) {

--- a/jablib/src/main/java/org/jabref/logic/importer/PagedSearchBasedParserFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/PagedSearchBasedParserFetcher.java
@@ -52,4 +52,13 @@ public interface PagedSearchBasedParserFetcher extends SearchBasedParserFetcher,
     default List<BibEntry> performSearch(BaseQueryNode queryNode) throws FetcherException {
         return SearchBasedParserFetcher.super.performSearch(queryNode);
     }
+
+    /// Resolves the diamond inheritance of `performRawSearchQuery`: this interface inherits one default from
+    /// {@link SearchBasedParserFetcher} (single-page, via `getURLForRawQuery`) and another from
+    /// {@link PagedSearchBasedFetcher} (paged, via `performRawSearchQueryPaged`). Paged fetchers implement the paged
+    /// hook, so we route through the paged default.
+    @Override
+    default List<BibEntry> performRawSearchQuery(String rawQuery) throws FetcherException {
+        return PagedSearchBasedFetcher.super.performRawSearchQuery(rawQuery);
+    }
 }

--- a/jablib/src/main/java/org/jabref/logic/importer/SearchBasedParserFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/SearchBasedParserFetcher.java
@@ -48,6 +48,21 @@ public interface SearchBasedParserFetcher extends SearchBasedFetcher, ParserFetc
         return getBibEntries(urlForQuery);
     }
 
+    /// Default implementation: builds the URL via {@link #getURLForRawQuery(String)}, then downloads, parses, and post-cleans the result.
+    @Override
+    default List<BibEntry> performRawSearchQuery(String rawQuery) throws FetcherException {
+        if (rawQuery.isBlank()) {
+            return List.of();
+        }
+        URL urlForQuery;
+        try {
+            urlForQuery = getURLForRawQuery(rawQuery);
+        } catch (URISyntaxException | MalformedURLException | FetcherException e) {
+            throw new FetcherException("Search URI crafted from raw search query is malformed: " + rawQuery, e);
+        }
+        return getBibEntries(urlForQuery);
+    }
+
     private List<BibEntry> getBibEntries(URL urlForQuery) throws FetcherException {
         try (InputStream stream = getUrlDownload(urlForQuery).asInputStream()) {
             List<BibEntry> fetchedEntries = getParser().parseEntries(stream);
@@ -69,4 +84,11 @@ public interface SearchBasedParserFetcher extends SearchBasedFetcher, ParserFetc
     ///
     /// @param queryList the list that contains the parsed nodes
     URL getURLForQuery(BaseQueryNode queryList) throws URISyntaxException, MalformedURLException, FetcherException;
+
+    /// Constructs a URL that sends the raw, catalog-native query verbatim to the catalog (bypassing the query transformer).
+    ///
+    /// @param rawQuery catalog-native query string sent verbatim to the catalog
+    default URL getURLForRawQuery(String rawQuery) throws URISyntaxException, MalformedURLException, FetcherException {
+        throw new UnsupportedOperationException(getName() + " has not yet been migrated to performRawSearchQuery");
+    }
 }

--- a/jablib/src/main/java/org/jabref/logic/importer/SearchBasedParserFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/SearchBasedParserFetcher.java
@@ -13,21 +13,21 @@ import org.jabref.model.search.query.BaseQueryNode;
 /// Provides a convenient interface for search-based fetcher, which follows the usual three-step procedure:
 ///
 /// - Open a URL based on the search query
-/// - Parse the response to get a list of {@link BibEntry}
+/// - Parse the response to get a list of [BibEntry]
 /// - Post-process fetched entries
 ///
 ///
-/// This interface is used for web resources which do NOT provide BibTeX data {@link BibEntry}.
-/// JabRef's infrastructure to convert arbitrary input data to BibTeX is {@link Parser}.
+/// This interface is used for web resources which do NOT provide BibTeX data [BibEntry].
+/// JabRef's infrastructure to convert arbitrary input data to BibTeX is [Parser].
 ///
 ///
-/// This interface inherits {@link SearchBasedFetcher}, because the methods `performSearch` have to be provided by both.
-/// As non-BibTeX web fetcher one could do "magic" stuff without this helper interface and directly use {@link WebFetcher}, but this is more work.
+/// This interface inherits [SearchBasedFetcher], because the methods `performSearch` have to be provided by both.
+/// As non-BibTeX web fetcher one could do "magic" stuff without this helper interface and directly use [WebFetcher], but this is more work.
 ///
 ///
 /// Note that this interface "should" be an abstract class.
 /// However, Java does not support multi inheritance with classes (but with interfaces).
-/// We need multi inheritance, because a fetcher might implement multiple query types (such as id fetching {@link IdBasedFetcher}), complete entry {@link EntryBasedFetcher}, and search-based fetcher (this class).
+/// We need multi inheritance, because a fetcher might implement multiple query types (such as id fetching [IdBasedFetcher]), complete entry [EntryBasedFetcher], and search-based fetcher (this class).
 
 public interface SearchBasedParserFetcher extends SearchBasedFetcher, ParserFetcher {
 
@@ -48,7 +48,7 @@ public interface SearchBasedParserFetcher extends SearchBasedFetcher, ParserFetc
         return getBibEntries(urlForQuery);
     }
 
-    /// Default implementation: builds the URL via {@link #getURLForRawQuery(String)}, then downloads, parses, and post-cleans the result.
+    /// Default implementation: builds the URL via [#getURLForRawQuery(String)], then downloads, parses, and post-cleans the result.
     @Override
     default List<BibEntry> performRawSearchQuery(String rawQuery) throws FetcherException {
         if (rawQuery.isBlank()) {
@@ -77,7 +77,7 @@ public interface SearchBasedParserFetcher extends SearchBasedFetcher, ParserFetc
         }
     }
 
-    /// Returns the parser used to convert the response to a list of {@link BibEntry}.
+    /// Returns the parser used to convert the response to a list of [BibEntry].
     Parser getParser();
 
     /// Constructs a URL based on the lucene query.

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ACMPortalFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ACMPortalFetcher.java
@@ -1,17 +1,23 @@
 package org.jabref.logic.importer.fetcher;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.List;
 import java.util.Optional;
 
 import org.jabref.logic.help.HelpFile;
+import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.SearchBasedParserFetcher;
 import org.jabref.logic.importer.fetcher.transformers.DefaultQueryTransformer;
 import org.jabref.logic.importer.fileformat.ACMPortalParser;
+import org.jabref.model.entry.BibEntry;
 import org.jabref.model.search.query.BaseQueryNode;
 
 import org.apache.hc.core5.net.URIBuilder;
@@ -47,9 +53,33 @@ public class ACMPortalFetcher implements SearchBasedParserFetcher {
     /// @return query URL
     @Override
     public URL getURLForQuery(BaseQueryNode queryNode) throws URISyntaxException, MalformedURLException {
+        return buildSearchURL(createQueryString(queryNode));
+    }
+
+    /// Builds the ACM search URL, sending the given query as the `AllField` parameter.
+    private static URL buildSearchURL(String query) throws URISyntaxException, MalformedURLException {
         URIBuilder uriBuilder = new URIBuilder(SEARCH_URL);
-        uriBuilder.addParameter("AllField", createQueryString(queryNode));
+        uriBuilder.addParameter("AllField", query);
         return uriBuilder.build().toURL();
+    }
+
+    @Override
+    public List<BibEntry> performRawSearchQuery(String rawQuery) throws FetcherException {
+        if (rawQuery.isBlank()) {
+            return List.of();
+        }
+        try {
+            URL url = buildSearchURL(rawQuery);
+            try (InputStream stream = getUrlDownload(url).asInputStream()) {
+                return getParser().parseEntries(stream);
+            }
+        } catch (URISyntaxException e) {
+            throw new FetcherException("ACM raw search URL is malformed for query: " + rawQuery, e);
+        } catch (IOException e) {
+            throw new FetcherException(rawQuery, e);
+        } catch (ParseException e) {
+            throw new FetcherException("ACM raw search parse error for query: " + rawQuery, e);
+        }
     }
 
     /// Gets an instance of ACMPortalParser.

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ACMPortalFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ACMPortalFetcher.java
@@ -1,23 +1,17 @@
 package org.jabref.logic.importer.fetcher;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.List;
 import java.util.Optional;
 
 import org.jabref.logic.help.HelpFile;
-import org.jabref.logic.importer.FetcherException;
-import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.SearchBasedParserFetcher;
 import org.jabref.logic.importer.fetcher.transformers.DefaultQueryTransformer;
 import org.jabref.logic.importer.fileformat.ACMPortalParser;
-import org.jabref.model.entry.BibEntry;
 import org.jabref.model.search.query.BaseQueryNode;
 
 import org.apache.hc.core5.net.URIBuilder;
@@ -63,23 +57,10 @@ public class ACMPortalFetcher implements SearchBasedParserFetcher {
         return uriBuilder.build().toURL();
     }
 
+    /// Builds the ACM search URL for a raw, catalog-native query, sent verbatim as the `AllField` parameter.
     @Override
-    public List<BibEntry> performRawSearchQuery(String rawQuery) throws FetcherException {
-        if (rawQuery.isBlank()) {
-            return List.of();
-        }
-        try {
-            URL url = buildSearchURL(rawQuery);
-            try (InputStream stream = getUrlDownload(url).asInputStream()) {
-                return getParser().parseEntries(stream);
-            }
-        } catch (URISyntaxException e) {
-            throw new FetcherException("ACM raw search URL is malformed for query: " + rawQuery, e);
-        } catch (IOException e) {
-            throw new FetcherException(rawQuery, e);
-        } catch (ParseException e) {
-            throw new FetcherException("ACM raw search parse error for query: " + rawQuery, e);
-        }
+    public URL getURLForRawQuery(String rawQuery) throws URISyntaxException, MalformedURLException {
+        return buildSearchURL(rawQuery);
     }
 
     /// Gets an instance of ACMPortalParser.

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -309,7 +309,7 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
     }
 
     /// Builds the IEEE search URL for a raw, catalog-native query, sent verbatim as the `querytext` parameter.
-    /// Resets `transformer` so {@link #getParser()} applies no year filtering to raw results.
+    /// Resets `transformer` so [#getParser()] applies no year filtering to raw results.
     @Override
     public URL getURLForRawQuery(String rawQuery, int pageNumber) throws URISyntaxException, MalformedURLException {
         transformer = new IEEEQueryTransformer();

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -20,7 +20,6 @@ import org.jabref.logic.importer.FulltextFetcher;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.importer.PagedSearchBasedParserFetcher;
-import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.fetcher.transformers.IEEEQueryTransformer;
 import org.jabref.logic.net.URLDownload;
@@ -32,7 +31,6 @@ import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
 import org.jabref.model.entry.types.StandardEntryType;
-import org.jabref.model.paging.Page;
 import org.jabref.model.search.query.BaseQueryNode;
 
 import kong.unirest.core.UnirestException;
@@ -310,24 +308,12 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
         return uriBuilder.build().toURL();
     }
 
+    /// Builds the IEEE search URL for a raw, catalog-native query, sent verbatim as the `querytext` parameter.
+    /// Resets `transformer` so {@link #getParser()} applies no year filtering to raw results.
     @Override
-    public Page<BibEntry> performRawSearchQueryPaged(String rawQuery, int pageNumber) throws FetcherException {
-        if (rawQuery.isBlank()) {
-            return new Page<>(rawQuery, pageNumber, List.of());
-        }
+    public URL getURLForRawQuery(String rawQuery, int pageNumber) throws URISyntaxException, MalformedURLException {
         transformer = new IEEEQueryTransformer();
-        try {
-            URL url = buildSearchURL(rawQuery, pageNumber);
-            try (var stream = getUrlDownload(url).asInputStream()) {
-                return new Page<>(rawQuery, pageNumber, getParser().parseEntries(stream));
-            }
-        } catch (URISyntaxException e) {
-            throw new FetcherException("IEEE raw search URL is malformed for query: " + rawQuery, e);
-        } catch (IOException e) {
-            throw new FetcherException(rawQuery, e);
-        } catch (ParseException e) {
-            throw new FetcherException("IEEE raw search parse error for query: " + rawQuery, e);
-        }
+        return buildSearchURL(rawQuery, pageNumber);
     }
 
     /// Builds the IEEE search API URL for the given raw query string and page number.

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcher.java
@@ -2,7 +2,6 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -14,10 +13,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.jabref.logic.help.HelpFile;
-import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.importer.PagedSearchBasedParserFetcher;
-import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.fetcher.transformers.SpringerQueryTransformer;
 import org.jabref.logic.net.URLDownload;
@@ -29,7 +26,6 @@ import org.jabref.model.entry.Month;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
-import org.jabref.model.paging.Page;
 import org.jabref.model.search.query.BaseQueryNode;
 
 import com.google.common.base.Strings;
@@ -199,23 +195,10 @@ public class SpringerNatureWebFetcher implements PagedSearchBasedParserFetcher, 
         return buildSearchURL(transformedQuery, pageNumber);
     }
 
+    /// Builds the Springer search URL for a raw, catalog-native query, sent verbatim as the `q` parameter.
     @Override
-    public Page<BibEntry> performRawSearchQueryPaged(String rawQuery, int pageNumber) throws FetcherException {
-        if (rawQuery.isBlank()) {
-            return new Page<>(rawQuery, pageNumber, List.of());
-        }
-        try {
-            URL url = buildSearchURL(rawQuery, pageNumber);
-            try (InputStream stream = getUrlDownload(url).asInputStream()) {
-                return new Page<>(rawQuery, pageNumber, getParser().parseEntries(stream));
-            }
-        } catch (URISyntaxException e) {
-            throw new FetcherException("Springer raw search URL is malformed for query: " + rawQuery, e);
-        } catch (IOException e) {
-            throw new FetcherException(rawQuery, e);
-        } catch (ParseException e) {
-            throw new FetcherException("Springer raw search parse error for query: " + rawQuery, e);
-        }
+    public URL getURLForRawQuery(String rawQuery, int pageNumber) throws URISyntaxException, MalformedURLException {
+        return buildSearchURL(rawQuery, pageNumber);
     }
 
     /// Builds the Springer Nature search API URL for the given raw query string and page number.

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/ACMPortalFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/ACMPortalFetcherTest.java
@@ -60,6 +60,18 @@ class ACMPortalFetcherTest {
     }
 
     @Test
+    void performRawSearchQueryFindsEntry() throws FetcherException {
+        List<BibEntry> fetchedEntries = fetcher.performRawSearchQuery("The relationship of code churn and architectural violations in the open source software JabRef");
+        assertEquals(Optional.of("10.1145/3129790.3129810"),
+                fetchedEntries.stream().findFirst().flatMap(entry -> entry.getField(StandardField.DOI)));
+    }
+
+    @Test
+    void performRawSearchQueryReturnsEmptyForBlankQuery() throws FetcherException {
+        assertEquals(List.of(), fetcher.performRawSearchQuery("  "));
+    }
+
+    @Test
     void getURLForQuery() throws MalformedURLException, URISyntaxException {
         String testQuery = "test query url";
         SearchQuery searchQueryObject = new SearchQuery(testQuery);


### PR DESCRIPTION
### Related issues and pull requests

part of the SLR raw query migration series

### PR Description
Implementing performRawSearchQuery, sends the query as ACM's AllField parameter, bypassing DefaultQueryTransformer, and url construction is extracted into a buildSearchURL helper shared by the translated and raw paths.

### Steps to test


### AI usage
claude-opus-4.6 to investigate files and review my code

### Checklist


- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
