### PR TITLE
Fix: register Caffeine weakKeys cache classes for native image

### DIFF
--- a/jablib/src/main/resources/META-INF/native-image/org.jabref/jablib/reachability-metadata.json
+++ b/jablib/src/main/resources/META-INF/native-image/org.jabref/jablib/reachability-metadata.json
@@ -93,6 +93,63 @@
       ]
     },
     {
+      "type": "com.github.benmanes.caffeine.cache.FS",
+      "fields": [
+        {
+          "name": "key"
+        },
+        {
+          "name": "value"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.FSMS",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.PSMS",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.SSMS",
+      "fields": [
+        {
+          "name": "FACTORY"
+        },
+        {
+          "name": "maximum"
+        },
+        {
+          "name": "weightedSize"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.WSMS",
+      "fields": [
+        {
+          "name": "FACTORY"
+        },
+        {
+          "name": "maximum"
+        },
+        {
+          "name": "weightedSize"
+        }
+      ]
+    },
+    {
       "type": "com.github.benmanes.caffeine.cache.StripedBuffer",
       "fields": [
         {


### PR DESCRIPTION
### Related issues and pull requests
Follow-up of https://github.com/JabRef/jabref/pull/16140
Fixes the failing [Run JabKit offline smoke tests](https://github.com/JabRef/jabref/actions/runs/28600582621/job/84807424254) job.

### PR Description

Fixes JabKit native-image failures caused by missing Caffeine reachability metadata after `AuthorList` started using a Caffeine cache. 

### Steps to test

Build the native image and run the offline smoke test:
```
./gradlew :jabkit:nativeCompile
cd jabkit && clitest src/test/nativeimage/jabkit-offline.md
```

### AI usage
Claude Code (model claude-opus-4-8)

### Checklist
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
