### PR TITLE
Document sync fork warning before submodule fix in FAQ

### DIFF
--- a/docs/code-howtos/faq.md
+++ b/docs/code-howtos/faq.md
@@ -123,6 +123,9 @@ What's strange (mostly an IntelliJ bug): Regardless of CLI or GUI, These changes
 
 For `abbrev.jabref.org`, `csl-styles`, `csl-locales`, and `ltwa`:
 
+**Note:** Before running the fix, ensure your fork is synced with upstream.
+See [Failing GitHub workflow "Sync fork with upstream"](#failing-github-workflow-sync-fork-with-upstream).
+
 ```bash
 git merge origin/main
 git checkout main -- jablib/src/main/abbrv.jabref.org

--- a/docs/code-howtos/faq.md
+++ b/docs/code-howtos/faq.md
@@ -126,10 +126,10 @@ For `abbrev.jabref.org`, `csl-styles`, `csl-locales`, and `ltwa`:
 ```bash
 git fetch upstream --prune
 git merge upstream/main
-git checkout main -- jablib/src/main/abbrv.jabref.org
-git checkout main -- jablib/src/main/resources/csl-styles
-git checkout main -- jablib/src/main/resources/csl-locales
-git checkout main -- jablib/src/main/resources/ltwa
+git checkout upstream/main -- jablib/src/main/abbrv.jabref.org
+git checkout upstream/main -- jablib/src/main/resources/csl-styles
+git checkout upstream/main -- jablib/src/main/resources/csl-locales
+git checkout upstream/main -- jablib/src/main/resources/ltwa
 git commit -m "Fix submodules"
 git push
 ```

--- a/docs/code-howtos/faq.md
+++ b/docs/code-howtos/faq.md
@@ -123,11 +123,9 @@ What's strange (mostly an IntelliJ bug): Regardless of CLI or GUI, These changes
 
 For `abbrev.jabref.org`, `csl-styles`, `csl-locales`, and `ltwa`:
 
-**Note:** Before running the fix, ensure your fork is synced with upstream.
-See [Failing GitHub workflow "Sync fork with upstream"](#failing-github-workflow-sync-fork-with-upstream).
-
 ```bash
-git merge origin/main
+git fetch upstream --prune
+git merge upstream/main
 git checkout main -- jablib/src/main/abbrv.jabref.org
 git checkout main -- jablib/src/main/resources/csl-styles
 git checkout main -- jablib/src/main/resources/csl-locales


### PR DESCRIPTION
### Related issues and pull requests



### PR Description

Added a note to the submodules fix section in the FAQ warning contributors **to sync their fork with upstream** before running the fix commands. 
This **prevents** unintended changes appearing in PRs due to an outdated origin/main.

### Steps to test

1. Open the changed `docs/code-howtos/faq.md` file in this PR
2. Verify the note appears before the fix commands in the submodules section
3. Confirm the link points correctly to the "Sync fork with upstream" section 

### AI usage

Claude (Claude Sonnet 4.6) — used for code review, understanding issue scope, and double-checking changes.


### Checklist


- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
