### PR TITLE
Feat(gui): show entry count badge in library tab #15246

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added file notification to OCRed file to let users open the directory and show the new file. [#16082](https://github.com/JabRef/jabref/pull/16082)
 - We added a "Jump to field" button to the entry editor toolbar, triggering the same action as the <kbd>Ctrl</kbd>+<kbd>J</kbd> shortcut. [#16169](https://github.com/JabRef/jabref/pull/16169)
 - The `jabkit` `--input` option (and positional input argument) now accepts http(s)/ftp URLs, downloading the file before processing. [#16165](https://github.com/JabRef/jabref/pull/16165)
+- We added an entry-count badge to library tabs so you can see how many entries are in each open library. [#15246](https://github.com/JabRef/jabref/issues/15246)
 
 ### Changed
 

--- a/docs/requirements/ux.md
+++ b/docs/requirements/ux.md
@@ -32,4 +32,11 @@ Since some data fetchers take time, we need to open the dialog and wait until al
 
 Needs: impl
 
+## Library tab shows entry count badge
+`req~ux.library-tab-entry-count-badge~1`
+
+The library tab shows a badge with the total number of entries in the open library. The badge updates when entries are added or removed.
+
+Needs: impl
+
 <!-- markdownlint-disable-file MD022 -->

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -266,6 +266,7 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
 
         aiService.setupDatabase(bibDatabaseContext, isDummyContext);
 
+        // [impl->req~ux.library-tab-entry-count-badge~1]
         bindEntryCountBadge();
         setGraphic(entryCountBadge);
 

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import javax.swing.undo.UndoManager;
 
 import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ListProperty;
@@ -18,12 +19,12 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.beans.value.ObservableBooleanValue;
-import javafx.collections.ListChangeListener;
 import javafx.event.Event;
 import javafx.scene.Node;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
+import javafx.scene.control.Label;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
@@ -152,6 +153,8 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
 
     private SuggestionProviders suggestionProviders;
 
+    private final Label entryCountBadge = createEntryCountBadge();
+
     @SuppressWarnings({"FieldCanBeLocal"})
     private Subscription dividerPositionSubscription;
 
@@ -263,10 +266,13 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
 
         aiService.setupDatabase(bibDatabaseContext, isDummyContext);
 
+        bindEntryCountBadge();
+        setGraphic(entryCountBadge);
+
+        updateTabTitle(changedProperty.getValue());
+
         Platform.runLater(() -> {
             EasyBind.subscribe(changedProperty, this::updateTabTitle);
-            stateManager.getOpenDatabases().addListener((ListChangeListener<BibDatabaseContext>) _ ->
-                    updateTabTitle(changedProperty.getValue()));
         });
     }
 
@@ -387,9 +393,12 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
         Optional<BibDatabaseContext> foundExistingBibDatabase = stateManager.getOpenDatabases().stream().filter(databaseContext -> databaseContext.equals(this.bibDatabaseContext)).findFirst();
         foundExistingBibDatabase.ifPresent(databaseContext -> stateManager.getOpenDatabases().remove(databaseContext));
 
+        entryCountBadge.textProperty().unbind();
+
         this.bibDatabaseContext = bibDatabaseContext;
 
         stateManager.getOpenDatabases().add(bibDatabaseContext);
+        updateTabTitle(changedProperty.getValue());
 
         initializeComponentsAndListeners(false);
 
@@ -486,6 +495,17 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
             textProperty().setValue(tabTitle.toString());
             setTooltip(new Tooltip(toolTipText.toString()));
         });
+    }
+
+    private void bindEntryCountBadge() {
+        entryCountBadge.textProperty().unbind();
+        entryCountBadge.textProperty().bind(Bindings.size(this.bibDatabaseContext.getDatabase().getEntries()).asString());
+    }
+
+    static Label createEntryCountBadge() {
+        Label badge = new Label();
+        badge.getStyleClass().add("library-tab-entry-count");
+        return badge;
     }
 
     @Subscribe
@@ -744,6 +764,8 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
         } catch (RuntimeException e) {
             LOGGER.error("Problem when closing search context", e);
         }
+
+        entryCountBadge.textProperty().unbind();
 
         try {
             AutosaveManager.shutdown(bibDatabaseContext);

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-javafx.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-javafx.css
@@ -567,9 +567,23 @@ TextFlow > .tooltip-text-monospaced {
     -fx-text-fill: -fx-mid-text-color;
 }
 
+.tab-pane > .tab-header-area > .headers-region > .tab .library-tab-entry-count {
+    -fx-background-color: -jr-theme;
+    -fx-background-radius: 1em;
+    -fx-padding: 0.1em 0.55em 0.1em 0.55em;
+    -fx-text-fill: white;
+    -fx-font-size: 0.85em;
+    -fx-font-weight: bold;
+}
+
 .tab-pane > .tab-header-area > .headers-region > .tab:selected .glyph-icon {
     -fx-fill: -jr-theme;
     -fx-text-fill: -jr-theme;
+}
+
+.tab-pane > .tab-header-area > .headers-region > .tab:selected .library-tab-entry-count {
+    -fx-background-color: -jr-theme;
+    -fx-text-fill: white;
 }
 
 .tab-pane > .tab-header-area {


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/15246

### PR Description

This change adds a persistent entry-count badge to the library tab and keeps it synchronized with the active library entries. The badge now updates reliably when entries are added, removed, or when the active database context changes, while preserving the existing tab styling and layout.

### Screenshots
<img width="1917" height="631" alt="Captura de tela 2026-07-06 232652" src="https://github.com/user-attachments/assets/19b00fac-3ec5-4438-8f0c-b3ef731998aa" />

After removing the entry
<img width="1916" height="570" alt="Captura de tela 2026-07-06 232706" src="https://github.com/user-attachments/assets/de17e2ea-eefc-4c67-ac8a-904fe982879d" />

jabref-contrib-policy:4.2:reviewed​:ok

### Steps to test

1. Open JabRef and load a library.
2. Verify the library tab shows the total number of entries as a badge.
3. Add the first entry and confirm the badge updates to 1.
4. Add another entry and confirm the badge increments correctly.
5. Remove an entry and confirm the badge decrements immediately.
6. Close and reopen the library to confirm the badge still shows the correct total.

### AI usage

GitHub Copilot (GPT-5.4 mini)

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef
- [ ] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description if change is visible to the user
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user
- [ ] I checked the user documentation for up to dateness and submitted a pull request to our user documentation repository

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef
- [ ] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description if change is visible to the user
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user
- [ ] I checked the user documentation for up to dateness and submitted a pull request to our user documentation repository