### PR TITLE
Migrate JabRefGuiPreferences to PreferenceBindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where no raw preferences values were visible anymore in the preferences filter [#16161](https://github.com/JabRef/jabref/pull/16161)
+- We fixed an issue where no raw preferences values were visible anymore in the preferences filter. [#16161](https://github.com/JabRef/jabref/pull/16161)
 - We fixed an issue where cleanup did not detect an arXiv entry when its `url` field ended with a fragment anchor (e.g. `https://arxiv.org/html/2510.26275v2#bib`). [#16150](https://github.com/JabRef/jabref/pull/16150)
 - We fixed an issue where fetchers sent an empty API-key parameter (e.g. `api_key=`) to the remote service when no key was configured. [#16044](https://github.com/JabRef/jabref/pull/16044)
 - We fixed an issue where the global search dialog kept showing the previous entry preview when the search returned no results. [#15613](https://github.com/JabRef/jabref/issues/15613)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where no raw preferences values were visible anymore in the preferences filter [#16161](https://github.com/JabRef/jabref/pull/16161)
 - We fixed an issue where cleanup did not detect an arXiv entry when its `url` field ended with a fragment anchor (e.g. `https://arxiv.org/html/2510.26275v2#bib`). [#16150](https://github.com/JabRef/jabref/pull/16150)
 - We fixed an issue where fetchers sent an empty API-key parameter (e.g. `api_key=`) to the remote service when no key was configured. [#16044](https://github.com/JabRef/jabref/pull/16044)
 - We fixed an issue where the global search dialog kept showing the previous entry preview when the search returned no results. [#15613](https://github.com/JabRef/jabref/issues/15613)

--- a/jabgui/src/main/java/org/jabref/gui/CoreGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/CoreGuiPreferences.java
@@ -48,16 +48,6 @@ public class CoreGuiPreferences {
         return new CoreGuiPreferences();
     }
 
-    public void setAll(CoreGuiPreferences preferences) {
-        this.positionX.set(preferences.getPositionX());
-        this.positionY.set(preferences.getPositionY());
-        this.sizeX.set(preferences.getSizeX());
-        this.sizeY.set(preferences.getSizeY());
-        this.windowMaximised.set(preferences.isWindowMaximised());
-        this.horizontalDividerPosition.set(preferences.getHorizontalDividerPosition());
-        this.verticalDividerPosition.set(preferences.getVerticalDividerPosition());
-    }
-
     public double getPositionX() {
         return positionX.get();
     }

--- a/jabgui/src/main/java/org/jabref/gui/WorkspacePreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/WorkspacePreferences.java
@@ -69,19 +69,6 @@ public class WorkspacePreferences {
         return new WorkspacePreferences();
     }
 
-    public void setAll(WorkspacePreferences preferences) {
-        this.language.set(preferences.getLanguage());
-        this.shouldOverrideDefaultFontSize.set(preferences.shouldOverrideDefaultFontSize());
-        this.mainFontSize.set(preferences.getMainFontSize());
-        this.theme.set(preferences.getTheme());
-        this.themeSyncOs.set(preferences.shouldThemeSyncOs());
-        this.shouldOpenLastEdited.set(preferences.shouldOpenLastEdited());
-        this.showAdvancedHints.set(preferences.shouldShowAdvancedHints());
-        this.confirmDelete.set(preferences.shouldConfirmDelete());
-        this.confirmHideTabBar.set(preferences.shouldHideTabBar());
-        this.selectedSlrCatalogs.setAll(preferences.getSelectedSlrCatalogs());
-    }
-
     public Language getLanguage() {
         return language.get();
     }

--- a/jabgui/src/main/java/org/jabref/gui/autocompleter/AutoCompletePreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/autocompleter/AutoCompletePreferences.java
@@ -56,13 +56,6 @@ public class AutoCompletePreferences {
         return new AutoCompletePreferences();
     }
 
-    public void setAll(AutoCompletePreferences preferences) {
-        this.shouldAutoComplete.set(preferences.shouldAutoComplete());
-        this.firstNameMode.set(preferences.getFirstNameMode());
-        this.nameFormat.set(preferences.getNameFormat());
-        this.completeFields.addAll(preferences.getCompleteFields());
-    }
-
     public boolean shouldAutoComplete() {
         return shouldAutoComplete.get();
     }

--- a/jabgui/src/main/java/org/jabref/gui/edit/CopyToPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/edit/CopyToPreferences.java
@@ -23,11 +23,6 @@ public class CopyToPreferences {
         return new CopyToPreferences();
     }
 
-    public void setAll(CopyToPreferences other) {
-        this.shouldIncludeCrossReferences.set(other.getShouldIncludeCrossReferences());
-        this.shouldAskForIncludingCrossReferences.set(other.getShouldAskForIncludingCrossReferences());
-    }
-
     public boolean getShouldIncludeCrossReferences() {
         return shouldIncludeCrossReferences.get();
     }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditorPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditorPreferences.java
@@ -159,20 +159,6 @@ public class EntryEditorPreferences {
         return new EntryEditorPreferences();
     }
 
-    public void setAll(EntryEditorPreferences preferences) {
-        tabModels.setAll(preferences.getTabModels());
-        this.shouldOpenOnNewEntry.set(preferences.shouldOpenOnNewEntry());
-        this.showSourceTabByDefault.set(preferences.showSourceTabByDefault());
-        this.enableValidation.set(preferences.shouldEnableValidation());
-        this.allowIntegerEditionBibtex.set(preferences.shouldAllowIntegerEditionBibtex());
-        this.autoLinkFiles.set(preferences.autoLinkFilesEnabled());
-        this.enablementStatus.set(preferences.shouldEnableJournalPopup());
-        this.citationFetcherType.set(preferences.getCitationFetcherType());
-        this.citationCountFetcherType.set(preferences.getCitationCountFetcherType());
-        this.showUserCommentsFields.set(preferences.shouldShowUserCommentsFields());
-        this.previewWidthDividerPosition.set(preferences.getPreviewWidthDividerPosition());
-    }
-
     public ObservableList<EntryEditorTabModel> getTabModels() {
         return tabModels;
     }

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogPreferences.java
@@ -34,12 +34,6 @@ public class UnlinkedFilesDialogPreferences {
         return new UnlinkedFilesDialogPreferences();
     }
 
-    public void setAll(UnlinkedFilesDialogPreferences preferences) {
-        this.unlinkedFilesSelectedExtension.set(preferences.getUnlinkedFilesSelectedExtension());
-        this.unlinkedFilesSelectedDateRange.set(preferences.getUnlinkedFilesSelectedDateRange());
-        this.unlinkedFilesSelectedSort.set(preferences.getUnlinkedFilesSelectedSort());
-    }
-
     public String getUnlinkedFilesSelectedExtension() {
         return unlinkedFilesSelectedExtension.get();
     }

--- a/jabgui/src/main/java/org/jabref/gui/frame/ExternalApplicationsPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/ExternalApplicationsPreferences.java
@@ -66,22 +66,6 @@ public class ExternalApplicationsPreferences {
         return new ExternalApplicationsPreferences();
     }
 
-    public void setAll(ExternalApplicationsPreferences preferences) {
-        this.eMailSubject.set(preferences.getEmailSubject());
-        this.shouldAutoOpenEmailAttachmentsFolder.set(preferences.shouldAutoOpenEmailAttachmentsFolder());
-
-        this.useCustomTerminal.set(preferences.useCustomTerminal());
-        this.customTerminalCommand.set(preferences.getCustomTerminalCommand());
-
-        this.useCustomFileBrowser.set(preferences.useCustomFileBrowser());
-        this.customFileBrowserCommand.set(preferences.getCustomFileBrowserCommand());
-
-        this.kindleEmail.set(preferences.getKindleEmail());
-
-        this.externalFileTypes.clear();
-        this.externalFileTypes.addAll(preferences.getExternalFileTypes());
-    }
-
     public String getEmailSubject() {
         return eMailSubject.get();
     }

--- a/jabgui/src/main/java/org/jabref/gui/frame/SidePanePreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/SidePanePreferences.java
@@ -69,10 +69,4 @@ public class SidePanePreferences {
     public void setWebSearchFetcherSelected(int webSearchFetcherSelected) {
         this.webSearchFetcherSelected.set(webSearchFetcherSelected);
     }
-
-    public void setAll(SidePanePreferences preferences) {
-        this.setVisiblePanes(preferences.visiblePanes());
-        this.setPreferredPositions(preferences.getPreferredPositions());
-        this.webSearchFetcherSelected.set(preferences.getWebSearchFetcherSelected());
-    }
 }

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupsPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupsPreferences.java
@@ -76,13 +76,6 @@ public class GroupsPreferences {
         return new GroupsPreferences();
     }
 
-    public void setAll(GroupsPreferences preferences) {
-        this.groupViewMode.set(preferences.groupViewMode);
-        this.shouldAutoAssignGroup.set(preferences.shouldAutoAssignGroup());
-        this.shouldDisplayGroupCount.set(preferences.shouldDisplayGroupCount());
-        this.defaultHierarchicalContext.set(preferences.getDefaultHierarchicalContext());
-    }
-
     public EnumSet<GroupViewMode> getGroupViewMode() {
         if (groupViewMode.isEmpty()) {
             return EnumSet.noneOf(GroupViewMode.class);

--- a/jabgui/src/main/java/org/jabref/gui/maintable/ColumnPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/ColumnPreferences.java
@@ -45,11 +45,6 @@ public class ColumnPreferences {
         return new ColumnPreferences();
     }
 
-    public void setAll(ColumnPreferences columnPreferences) {
-        this.columns.addAll(columnPreferences.getColumns());
-        this.columnSortOrder.addAll(columnPreferences.getColumnSortOrder());
-    }
-
     public ObservableList<MainTableColumnModel> getColumns() {
         return columns;
     }

--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTablePreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTablePreferences.java
@@ -29,13 +29,6 @@ public class MainTablePreferences {
         return new MainTablePreferences();
     }
 
-    public void setAll(MainTablePreferences preferences) {
-        this.columnPreferences.setColumns(preferences.getColumnPreferences().getColumns());
-        this.columnPreferences.setColumnSortOrder(preferences.getColumnPreferences().getColumnSortOrder());
-        this.setResizeColumnsToFit(preferences.getResizeColumnsToFit());
-        this.setExtraFileColumnsEnabled(preferences.getExtraFileColumnsEnabled());
-    }
-
     public ColumnPreferences getColumnPreferences() {
         return columnPreferences;
     }

--- a/jabgui/src/main/java/org/jabref/gui/maintable/NameDisplayPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/NameDisplayPreferences.java
@@ -33,11 +33,6 @@ public class NameDisplayPreferences {
         return new NameDisplayPreferences();
     }
 
-    public void setAll(NameDisplayPreferences preferences) {
-        this.displayStyle.set(preferences.displayStyle.get());
-        this.abbreviationStyle.set(preferences.abbreviationStyle.get());
-    }
-
     public DisplayStyle getDisplayStyle() {
         return displayStyle.get();
     }

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/MergeDialogPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/MergeDialogPreferences.java
@@ -47,16 +47,6 @@ public class MergeDialogPreferences {
         return new MergeDialogPreferences();
     }
 
-    public void setAll(MergeDialogPreferences preferences) {
-        this.setMergeDiffMode(preferences.getMergeDiffMode());
-        this.setMergeShouldShowDiff(preferences.getMergeShouldShowDiff());
-        this.setMergeShouldShowUnifiedDiff(preferences.getMergeShouldShowUnifiedDiff());
-        this.setMergeHighlightWords(preferences.getMergeHighlightWords());
-        this.setMergeShowChangedFieldsOnly(preferences.shouldMergeShowChangedFieldsOnly());
-        this.setIsMergeApplyToAllEntries(preferences.shouldMergeApplyToAllEntries());
-        this.setAllEntriesDuplicateResolverDecision(preferences.getAllEntriesDuplicateResolverDecision());
-    }
-
     public DiffMode getMergeDiffMode() {
         return mergeDiffMode.get();
     }

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryPreferences.java
@@ -57,17 +57,6 @@ public class NewEntryPreferences {
         return new NewEntryPreferences();
     }
 
-    public void setAll(NewEntryPreferences other) {
-        this.latestApproach.set(other.getLatestApproach());
-        this.typesRecommendedExpanded.set(other.getTypesRecommendedExpanded());
-        this.typesOtherExpanded.set(other.getTypesOtherExpanded());
-        this.typesCustomExpanded.set(other.getTypesCustomExpanded());
-        this.latestImmediateType.set(other.getLatestImmediateType());
-        this.idLookupGuessing.set(other.getIdLookupGuessing());
-        this.latestIdFetcherName.set(other.getLatestIdFetcher());
-        this.latestInterpretParserName.set(other.getLatestInterpretParser());
-    }
-
     public NewEntryDialogTab getLatestApproach() {
         return latestApproach.get();
     }

--- a/jabgui/src/main/java/org/jabref/gui/preferences/DonationPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/DonationPreferences.java
@@ -25,11 +25,6 @@ public class DonationPreferences {
         return new DonationPreferences();
     }
 
-    public void setAll(DonationPreferences preferences) {
-        this.neverShowAgain.set(preferences.isNeverShowAgain());
-        this.lastShownEpochDay.set(preferences.getLastShownEpochDay());
-    }
-
     public boolean isNeverShowAgain() {
         return neverShowAgain.get();
     }

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -293,6 +293,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getCopyToPreferences();
         getEntryEditorPreferences();
         getMergeDialogPreferences();
+        getAutoCompletePreferences();
 
         super.clear();
 
@@ -307,7 +308,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getSearchDialogColumnPreferences().setAll(ColumnPreferences.getDefault());
         getUnlinkedFilesDialogPreferences().setAll(UnlinkedFilesDialogPreferences.getDefault());
         getWorkspacePreferences().setAll(WorkspacePreferences.getDefault());
-        getAutoCompletePreferences().setAll(AutoCompletePreferences.getDefault());
         getSidePanePreferences().setAll(SidePanePreferences.getDefault());
         getNameDisplayPreferences().setAll(NameDisplayPreferences.getDefault());
         getPreviewPreferences().setAll(PreviewPreferences.getDefaultWithStyles(
@@ -323,6 +323,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getCopyToPreferences();
         getEntryEditorPreferences();
         getMergeDialogPreferences();
+        getAutoCompletePreferences();
 
         super.importPreferences(path);
 
@@ -338,7 +339,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getSearchDialogColumnPreferences().setAll(getSearchDialogColumnPreferencesFromBackingStore(getSearchDialogColumnPreferences()));
         getUnlinkedFilesDialogPreferences().setAll(getUnlinkedFilesDialogPreferences());
         getWorkspacePreferences().setAll(getWorkspacePreferencesFromBackingStore(getWorkspacePreferences()));
-        getAutoCompletePreferences().setAll(getAutoCompletePreferencesFromBackingStore(getAutoCompletePreferences()));
         getSidePanePreferences().setAll(getSidePanePreferencesFromBackingStore(getSidePanePreferences()));
         getNameDisplayPreferences().setAll(getNameDisplayPreferencesFromBackingStore(getNameDisplayPreferences()));
         getPreviewPreferences().setAll(getPreviewPreferencesFromBackingStore(getPreviewPreferences()));
@@ -568,44 +568,29 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return autoCompletePreferences;
         }
 
-        autoCompletePreferences = getAutoCompletePreferencesFromBackingStore(AutoCompletePreferences.getDefault());
+        AutoCompletePreferences defaultValues = AutoCompletePreferences.getDefault();
 
-        EasyBind.listen(autoCompletePreferences.autoCompleteProperty(), (_, _, newValue) -> putBoolean(AUTO_COMPLETE, newValue));
-        EasyBind.listen(autoCompletePreferences.firstNameModeProperty(), (_, _, newValue) -> put(AUTOCOMPLETER_FIRSTNAME_MODE, newValue.name()));
-        autoCompletePreferences.getCompleteFields().addListener((SetChangeListener<Field>) _ ->
-                putStringList(AUTOCOMPLETER_COMPLETE_FIELDS, autoCompletePreferences.getCompleteFields().stream()
-                                                                                    .map(Field::getName)
-                                                                                    .collect(Collectors.toList())));
-        EasyBind.listen(autoCompletePreferences.nameFormatProperty(), (_, _, _) -> {
-            if (autoCompletePreferences.getNameFormat() == AutoCompletePreferences.NameFormat.BOTH) {
-                putBoolean(AUTOCOMPLETER_LAST_FIRST, false);
-                putBoolean(AUTOCOMPLETER_FIRST_LAST, false);
-            } else if (autoCompletePreferences.getNameFormat() == AutoCompletePreferences.NameFormat.LAST_FIRST) {
-                putBoolean(AUTOCOMPLETER_LAST_FIRST, true);
-                putBoolean(AUTOCOMPLETER_FIRST_LAST, false);
-            } else {
-                putBoolean(AUTOCOMPLETER_LAST_FIRST, false);
-                putBoolean(AUTOCOMPLETER_FIRST_LAST, true);
-            }
-        });
+        autoCompletePreferences = new AutoCompletePreferences(
+                getBoolean(AUTO_COMPLETE, defaultValues.shouldAutoComplete()),
+                AutoCompleteFirstNameMode.parse(get(AUTOCOMPLETER_FIRSTNAME_MODE, defaultValues.getFirstNameMode().name())),
+                readExclusiveFlags(defaultValues.getNameFormat(), AutoCompletePreferences.NameFormat.BOTH,
+                        Map.entry(AUTOCOMPLETER_LAST_FIRST, AutoCompletePreferences.NameFormat.LAST_FIRST),
+                        Map.entry(AUTOCOMPLETER_FIRST_LAST, AutoCompletePreferences.NameFormat.FIRST_LAST)),
+                getFieldSequencedSet(AUTOCOMPLETER_COMPLETE_FIELDS, defaultValues.getCompleteFields()));
+
+        bindBoolean(autoCompletePreferences.autoCompleteProperty(), AUTO_COMPLETE, defaultValues.shouldAutoComplete());
+        bindObject(autoCompletePreferences.firstNameModeProperty(), AUTOCOMPLETER_FIRSTNAME_MODE, defaultValues.getFirstNameMode(),
+                AutoCompleteFirstNameMode::name, AutoCompleteFirstNameMode::parse);
+        // NameFormat.BOTH is the implicit value (both flags stored false); LAST_FIRST wins over FIRST_LAST on the
+        // non-canonical "both true" state, per readExclusiveFlags.
+        bindExclusiveFlags(autoCompletePreferences.nameFormatProperty(), defaultValues.getNameFormat(), AutoCompletePreferences.NameFormat.BOTH,
+                Map.entry(AUTOCOMPLETER_LAST_FIRST, AutoCompletePreferences.NameFormat.LAST_FIRST),
+                Map.entry(AUTOCOMPLETER_FIRST_LAST, AutoCompletePreferences.NameFormat.FIRST_LAST));
+        bindSet(autoCompletePreferences.getCompleteFields(), AUTOCOMPLETER_COMPLETE_FIELDS, defaultValues.getCompleteFields(),
+                set -> putStringList(AUTOCOMPLETER_COMPLETE_FIELDS, set.stream().map(Field::getName).collect(Collectors.toList())),
+                () -> getFieldSequencedSet(AUTOCOMPLETER_COMPLETE_FIELDS, defaultValues.getCompleteFields()));
 
         return autoCompletePreferences;
-    }
-
-    private AutoCompletePreferences getAutoCompletePreferencesFromBackingStore(AutoCompletePreferences defaults) {
-        AutoCompletePreferences.NameFormat nameFormat = defaults.getNameFormat();
-        final boolean firstLast = getBoolean(AUTOCOMPLETER_FIRST_LAST, false);
-        final boolean lastFirst = getBoolean(AUTOCOMPLETER_LAST_FIRST, false);
-        if (firstLast && !lastFirst) {
-            nameFormat = AutoCompletePreferences.NameFormat.FIRST_LAST;
-        } else if (!firstLast && lastFirst) {
-            nameFormat = AutoCompletePreferences.NameFormat.LAST_FIRST;
-        }
-
-        return new AutoCompletePreferences(getBoolean(AUTO_COMPLETE, defaults.shouldAutoComplete()),
-                AutoCompleteFirstNameMode.parse(get(AUTOCOMPLETER_FIRSTNAME_MODE, defaults.getFirstNameMode().name())),
-                nameFormat,
-                getFieldSequencedSet(AUTOCOMPLETER_COMPLETE_FIELDS, defaults.getCompleteFields()));
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -2,6 +2,7 @@ package org.jabref.gui.preferences;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -824,7 +825,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     }
 
     private Set<GroupViewMode> getGroupViewModes(GroupsPreferences defaults) {
-        Set<GroupViewMode> modes = new HashSet<>();
+        Set<GroupViewMode> modes = EnumSet.noneOf(GroupViewMode.class);
         if (getBoolean(GROUP_VIEW_INTERSECTION, defaults.groupViewModeProperty().contains(GroupViewMode.INTERSECTION))) {
             modes.add(GroupViewMode.INTERSECTION);
         }

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -808,17 +808,9 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
 
         bindString(externalApplicationsPreferences.eMailSubjectProperty(), EMAIL_SUBJECT, defaultValues.getEmailSubject());
         bindBoolean(externalApplicationsPreferences.autoOpenEmailAttachmentsFolderProperty(), OPEN_FOLDERS_OF_ATTACHED_FILES, defaultValues.shouldAutoOpenEmailAttachmentsFolder());
-        // useCustomTerminal is persisted inverted, under the legacy USE_DEFAULT_CONSOLE_APPLICATION key.
-        bindCustom(externalApplicationsPreferences.useCustomTerminalProperty(), USE_DEFAULT_CONSOLE_APPLICATION, defaultValues.useCustomTerminal(),
-                (_, _, newValue) -> putBoolean(USE_DEFAULT_CONSOLE_APPLICATION, !newValue),
-                () -> externalApplicationsPreferences.useCustomTerminalProperty().set(!getBoolean(USE_DEFAULT_CONSOLE_APPLICATION, !defaultValues.useCustomTerminal())),
-                () -> externalApplicationsPreferences.useCustomTerminalProperty().set(defaultValues.useCustomTerminal()));
+        bindBooleanInverted(externalApplicationsPreferences.useCustomTerminalProperty(), USE_DEFAULT_CONSOLE_APPLICATION, defaultValues.useCustomTerminal());
         bindString(externalApplicationsPreferences.customTerminalCommandProperty(), CONSOLE_COMMAND, defaultValues.getCustomTerminalCommand());
-        // useCustomFileBrowser is persisted inverted, under the legacy USE_DEFAULT_FILE_BROWSER_APPLICATION key.
-        bindCustom(externalApplicationsPreferences.useCustomFileBrowserProperty(), USE_DEFAULT_FILE_BROWSER_APPLICATION, defaultValues.useCustomFileBrowser(),
-                (_, _, newValue) -> putBoolean(USE_DEFAULT_FILE_BROWSER_APPLICATION, !newValue),
-                () -> externalApplicationsPreferences.useCustomFileBrowserProperty().set(!getBoolean(USE_DEFAULT_FILE_BROWSER_APPLICATION, !defaultValues.useCustomFileBrowser())),
-                () -> externalApplicationsPreferences.useCustomFileBrowserProperty().set(defaultValues.useCustomFileBrowser()));
+        bindBooleanInverted(externalApplicationsPreferences.useCustomFileBrowserProperty(), USE_DEFAULT_FILE_BROWSER_APPLICATION, defaultValues.useCustomFileBrowser());
         bindString(externalApplicationsPreferences.customFileBrowserCommandProperty(), FILE_BROWSER_COMMAND, defaultValues.getCustomFileBrowserCommand());
         bindString(externalApplicationsPreferences.kindleEmailProperty(), KINDLE_EMAIL, defaultValues.getKindleEmail());
         bindSet(externalApplicationsPreferences.getExternalFileTypes(), EXTERNAL_FILE_TYPES, defaultValues.getExternalFileTypes(),

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -305,11 +305,11 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getSidePanePreferences();
         getExternalApplicationsPreferences();
         getGroupsPreferences();
+        getSpecialFieldsPreferences();
 
         super.clear();
 
         getDonationPreferences().setAll(DonationPreferences.getDefault());
-        getSpecialFieldsPreferences().setAll(SpecialFieldsPreferences.getDefault());
         getMainTableColumnPreferences().setAll(ColumnPreferences.getDefault());
         getMainTablePreferences().setAll(MainTablePreferences.getDefault());
         getNewEntryPreferences().setAll(NewEntryPreferences.getDefault());
@@ -335,12 +335,12 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getSidePanePreferences();
         getExternalApplicationsPreferences();
         getGroupsPreferences();
+        getSpecialFieldsPreferences();
 
         super.importPreferences(path);
 
         // in case of incomplete or corrupt xml fall back to current preferences
         getDonationPreferences().setAll(getDonationPreferencesFromBackingStore(getDonationPreferences()));
-        getSpecialFieldsPreferences().setAll(getSpecialFieldsPreferencesFromBackingStore(getSpecialFieldsPreferences()));
         getMainTableColumnPreferences().setAll(getMainTableColumnPreferencesFromBackingStore(getMainTableColumnPreferences()));
         getMainTablePreferences().setAll(getMainTablePreferencesFromBackingStore(getMainTablePreferences()));
         getNewEntryPreferences().setAll(getNewEntryPreferencesFromBackingStore(getNewEntryPreferences()));
@@ -882,17 +882,15 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return specialFieldsPreferences;
         }
 
-        specialFieldsPreferences = getSpecialFieldsPreferencesFromBackingStore(SpecialFieldsPreferences.getDefault());
+        SpecialFieldsPreferences defaultValues = SpecialFieldsPreferences.getDefault();
 
-        EasyBind.listen(specialFieldsPreferences.specialFieldsEnabledProperty(), (_, _, newValue) -> putBoolean(SPECIALFIELDSENABLED, newValue));
+        specialFieldsPreferences = new SpecialFieldsPreferences(
+                getBoolean(SPECIALFIELDSENABLED, defaultValues.isSpecialFieldsEnabled())
+        );
+
+        bindBoolean(specialFieldsPreferences.specialFieldsEnabledProperty(), SPECIALFIELDSENABLED, defaultValues.isSpecialFieldsEnabled());
 
         return specialFieldsPreferences;
-    }
-
-    private SpecialFieldsPreferences getSpecialFieldsPreferencesFromBackingStore(SpecialFieldsPreferences defaults) {
-        return new SpecialFieldsPreferences(
-                getBoolean(SPECIALFIELDSENABLED, defaults.isSpecialFieldsEnabled())
-        );
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -295,6 +295,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getAutoCompletePreferences();
         getGuiPreferences();
         getWorkspacePreferences();
+        getUnlinkedFilesDialogPreferences();
 
         super.clear();
 
@@ -306,7 +307,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getMainTablePreferences().setAll(MainTablePreferences.getDefault());
         getNewEntryPreferences().setAll(NewEntryPreferences.getDefault());
         getSearchDialogColumnPreferences().setAll(ColumnPreferences.getDefault());
-        getUnlinkedFilesDialogPreferences().setAll(UnlinkedFilesDialogPreferences.getDefault());
         getSidePanePreferences().setAll(SidePanePreferences.getDefault());
         getNameDisplayPreferences().setAll(NameDisplayPreferences.getDefault());
         getPreviewPreferences().setAll(PreviewPreferences.getDefaultWithStyles(
@@ -325,6 +325,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getAutoCompletePreferences();
         getGuiPreferences();
         getWorkspacePreferences();
+        getUnlinkedFilesDialogPreferences();
 
         super.importPreferences(path);
 
@@ -337,7 +338,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getMainTablePreferences().setAll(getMainTablePreferencesFromBackingStore(getMainTablePreferences()));
         getNewEntryPreferences().setAll(getNewEntryPreferencesFromBackingStore(getNewEntryPreferences()));
         getSearchDialogColumnPreferences().setAll(getSearchDialogColumnPreferencesFromBackingStore(getSearchDialogColumnPreferences()));
-        getUnlinkedFilesDialogPreferences().setAll(getUnlinkedFilesDialogPreferences());
         getSidePanePreferences().setAll(getSidePanePreferencesFromBackingStore(getSidePanePreferences()));
         getNameDisplayPreferences().setAll(getNameDisplayPreferencesFromBackingStore(getNameDisplayPreferences()));
         getPreviewPreferences().setAll(getPreviewPreferencesFromBackingStore(getPreviewPreferences()));
@@ -676,21 +676,21 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return unlinkedFilesDialogPreferences;
         }
 
-        unlinkedFilesDialogPreferences = getUnlinkedFilesDialogPreferencesFromBackingStore(UnlinkedFilesDialogPreferences.getDefault());
+        UnlinkedFilesDialogPreferences defaultValues = UnlinkedFilesDialogPreferences.getDefault();
 
-        EasyBind.listen(unlinkedFilesDialogPreferences.unlinkedFilesSelectedExtensionProperty(), (_, _, newValue) -> put(UNLINKED_FILES_SELECTED_EXTENSION, newValue));
-        EasyBind.listen(unlinkedFilesDialogPreferences.unlinkedFilesSelectedDateRangeProperty(), (_, _, newValue) -> put(UNLINKED_FILES_SELECTED_DATE_RANGE, newValue.name()));
-        EasyBind.listen(unlinkedFilesDialogPreferences.unlinkedFilesSelectedSortProperty(), (_, _, newValue) -> put(UNLINKED_FILES_SELECTED_SORT, newValue.name()));
+        unlinkedFilesDialogPreferences = new UnlinkedFilesDialogPreferences(
+                get(UNLINKED_FILES_SELECTED_EXTENSION, defaultValues.getUnlinkedFilesSelectedExtension()),
+                DateRange.parse(get(UNLINKED_FILES_SELECTED_DATE_RANGE, defaultValues.getUnlinkedFilesSelectedDateRange().name())),
+                ExternalFileSorter.parse(get(UNLINKED_FILES_SELECTED_SORT, defaultValues.getUnlinkedFilesSelectedSort().name()))
+        );
+
+        bindString(unlinkedFilesDialogPreferences.unlinkedFilesSelectedExtensionProperty(), UNLINKED_FILES_SELECTED_EXTENSION, defaultValues.getUnlinkedFilesSelectedExtension());
+        bindObject(unlinkedFilesDialogPreferences.unlinkedFilesSelectedDateRangeProperty(), UNLINKED_FILES_SELECTED_DATE_RANGE, defaultValues.getUnlinkedFilesSelectedDateRange(),
+                DateRange::name, DateRange::parse);
+        bindObject(unlinkedFilesDialogPreferences.unlinkedFilesSelectedSortProperty(), UNLINKED_FILES_SELECTED_SORT, defaultValues.getUnlinkedFilesSelectedSort(),
+                ExternalFileSorter::name, ExternalFileSorter::parse);
 
         return unlinkedFilesDialogPreferences;
-    }
-
-    private UnlinkedFilesDialogPreferences getUnlinkedFilesDialogPreferencesFromBackingStore(UnlinkedFilesDialogPreferences defaults) {
-        return new UnlinkedFilesDialogPreferences(
-                get(UNLINKED_FILES_SELECTED_EXTENSION, defaults.getUnlinkedFilesSelectedExtension()),
-                DateRange.parse(get(UNLINKED_FILES_SELECTED_DATE_RANGE, defaults.getUnlinkedFilesSelectedDateRange().name())),
-                ExternalFileSorter.parse(get(UNLINKED_FILES_SELECTED_SORT, defaults.getUnlinkedFilesSelectedSort().name()))
-        );
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -307,6 +307,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getGroupsPreferences();
         getSpecialFieldsPreferences();
         getPreviewPreferences();
+        getNameDisplayPreferences();
 
         super.clear();
 
@@ -315,7 +316,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getMainTablePreferences().setAll(MainTablePreferences.getDefault());
         getNewEntryPreferences().setAll(NewEntryPreferences.getDefault());
         getSearchDialogColumnPreferences().setAll(ColumnPreferences.getDefault());
-        getNameDisplayPreferences().setAll(NameDisplayPreferences.getDefault());
         getMrDlibPreferences().setAll(MrDlibPreferences.getDefault());
     }
 
@@ -334,6 +334,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getGroupsPreferences();
         getSpecialFieldsPreferences();
         getPreviewPreferences();
+        getNameDisplayPreferences();
 
         super.importPreferences(path);
 
@@ -343,7 +344,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getMainTablePreferences().setAll(getMainTablePreferencesFromBackingStore(getMainTablePreferences()));
         getNewEntryPreferences().setAll(getNewEntryPreferencesFromBackingStore(getNewEntryPreferences()));
         getSearchDialogColumnPreferences().setAll(getSearchDialogColumnPreferencesFromBackingStore(getSearchDialogColumnPreferences()));
-        getNameDisplayPreferences().setAll(getNameDisplayPreferencesFromBackingStore(getNameDisplayPreferences()));
         getMrDlibPreferences().setAll(getMrDlibPreferencesFromBackingStore(getMrDlibPreferences()));
     }
 
@@ -1006,59 +1006,28 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return nameDisplayPreferences;
         }
 
-        nameDisplayPreferences = getNameDisplayPreferencesFromBackingStore(NameDisplayPreferences.getDefault());
+        NameDisplayPreferences defaultValues = NameDisplayPreferences.getDefault();
 
-        EasyBind.listen(nameDisplayPreferences.displayStyleProperty(), (_, _, newValue) -> {
-            putBoolean(NAMES_NATBIB, newValue == NameDisplayPreferences.DisplayStyle.NATBIB);
-            putBoolean(NAMES_AS_IS, newValue == NameDisplayPreferences.DisplayStyle.AS_IS);
-            putBoolean(NAMES_FIRST_LAST, newValue == NameDisplayPreferences.DisplayStyle.FIRSTNAME_LASTNAME);
-        });
-        EasyBind.listen(nameDisplayPreferences.abbreviationStyleProperty(), (_, _, newValue) -> {
-            putBoolean(ABBR_AUTHOR_NAMES, newValue == NameDisplayPreferences.AbbreviationStyle.FULL);
-            putBoolean(NAMES_LAST_ONLY, newValue == NameDisplayPreferences.AbbreviationStyle.LASTNAME_ONLY);
-        });
+        nameDisplayPreferences = new NameDisplayPreferences(
+                readExclusiveFlags(defaultValues.getDisplayStyle(), NameDisplayPreferences.DisplayStyle.LASTNAME_FIRSTNAME,
+                        Map.entry(NAMES_NATBIB, NameDisplayPreferences.DisplayStyle.NATBIB),
+                        Map.entry(NAMES_AS_IS, NameDisplayPreferences.DisplayStyle.AS_IS),
+                        Map.entry(NAMES_FIRST_LAST, NameDisplayPreferences.DisplayStyle.FIRSTNAME_LASTNAME)),
+                readExclusiveFlags(defaultValues.getAbbreviationStyle(), NameDisplayPreferences.AbbreviationStyle.NONE,
+                        Map.entry(ABBR_AUTHOR_NAMES, NameDisplayPreferences.AbbreviationStyle.FULL),
+                        Map.entry(NAMES_LAST_ONLY, NameDisplayPreferences.AbbreviationStyle.LASTNAME_ONLY)));
+
+        // displayStyle: LASTNAME_FIRSTNAME is the implicit value (all flags stored false).
+        bindExclusiveFlags(nameDisplayPreferences.displayStyleProperty(), defaultValues.getDisplayStyle(), NameDisplayPreferences.DisplayStyle.LASTNAME_FIRSTNAME,
+                Map.entry(NAMES_NATBIB, NameDisplayPreferences.DisplayStyle.NATBIB),
+                Map.entry(NAMES_AS_IS, NameDisplayPreferences.DisplayStyle.AS_IS),
+                Map.entry(NAMES_FIRST_LAST, NameDisplayPreferences.DisplayStyle.FIRSTNAME_LASTNAME));
+        // abbreviationStyle: NONE is the implicit value (all flags stored false).
+        bindExclusiveFlags(nameDisplayPreferences.abbreviationStyleProperty(), defaultValues.getAbbreviationStyle(), NameDisplayPreferences.AbbreviationStyle.NONE,
+                Map.entry(ABBR_AUTHOR_NAMES, NameDisplayPreferences.AbbreviationStyle.FULL),
+                Map.entry(NAMES_LAST_ONLY, NameDisplayPreferences.AbbreviationStyle.LASTNAME_ONLY));
 
         return nameDisplayPreferences;
-    }
-
-    private NameDisplayPreferences getNameDisplayPreferencesFromBackingStore(NameDisplayPreferences defaults) {
-        return new NameDisplayPreferences(
-                getNameDisplayStyleFromBackingStore(defaults),
-                getNameAbbreviationStyleFromBackingStore(defaults)
-        );
-    }
-
-    private NameDisplayPreferences.DisplayStyle getNameDisplayStyleFromBackingStore(NameDisplayPreferences defaults) {
-        if (!hasKey(NAMES_NATBIB) && !hasKey(NAMES_AS_IS) && !hasKey(NAMES_FIRST_LAST)) {
-            return defaults.getDisplayStyle();
-        }
-
-        if (getBoolean(NAMES_NATBIB, false)) {
-            return NameDisplayPreferences.DisplayStyle.NATBIB;
-        }
-        if (getBoolean(NAMES_AS_IS, false)) {
-            return NameDisplayPreferences.DisplayStyle.AS_IS;
-        }
-        if (getBoolean(NAMES_FIRST_LAST, false)) {
-            return NameDisplayPreferences.DisplayStyle.FIRSTNAME_LASTNAME;
-        }
-
-        return NameDisplayPreferences.DisplayStyle.LASTNAME_FIRSTNAME;
-    }
-
-    private NameDisplayPreferences.AbbreviationStyle getNameAbbreviationStyleFromBackingStore(NameDisplayPreferences defaults) {
-        if (!hasKey(ABBR_AUTHOR_NAMES) && !hasKey(NAMES_LAST_ONLY)) {
-            return defaults.getAbbreviationStyle();
-        }
-
-        if (getBoolean(ABBR_AUTHOR_NAMES, false)) {
-            return NameDisplayPreferences.AbbreviationStyle.FULL;
-        }
-        if (getBoolean(NAMES_LAST_ONLY, false)) {
-            return NameDisplayPreferences.AbbreviationStyle.LASTNAME_ONLY;
-        }
-
-        return NameDisplayPreferences.AbbreviationStyle.NONE;
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -306,6 +306,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getExternalApplicationsPreferences();
         getGroupsPreferences();
         getSpecialFieldsPreferences();
+        getPreviewPreferences();
 
         super.clear();
 
@@ -315,10 +316,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getNewEntryPreferences().setAll(NewEntryPreferences.getDefault());
         getSearchDialogColumnPreferences().setAll(ColumnPreferences.getDefault());
         getNameDisplayPreferences().setAll(NameDisplayPreferences.getDefault());
-        getPreviewPreferences().setAll(PreviewPreferences.getDefaultWithStyles(
-                getLayoutFormatterPreferences(),
-                Injector.instantiateModelOrService(JournalAbbreviationRepository.class),
-                Injector.instantiateModelOrService(BibEntryTypesManager.class)));
         getMrDlibPreferences().setAll(MrDlibPreferences.getDefault());
     }
 
@@ -336,6 +333,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getExternalApplicationsPreferences();
         getGroupsPreferences();
         getSpecialFieldsPreferences();
+        getPreviewPreferences();
 
         super.importPreferences(path);
 
@@ -346,7 +344,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getNewEntryPreferences().setAll(getNewEntryPreferencesFromBackingStore(getNewEntryPreferences()));
         getSearchDialogColumnPreferences().setAll(getSearchDialogColumnPreferencesFromBackingStore(getSearchDialogColumnPreferences()));
         getNameDisplayPreferences().setAll(getNameDisplayPreferencesFromBackingStore(getNameDisplayPreferences()));
-        getPreviewPreferences().setAll(getPreviewPreferencesFromBackingStore(getPreviewPreferences()));
         getMrDlibPreferences().setAll(getMrDlibPreferencesFromBackingStore(getMrDlibPreferences()));
     }
 
@@ -900,43 +897,63 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return previewPreferences;
         }
 
-        this.previewPreferences = getPreviewPreferencesFromBackingStore(PreviewPreferences.getDefault());
+        // The layout cycle's default (and thus reset target) is the styled default; it needs the injected repositories.
+        PreviewPreferences defaultValues = PreviewPreferences.getDefaultWithStyles(
+                getLayoutFormatterPreferences(),
+                Injector.instantiateModelOrService(JournalAbbreviationRepository.class),
+                Injector.instantiateModelOrService(BibEntryTypesManager.class));
 
-        previewPreferences.getLayoutCycle().addListener((InvalidationListener) _ -> putStringList(PREVIEW_CYCLE, previewLayoutsToStrings(previewPreferences.getLayoutCycle())));
-        EasyBind.listen(previewPreferences.layoutCyclePositionProperty(), (_, _, newValue) -> putInt(PREVIEW_CYCLE_POS, newValue));
-        // must be stored with __NEWLINE__ instead of \n so that our migration correctly triggers, in getText it will be replaced by \n
-        EasyBind.listen(previewPreferences.customPreviewLayoutProperty(), (_, _, newValue) -> put(PREVIEW_STYLE, newValue.replace("\n", "__NEWLINE__")));
-        EasyBind.listen(previewPreferences.showPreviewAsExtraTabProperty(), (_, _, newValue) -> putBoolean(PREVIEW_AS_TAB, newValue));
-        EasyBind.listen(previewPreferences.showPreviewEntryTableTooltip(), (_, _, newValue) -> putBoolean(PREVIEW_IN_ENTRY_TABLE_TOOLTIP, newValue));
-        previewPreferences.getBstPreviewLayoutPaths().addListener((InvalidationListener) _ -> storeBstPaths(previewPreferences.getBstPreviewLayoutPaths()));
-        EasyBind.listen(previewPreferences.shouldDownloadCoversProperty(), (_, _, newValue) -> putBoolean(PREVIEW_COVER_IMAGE_DOWNLOAD, newValue));
-        return this.previewPreferences;
-    }
-
-    private PreviewPreferences getPreviewPreferencesFromBackingStore(PreviewPreferences defaults) {
         // Mutable lists required
-        String customPreviewLayout = get(PREVIEW_STYLE, defaults.getCustomPreviewLayout());
+        String customPreviewLayout = get(PREVIEW_STYLE, defaultValues.getCustomPreviewLayout());
         List<PreviewLayout> layouts = getPreviewLayouts(getStringList(PREVIEW_CYCLE), customPreviewLayout);
         if (layouts.isEmpty()) {
-            layouts = new ArrayList<>(defaults.getLayoutCycle());
+            layouts = new ArrayList<>(defaultValues.getLayoutCycle());
         }
 
         List<Path> bstPaths;
         if (hasKey(PREVIEW_BST_LAYOUT_PATHS)) {
             bstPaths = getStringList(PREVIEW_BST_LAYOUT_PATHS).stream().map(Path::of).collect(Collectors.toList());
         } else {
-            bstPaths = new ArrayList<>(defaults.getBstPreviewLayoutPaths());
+            bstPaths = new ArrayList<>(defaultValues.getBstPreviewLayoutPaths());
         }
 
-        return new PreviewPreferences(
+        this.previewPreferences = new PreviewPreferences(
                 layouts,
-                getPreviewCyclePosition(layouts, getInt(PREVIEW_CYCLE_POS, defaults.getLayoutCyclePosition())),
+                getPreviewCyclePosition(layouts, getInt(PREVIEW_CYCLE_POS, defaultValues.getLayoutCyclePosition())),
                 customPreviewLayout,
-                getBoolean(PREVIEW_AS_TAB, defaults.shouldShowPreviewAsExtraTab()),
-                getBoolean(PREVIEW_IN_ENTRY_TABLE_TOOLTIP, defaults.shouldShowPreviewEntryTableTooltip()),
+                getBoolean(PREVIEW_AS_TAB, defaultValues.shouldShowPreviewAsExtraTab()),
+                getBoolean(PREVIEW_IN_ENTRY_TABLE_TOOLTIP, defaultValues.shouldShowPreviewEntryTableTooltip()),
                 bstPaths,
-                getBoolean(PREVIEW_COVER_IMAGE_DOWNLOAD, defaults.shouldDownloadCovers())
+                getBoolean(PREVIEW_COVER_IMAGE_DOWNLOAD, defaultValues.shouldDownloadCovers())
         );
+
+        // Registered before layoutCyclePosition, so its import runs first and the position can be clamped against the loaded cycle.
+        bindCustomList(previewPreferences.getLayoutCycle(), PREVIEW_CYCLE, defaultValues.getLayoutCycle(),
+                boundList -> putStringList(PREVIEW_CYCLE, previewLayoutsToStrings(boundList)),
+                () -> {
+                    List<PreviewLayout> stored = getPreviewLayouts(getStringList(PREVIEW_CYCLE), get(PREVIEW_STYLE, defaultValues.getCustomPreviewLayout()));
+                    return stored.isEmpty() ? defaultValues.getLayoutCycle() : stored;
+                });
+        // layoutCyclePosition is clamped to the current cycle on load, so it needs a custom binding.
+        bindCustom(previewPreferences.layoutCyclePositionProperty(), PREVIEW_CYCLE_POS, defaultValues.getLayoutCyclePosition(),
+                (_, _, newValue) -> putInt(PREVIEW_CYCLE_POS, newValue.intValue()),
+                () -> previewPreferences.layoutCyclePositionProperty().set(getPreviewCyclePosition(previewPreferences.getLayoutCycle(), defaultValues.getLayoutCyclePosition())),
+                () -> previewPreferences.layoutCyclePositionProperty().set(defaultValues.getLayoutCyclePosition()));
+        // customPreviewLayout is stored with __NEWLINE__ instead of \n so that our migration correctly triggers; in getText it is replaced back by \n.
+        bindCustom(previewPreferences.customPreviewLayoutProperty(), PREVIEW_STYLE, defaultValues.getCustomPreviewLayout(),
+                (_, _, newValue) -> put(PREVIEW_STYLE, newValue.replace("\n", "__NEWLINE__")),
+                () -> previewPreferences.customPreviewLayoutProperty().set(get(PREVIEW_STYLE, defaultValues.getCustomPreviewLayout())),
+                () -> previewPreferences.customPreviewLayoutProperty().set(defaultValues.getCustomPreviewLayout()));
+        bindBoolean(previewPreferences.showPreviewAsExtraTabProperty(), PREVIEW_AS_TAB, defaultValues.shouldShowPreviewAsExtraTab());
+        bindBoolean(previewPreferences.showPreviewEntryTableTooltip(), PREVIEW_IN_ENTRY_TABLE_TOOLTIP, defaultValues.shouldShowPreviewEntryTableTooltip());
+        bindCustomList(previewPreferences.getBstPreviewLayoutPaths(), PREVIEW_BST_LAYOUT_PATHS, defaultValues.getBstPreviewLayoutPaths(),
+                this::storeBstPaths,
+                () -> hasKey(PREVIEW_BST_LAYOUT_PATHS)
+                        ? getStringList(PREVIEW_BST_LAYOUT_PATHS).stream().map(Path::of).toList()
+                        : defaultValues.getBstPreviewLayoutPaths());
+        bindBoolean(previewPreferences.shouldDownloadCoversProperty(), PREVIEW_COVER_IMAGE_DOWNLOAD, defaultValues.shouldDownloadCovers());
+
+        return this.previewPreferences;
     }
 
     private void storeBstPaths(List<Path> bstPaths) {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -385,8 +385,8 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 getBoolean(ALLOW_INTEGER_EDITION_BIBTEX, defaultValues.shouldAllowIntegerEditionBibtex()),
                 getBoolean(AUTOLINK_FILES_ENABLED, defaultValues.autoLinkFilesEnabled()),
                 EntryEditorPreferences.JournalPopupEnabled.fromString(get(JOURNAL_POPUP, defaultValues.shouldEnableJournalPopup().name())),
-                CitationFetcherType.valueOf(get(CITATION_FETCHER_TYPE, defaultValues.getCitationFetcherType().name())),
-                CitationCountFetcherType.valueOf(get(CITATION_COUNT_FETCHER_TYPE, defaultValues.getCitationCountFetcherType().name())),
+                CitationFetcherType.safeValueOf(get(CITATION_FETCHER_TYPE, defaultValues.getCitationFetcherType().name())),
+                CitationCountFetcherType.safeValueOf(get(CITATION_COUNT_FETCHER_TYPE, defaultValues.getCitationCountFetcherType().name())),
                 getBoolean(SHOW_USER_COMMENTS_FIELDS, defaultValues.shouldShowUserCommentsFields()),
                 getDouble(ENTRY_EDITOR_PREVIEW_DIVIDER_POS, defaultValues.getPreviewWidthDividerPosition())
         );
@@ -402,10 +402,10 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 EntryEditorPreferences.JournalPopupEnabled::name, EntryEditorPreferences.JournalPopupEnabled::fromString);
         bindDouble(entryEditorPreferences.previewWidthDividerPositionProperty(), ENTRY_EDITOR_PREVIEW_DIVIDER_POS, defaultValues.getPreviewWidthDividerPosition());
         bindObject(entryEditorPreferences.citationFetcherTypeProperty(), CITATION_FETCHER_TYPE, defaultValues.getCitationFetcherType(),
-                CitationFetcherType::name, CitationFetcherType::valueOf);
+                CitationFetcherType::name, CitationFetcherType::safeValueOf);
         bindBoolean(entryEditorPreferences.showUserCommentsFieldsProperty(), SHOW_USER_COMMENTS_FIELDS, defaultValues.shouldShowUserCommentsFields());
         bindObject(entryEditorPreferences.citationCountFetcherTypeProperty(), CITATION_COUNT_FETCHER_TYPE, defaultValues.getCitationCountFetcherType(),
-                CitationCountFetcherType::name, CitationCountFetcherType::valueOf);
+                CitationCountFetcherType::name, CitationCountFetcherType::safeValueOf);
 
         return entryEditorPreferences;
     }
@@ -542,25 +542,25 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         MergeDialogPreferences defaultValues = MergeDialogPreferences.getDefault();
 
         mergeDialogPreferences = new MergeDialogPreferences(
-                DiffMode.valueOf(get(MERGE_ENTRIES_DIFF_MODE, defaultValues.getMergeDiffMode().name())),
+                DiffMode.parse(get(MERGE_ENTRIES_DIFF_MODE, defaultValues.getMergeDiffMode().name())),
                 getBoolean(MERGE_ENTRIES_SHOULD_SHOW_DIFF, defaultValues.getMergeShouldShowDiff()),
                 getBoolean(MERGE_ENTRIES_SHOULD_SHOW_UNIFIED_DIFF, defaultValues.getMergeShouldShowUnifiedDiff()),
                 getBoolean(MERGE_ENTRIES_HIGHLIGHT_WORDS, defaultValues.getMergeHighlightWords()),
                 getBoolean(MERGE_SHOW_ONLY_CHANGED_FIELDS, defaultValues.shouldMergeShowChangedFieldsOnly()),
                 getBoolean(MERGE_APPLY_TO_ALL_ENTRIES, defaultValues.shouldMergeApplyToAllEntries()),
-                DuplicateResolverDialog.DuplicateResolverResult.valueOf(
+                DuplicateResolverDialog.DuplicateResolverResult.parse(
                         get(DUPLICATE_RESOLVER_DECISION_RESULT_ALL_ENTRIES, defaultValues.getAllEntriesDuplicateResolverDecision().name()))
         );
 
         bindObject(mergeDialogPreferences.mergeDiffModeProperty(), MERGE_ENTRIES_DIFF_MODE, defaultValues.getMergeDiffMode(),
-                DiffMode::name, DiffMode::valueOf);
+                DiffMode::name, DiffMode::parse);
         bindBoolean(mergeDialogPreferences.mergeShouldShowDiffProperty(), MERGE_ENTRIES_SHOULD_SHOW_DIFF, defaultValues.getMergeShouldShowDiff());
         bindBoolean(mergeDialogPreferences.mergeShouldShowUnifiedDiffProperty(), MERGE_ENTRIES_SHOULD_SHOW_UNIFIED_DIFF, defaultValues.getMergeShouldShowUnifiedDiff());
         bindBoolean(mergeDialogPreferences.mergeHighlightWordsProperty(), MERGE_ENTRIES_HIGHLIGHT_WORDS, defaultValues.getMergeHighlightWords());
         bindBoolean(mergeDialogPreferences.mergeShowChangedFieldOnlyProperty(), MERGE_SHOW_ONLY_CHANGED_FIELDS, defaultValues.shouldMergeShowChangedFieldsOnly());
         bindBoolean(mergeDialogPreferences.mergeApplyToAllEntriesProperty(), MERGE_APPLY_TO_ALL_ENTRIES, defaultValues.shouldMergeApplyToAllEntries());
         bindObject(mergeDialogPreferences.allEntriesDuplicateResolverDecisionProperty(), DUPLICATE_RESOLVER_DECISION_RESULT_ALL_ENTRIES, defaultValues.getAllEntriesDuplicateResolverDecision(),
-                DuplicateResolverDialog.DuplicateResolverResult::name, DuplicateResolverDialog.DuplicateResolverResult::valueOf);
+                DuplicateResolverDialog.DuplicateResolverResult::name, DuplicateResolverDialog.DuplicateResolverResult::parse);
 
         return mergeDialogPreferences;
     }
@@ -837,9 +837,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 getBoolean(GROUP_VIEW_INVERT, defaultValues.groupViewModeProperty().contains(GroupViewMode.INVERT)),
                 getBoolean(AUTO_ASSIGN_GROUP, defaultValues.shouldAutoAssignGroup()),
                 getBoolean(DISPLAY_GROUP_COUNT, defaultValues.shouldDisplayGroupCount()),
-                GroupHierarchyType.valueOf(
-                        get(DEFAULT_HIERARCHICAL_CONTEXT, defaultValues.getDefaultHierarchicalContext().name())
-                ),
+                GroupHierarchyType.safeValueOf(get(DEFAULT_HIERARCHICAL_CONTEXT, defaultValues.getDefaultHierarchicalContext().name())),
                 getBoolean(GROUP_SHOW_AI_CHAT, defaultValues.showAiChatButton())
         );
 
@@ -849,7 +847,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         bindBoolean(groupsPreferences.autoAssignGroupProperty(), AUTO_ASSIGN_GROUP, defaultValues.shouldAutoAssignGroup());
         bindBoolean(groupsPreferences.displayGroupCountProperty(), DISPLAY_GROUP_COUNT, defaultValues.shouldDisplayGroupCount());
         bindObject(groupsPreferences.defaultHierarchicalContextProperty(), DEFAULT_HIERARCHICAL_CONTEXT, defaultValues.getDefaultHierarchicalContext(),
-                GroupHierarchyType::name, GroupHierarchyType::valueOf);
+                GroupHierarchyType::name, GroupHierarchyType::safeValueOf);
         bindBoolean(groupsPreferences.showAiChatButtonProperty(), GROUP_SHOW_AI_CHAT, defaultValues.showAiChatButton());
 
         return groupsPreferences;
@@ -1150,7 +1148,15 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
 
         List<TableColumn.SortType> columnSortTypes = getStringList(sortTypeList)
                 .stream()
-                .map(TableColumn.SortType::valueOf).toList();
+                .map(sortType -> {
+                    // TableColumn.SortType is a JavaFX enum and has no safe parser; fall back to
+                    // ASCENDING on unknown/corrupted values so recovery operations (reset/import) do not fail.
+                    try {
+                        return TableColumn.SortType.valueOf(sortType);
+                    } catch (IllegalArgumentException e) {
+                        return TableColumn.SortType.ASCENDING;
+                    }
+                }).toList();
 
         List<MainTableColumnModel> columns = new ArrayList<>();
         for (int i = 0; i < columnNames.size(); i++) {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -319,10 +319,9 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getSearchDialogColumnPreferences();
         getNewEntryPreferences();
         getDonationPreferences();
+        getMrDlibPreferences();
 
         super.clear();
-
-        getMrDlibPreferences().setAll(MrDlibPreferences.getDefault());
     }
 
     @Override
@@ -346,11 +345,9 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getSearchDialogColumnPreferences();
         getNewEntryPreferences();
         getDonationPreferences();
+        getMrDlibPreferences();
 
         super.importPreferences(path);
-
-        // in case of incomplete or corrupt xml fall back to current preferences
-        getMrDlibPreferences().setAll(getMrDlibPreferencesFromBackingStore(getMrDlibPreferences()));
     }
 
     // region CopyToPreferences
@@ -1284,22 +1281,20 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return mrDlibPreferences;
         }
 
-        mrDlibPreferences = getMrDlibPreferencesFromBackingStore(MrDlibPreferences.getDefault());
+        MrDlibPreferences defaultValues = MrDlibPreferences.getDefault();
 
-        EasyBind.listen(mrDlibPreferences.acceptRecommendationsProperty(), (_, _, newValue) -> putBoolean(MRDLIB_ACCEPT_RECOMMENDATIONS, newValue));
-        EasyBind.listen(mrDlibPreferences.sendLanguageProperty(), (_, _, newValue) -> putBoolean(MRDLIB_SEND_LANGUAGE_DATA, newValue));
-        EasyBind.listen(mrDlibPreferences.sendOsProperty(), (_, _, newValue) -> putBoolean(MRDLIB_SEND_OS_DATA, newValue));
-        EasyBind.listen(mrDlibPreferences.sendTimezoneProperty(), (_, _, newValue) -> putBoolean(MRDLIB_SEND_TIMEZONE_DATA, newValue));
+        mrDlibPreferences = new MrDlibPreferences(
+                getBoolean(MRDLIB_ACCEPT_RECOMMENDATIONS, defaultValues.shouldAcceptRecommendations()),
+                getBoolean(MRDLIB_SEND_LANGUAGE_DATA, defaultValues.shouldSendLanguage()),
+                getBoolean(MRDLIB_SEND_OS_DATA, defaultValues.shouldSendOs()),
+                getBoolean(MRDLIB_SEND_TIMEZONE_DATA, defaultValues.shouldSendTimezone()));
+
+        bindBoolean(mrDlibPreferences.acceptRecommendationsProperty(), MRDLIB_ACCEPT_RECOMMENDATIONS, defaultValues.shouldAcceptRecommendations());
+        bindBoolean(mrDlibPreferences.sendLanguageProperty(), MRDLIB_SEND_LANGUAGE_DATA, defaultValues.shouldSendLanguage());
+        bindBoolean(mrDlibPreferences.sendOsProperty(), MRDLIB_SEND_OS_DATA, defaultValues.shouldSendOs());
+        bindBoolean(mrDlibPreferences.sendTimezoneProperty(), MRDLIB_SEND_TIMEZONE_DATA, defaultValues.shouldSendTimezone());
 
         return mrDlibPreferences;
-    }
-
-    private MrDlibPreferences getMrDlibPreferencesFromBackingStore(MrDlibPreferences defaults) {
-        return new MrDlibPreferences(
-                getBoolean(MRDLIB_ACCEPT_RECOMMENDATIONS, defaults.shouldAcceptRecommendations()),
-                getBoolean(MRDLIB_SEND_LANGUAGE_DATA, defaults.shouldSendLanguage()),
-                getBoolean(MRDLIB_SEND_OS_DATA, defaults.shouldSendOs()),
-                getBoolean(MRDLIB_SEND_TIMEZONE_DATA, defaults.shouldSendTimezone()));
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -13,7 +13,6 @@ import java.util.prefs.BackingStoreException;
 import java.util.stream.Collectors;
 
 import javafx.beans.InvalidationListener;
-import javafx.collections.SetChangeListener;
 import javafx.scene.control.TableColumn;
 
 import org.jabref.gui.CoreGuiPreferences;
@@ -181,6 +180,9 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     // region GroupsPreferences
     private static final String AUTO_ASSIGN_GROUP = "autoAssignGroup";
     private static final String DISPLAY_GROUP_COUNT = "displayGroupCount";
+    // The view mode spans the three GROUP_VIEW_* flags above; this synthetic key is never written to the backing store
+    // and only serves as the binding's reporting key in getPreferences()/getDefaults() (see bindMap/PUSH_APPLICATIONS_PATHS_KEY).
+    private static final String GROUP_VIEW_MODE = "groupViewMode";
     private static final String GROUP_VIEW_INTERSECTION = "groupIntersection";
     private static final String GROUP_VIEW_FILTER = "groupFilter";
     private static final String GROUP_VIEW_INVERT = "groupInvert";
@@ -302,11 +304,11 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getUnlinkedFilesDialogPreferences();
         getSidePanePreferences();
         getExternalApplicationsPreferences();
+        getGroupsPreferences();
 
         super.clear();
 
         getDonationPreferences().setAll(DonationPreferences.getDefault());
-        getGroupsPreferences().setAll(GroupsPreferences.getDefault());
         getSpecialFieldsPreferences().setAll(SpecialFieldsPreferences.getDefault());
         getMainTableColumnPreferences().setAll(ColumnPreferences.getDefault());
         getMainTablePreferences().setAll(MainTablePreferences.getDefault());
@@ -332,12 +334,12 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getUnlinkedFilesDialogPreferences();
         getSidePanePreferences();
         getExternalApplicationsPreferences();
+        getGroupsPreferences();
 
         super.importPreferences(path);
 
         // in case of incomplete or corrupt xml fall back to current preferences
         getDonationPreferences().setAll(getDonationPreferencesFromBackingStore(getDonationPreferences()));
-        getGroupsPreferences().setAll(getGroupsPreferencesFromBackingStore(getGroupsPreferences()));
         getSpecialFieldsPreferences().setAll(getSpecialFieldsPreferencesFromBackingStore(getSpecialFieldsPreferences()));
         getMainTableColumnPreferences().setAll(getMainTableColumnPreferencesFromBackingStore(getMainTableColumnPreferences()));
         getMainTablePreferences().setAll(getMainTablePreferencesFromBackingStore(getMainTablePreferences()));
@@ -827,33 +829,50 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return groupsPreferences;
         }
 
-        groupsPreferences = getGroupsPreferencesFromBackingStore(GroupsPreferences.getDefault());
+        GroupsPreferences defaultValues = GroupsPreferences.getDefault();
 
-        groupsPreferences.groupViewModeProperty().addListener((SetChangeListener<GroupViewMode>) _ -> {
-            putBoolean(GROUP_VIEW_INTERSECTION, groupsPreferences.groupViewModeProperty().contains(GroupViewMode.INTERSECTION));
-            putBoolean(GROUP_VIEW_FILTER, groupsPreferences.groupViewModeProperty().contains(GroupViewMode.FILTER));
-            putBoolean(GROUP_VIEW_INVERT, groupsPreferences.groupViewModeProperty().contains(GroupViewMode.INVERT));
-        });
-        EasyBind.listen(groupsPreferences.autoAssignGroupProperty(), (_, _, newValue) -> putBoolean(AUTO_ASSIGN_GROUP, newValue));
-        EasyBind.listen(groupsPreferences.displayGroupCountProperty(), (_, _, newValue) -> putBoolean(DISPLAY_GROUP_COUNT, newValue));
-        EasyBind.listen(groupsPreferences.defaultHierarchicalContextProperty(), (_, _, newValue) -> put(DEFAULT_HIERARCHICAL_CONTEXT, newValue.name()));
-        EasyBind.listen(groupsPreferences.showAiChatButtonProperty(), (_, _, newValue) -> putBoolean(GROUP_SHOW_AI_CHAT, newValue));
+        groupsPreferences = new GroupsPreferences(
+                getBoolean(GROUP_VIEW_INTERSECTION, defaultValues.groupViewModeProperty().contains(GroupViewMode.INTERSECTION)),
+                getBoolean(GROUP_VIEW_FILTER, defaultValues.groupViewModeProperty().contains(GroupViewMode.FILTER)),
+                getBoolean(GROUP_VIEW_INVERT, defaultValues.groupViewModeProperty().contains(GroupViewMode.INVERT)),
+                getBoolean(AUTO_ASSIGN_GROUP, defaultValues.shouldAutoAssignGroup()),
+                getBoolean(DISPLAY_GROUP_COUNT, defaultValues.shouldDisplayGroupCount()),
+                GroupHierarchyType.valueOf(
+                        get(DEFAULT_HIERARCHICAL_CONTEXT, defaultValues.getDefaultHierarchicalContext().name())
+                ),
+                getBoolean(GROUP_SHOW_AI_CHAT, defaultValues.showAiChatButton())
+        );
+
+        bindSet(groupsPreferences.groupViewModeProperty(), GROUP_VIEW_MODE, defaultValues.groupViewModeProperty(),
+                this::storeGroupViewModes,
+                () -> getGroupViewModes(defaultValues));
+        bindBoolean(groupsPreferences.autoAssignGroupProperty(), AUTO_ASSIGN_GROUP, defaultValues.shouldAutoAssignGroup());
+        bindBoolean(groupsPreferences.displayGroupCountProperty(), DISPLAY_GROUP_COUNT, defaultValues.shouldDisplayGroupCount());
+        bindObject(groupsPreferences.defaultHierarchicalContextProperty(), DEFAULT_HIERARCHICAL_CONTEXT, defaultValues.getDefaultHierarchicalContext(),
+                GroupHierarchyType::name, GroupHierarchyType::valueOf);
+        bindBoolean(groupsPreferences.showAiChatButtonProperty(), GROUP_SHOW_AI_CHAT, defaultValues.showAiChatButton());
 
         return groupsPreferences;
     }
 
-    private GroupsPreferences getGroupsPreferencesFromBackingStore(GroupsPreferences defaults) {
-        return new GroupsPreferences(
-                getBoolean(GROUP_VIEW_INTERSECTION, defaults.groupViewModeProperty().contains(GroupViewMode.INTERSECTION)),
-                getBoolean(GROUP_VIEW_FILTER, defaults.groupViewModeProperty().contains(GroupViewMode.FILTER)),
-                getBoolean(GROUP_VIEW_INVERT, defaults.groupViewModeProperty().contains(GroupViewMode.INVERT)),
-                getBoolean(AUTO_ASSIGN_GROUP, defaults.shouldAutoAssignGroup()),
-                getBoolean(DISPLAY_GROUP_COUNT, defaults.shouldDisplayGroupCount()),
-                GroupHierarchyType.valueOf(
-                        get(DEFAULT_HIERARCHICAL_CONTEXT, defaults.getDefaultHierarchicalContext().name())
-                ),
-                getBoolean(GROUP_SHOW_AI_CHAT, defaults.showAiChatButton())
-        );
+    private Set<GroupViewMode> getGroupViewModes(GroupsPreferences defaults) {
+        Set<GroupViewMode> modes = new HashSet<>();
+        if (getBoolean(GROUP_VIEW_INTERSECTION, defaults.groupViewModeProperty().contains(GroupViewMode.INTERSECTION))) {
+            modes.add(GroupViewMode.INTERSECTION);
+        }
+        if (getBoolean(GROUP_VIEW_FILTER, defaults.groupViewModeProperty().contains(GroupViewMode.FILTER))) {
+            modes.add(GroupViewMode.FILTER);
+        }
+        if (getBoolean(GROUP_VIEW_INVERT, defaults.groupViewModeProperty().contains(GroupViewMode.INVERT))) {
+            modes.add(GroupViewMode.INVERT);
+        }
+        return modes;
+    }
+
+    private void storeGroupViewModes(Set<GroupViewMode> modes) {
+        putBoolean(GROUP_VIEW_INTERSECTION, modes.contains(GroupViewMode.INTERSECTION));
+        putBoolean(GROUP_VIEW_FILTER, modes.contains(GroupViewMode.FILTER));
+        putBoolean(GROUP_VIEW_INVERT, modes.contains(GroupViewMode.INVERT));
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -285,12 +285,14 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
 
     @Override
     public void clear() throws BackingStoreException {
+        // ensure registration of bindings
+        getCopyToPreferences();
+
         super.clear();
 
         getDonationPreferences().setAll(DonationPreferences.getDefault());
         getEntryEditorPreferences().setAll(EntryEditorPreferences.getDefault());
         getGroupsPreferences().setAll(GroupsPreferences.getDefault());
-        getCopyToPreferences().setAll(CopyToPreferences.getDefault());
         getGuiPreferences().setAll(CoreGuiPreferences.getDefault());
         getSpecialFieldsPreferences().setAll(SpecialFieldsPreferences.getDefault());
         getExternalApplicationsPreferences().setAll(ExternalApplicationsPreferences.getDefault());
@@ -313,13 +315,15 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
 
     @Override
     public void importPreferences(Path path) throws JabRefException {
+        // ensure registration of bindings
+        getCopyToPreferences();
+
         super.importPreferences(path);
 
         // in case of incomplete or corrupt xml fall back to current preferences
         getDonationPreferences().setAll(getDonationPreferencesFromBackingStore(getDonationPreferences()));
         getEntryEditorPreferences().setAll(getEntryEditorPreferencesFromBackingStore(getEntryEditorPreferences()));
         getGroupsPreferences().setAll(getGroupsPreferencesFromBackingStore(getGroupsPreferences()));
-        getCopyToPreferences().setAll(getCopyToPreferencesFromBackingStore(getCopyToPreferences()));
         getGuiPreferences().setAll(getCoreGuiPreferencesFromBackingStore(getGuiPreferences()));
         getSpecialFieldsPreferences().setAll(getSpecialFieldsPreferencesFromBackingStore(getSpecialFieldsPreferences()));
         getExternalApplicationsPreferences().setAll(getExternalApplicationsPreferencesFromBackingStore(getExternalApplicationsPreferences()));
@@ -342,19 +346,17 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         if (copyToPreferences != null) {
             return copyToPreferences;
         }
-        copyToPreferences = getCopyToPreferencesFromBackingStore(CopyToPreferences.getDefault());
 
-        EasyBind.listen(copyToPreferences.shouldAskForIncludingCrossReferencesProperty(), (_, _, newValue) -> putBoolean(ASK_FOR_INCLUDING_CROSS_REFERENCES, newValue));
-        EasyBind.listen(copyToPreferences.shouldIncludeCrossReferencesProperty(), (_, _, newValue) -> putBoolean(INCLUDE_CROSS_REFERENCES, newValue));
+        CopyToPreferences defaultValues = CopyToPreferences.getDefault();
+
+        copyToPreferences = new CopyToPreferences(
+                getBoolean(ASK_FOR_INCLUDING_CROSS_REFERENCES, defaultValues.getShouldAskForIncludingCrossReferences()),
+                getBoolean(INCLUDE_CROSS_REFERENCES, defaultValues.getShouldIncludeCrossReferences()));
+
+        bindBoolean(copyToPreferences.shouldAskForIncludingCrossReferencesProperty(), ASK_FOR_INCLUDING_CROSS_REFERENCES, defaultValues.getShouldAskForIncludingCrossReferences());
+        bindBoolean(copyToPreferences.shouldIncludeCrossReferencesProperty(), INCLUDE_CROSS_REFERENCES, defaultValues.getShouldIncludeCrossReferences());
 
         return copyToPreferences;
-    }
-
-    private CopyToPreferences getCopyToPreferencesFromBackingStore(CopyToPreferences defaults) {
-        return new CopyToPreferences(
-                getBoolean(ASK_FOR_INCLUDING_CROSS_REFERENCES, defaults.getShouldAskForIncludingCrossReferences()),
-                getBoolean(INCLUDE_CROSS_REFERENCES, defaults.getShouldIncludeCrossReferences())
-        );
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -292,6 +292,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         // ensure registration of bindings
         getCopyToPreferences();
         getEntryEditorPreferences();
+        getMergeDialogPreferences();
 
         super.clear();
 
@@ -301,7 +302,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getSpecialFieldsPreferences().setAll(SpecialFieldsPreferences.getDefault());
         getExternalApplicationsPreferences().setAll(ExternalApplicationsPreferences.getDefault());
         getMainTableColumnPreferences().setAll(ColumnPreferences.getDefault());
-        getMergeDialogPreferences().setAll(MergeDialogPreferences.getDefault());
         getMainTablePreferences().setAll(MainTablePreferences.getDefault());
         getNewEntryPreferences().setAll(NewEntryPreferences.getDefault());
         getSearchDialogColumnPreferences().setAll(ColumnPreferences.getDefault());
@@ -322,6 +322,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         // ensure registration of bindings
         getCopyToPreferences();
         getEntryEditorPreferences();
+        getMergeDialogPreferences();
 
         super.importPreferences(path);
 
@@ -332,7 +333,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getSpecialFieldsPreferences().setAll(getSpecialFieldsPreferencesFromBackingStore(getSpecialFieldsPreferences()));
         getExternalApplicationsPreferences().setAll(getExternalApplicationsPreferencesFromBackingStore(getExternalApplicationsPreferences()));
         getMainTableColumnPreferences().setAll(getMainTableColumnPreferencesFromBackingStore(getMainTableColumnPreferences()));
-        getMergeDialogPreferences().setAll(getMergeDialogPreferencesFromBackingStore(getMergeDialogPreferences()));
         getMainTablePreferences().setAll(getMainTablePreferencesFromBackingStore(getMainTablePreferences()));
         getNewEntryPreferences().setAll(getNewEntryPreferencesFromBackingStore(getNewEntryPreferences()));
         getSearchDialogColumnPreferences().setAll(getSearchDialogColumnPreferencesFromBackingStore(getSearchDialogColumnPreferences()));
@@ -534,32 +534,30 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return mergeDialogPreferences;
         }
 
-        MergeDialogPreferences defaults = MergeDialogPreferences.getDefault();
+        MergeDialogPreferences defaultValues = MergeDialogPreferences.getDefault();
 
-        mergeDialogPreferences = getMergeDialogPreferencesFromBackingStore(defaults);
+        mergeDialogPreferences = new MergeDialogPreferences(
+                DiffMode.valueOf(get(MERGE_ENTRIES_DIFF_MODE, defaultValues.getMergeDiffMode().name())),
+                getBoolean(MERGE_ENTRIES_SHOULD_SHOW_DIFF, defaultValues.getMergeShouldShowDiff()),
+                getBoolean(MERGE_ENTRIES_SHOULD_SHOW_UNIFIED_DIFF, defaultValues.getMergeShouldShowUnifiedDiff()),
+                getBoolean(MERGE_ENTRIES_HIGHLIGHT_WORDS, defaultValues.getMergeHighlightWords()),
+                getBoolean(MERGE_SHOW_ONLY_CHANGED_FIELDS, defaultValues.shouldMergeShowChangedFieldsOnly()),
+                getBoolean(MERGE_APPLY_TO_ALL_ENTRIES, defaultValues.shouldMergeApplyToAllEntries()),
+                DuplicateResolverDialog.DuplicateResolverResult.valueOf(
+                        get(DUPLICATE_RESOLVER_DECISION_RESULT_ALL_ENTRIES, defaultValues.getAllEntriesDuplicateResolverDecision().name()))
+        );
 
-        EasyBind.listen(mergeDialogPreferences.mergeDiffModeProperty(), (_, _, newValue) -> put(MERGE_ENTRIES_DIFF_MODE, newValue.name()));
-        EasyBind.listen(mergeDialogPreferences.mergeShouldShowDiffProperty(), (_, _, newValue) -> putBoolean(MERGE_ENTRIES_SHOULD_SHOW_DIFF, newValue));
-        EasyBind.listen(mergeDialogPreferences.mergeShouldShowUnifiedDiffProperty(), (_, _, newValue) -> putBoolean(MERGE_ENTRIES_SHOULD_SHOW_UNIFIED_DIFF, newValue));
-        EasyBind.listen(mergeDialogPreferences.mergeHighlightWordsProperty(), (_, _, newValue) -> putBoolean(MERGE_ENTRIES_HIGHLIGHT_WORDS, newValue));
-        EasyBind.listen(mergeDialogPreferences.mergeShowChangedFieldOnlyProperty(), (_, _, newValue) -> putBoolean(MERGE_SHOW_ONLY_CHANGED_FIELDS, newValue));
-        EasyBind.listen(mergeDialogPreferences.mergeApplyToAllEntriesProperty(), (_, _, newValue) -> putBoolean(MERGE_APPLY_TO_ALL_ENTRIES, newValue));
-        EasyBind.listen(mergeDialogPreferences.allEntriesDuplicateResolverDecisionProperty(), (_, _, newValue) -> put(DUPLICATE_RESOLVER_DECISION_RESULT_ALL_ENTRIES, newValue.name()));
+        bindObject(mergeDialogPreferences.mergeDiffModeProperty(), MERGE_ENTRIES_DIFF_MODE, defaultValues.getMergeDiffMode(),
+                DiffMode::name, DiffMode::valueOf);
+        bindBoolean(mergeDialogPreferences.mergeShouldShowDiffProperty(), MERGE_ENTRIES_SHOULD_SHOW_DIFF, defaultValues.getMergeShouldShowDiff());
+        bindBoolean(mergeDialogPreferences.mergeShouldShowUnifiedDiffProperty(), MERGE_ENTRIES_SHOULD_SHOW_UNIFIED_DIFF, defaultValues.getMergeShouldShowUnifiedDiff());
+        bindBoolean(mergeDialogPreferences.mergeHighlightWordsProperty(), MERGE_ENTRIES_HIGHLIGHT_WORDS, defaultValues.getMergeHighlightWords());
+        bindBoolean(mergeDialogPreferences.mergeShowChangedFieldOnlyProperty(), MERGE_SHOW_ONLY_CHANGED_FIELDS, defaultValues.shouldMergeShowChangedFieldsOnly());
+        bindBoolean(mergeDialogPreferences.mergeApplyToAllEntriesProperty(), MERGE_APPLY_TO_ALL_ENTRIES, defaultValues.shouldMergeApplyToAllEntries());
+        bindObject(mergeDialogPreferences.allEntriesDuplicateResolverDecisionProperty(), DUPLICATE_RESOLVER_DECISION_RESULT_ALL_ENTRIES, defaultValues.getAllEntriesDuplicateResolverDecision(),
+                DuplicateResolverDialog.DuplicateResolverResult::name, DuplicateResolverDialog.DuplicateResolverResult::valueOf);
 
         return mergeDialogPreferences;
-    }
-
-    private MergeDialogPreferences getMergeDialogPreferencesFromBackingStore(MergeDialogPreferences defaults) {
-        return new MergeDialogPreferences(
-                DiffMode.valueOf(get(MERGE_ENTRIES_DIFF_MODE, defaults.getMergeDiffMode().name())),
-                getBoolean(MERGE_ENTRIES_SHOULD_SHOW_DIFF, defaults.getMergeShouldShowDiff()),
-                getBoolean(MERGE_ENTRIES_SHOULD_SHOW_UNIFIED_DIFF, defaults.getMergeShouldShowUnifiedDiff()),
-                getBoolean(MERGE_ENTRIES_HIGHLIGHT_WORDS, defaults.getMergeHighlightWords()),
-                getBoolean(MERGE_SHOW_ONLY_CHANGED_FIELDS, defaults.shouldMergeShowChangedFieldsOnly()),
-                getBoolean(MERGE_APPLY_TO_ALL_ENTRIES, defaults.shouldMergeApplyToAllEntries()),
-                DuplicateResolverDialog.DuplicateResolverResult.valueOf(
-                        get(DUPLICATE_RESOLVER_DECISION_RESULT_ALL_ENTRIES, defaults.getAllEntriesDuplicateResolverDecision().name()))
-        );
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.prefs.BackingStoreException;
 import java.util.stream.Collectors;
 
@@ -1070,23 +1071,12 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 columnSortOrder.isEmpty() ? defaultValues.getColumnSortOrder() : columnSortOrder
         );
 
-        // The columns list is persisted across COLUMN_NAMES/COLUMN_WIDTHS/COLUMN_SORT_TYPES; registered before the sort
-        // order, so its import runs first and the sort order can resolve against the loaded columns.
-        bindCustomList(mainTableColumnPreferences.getColumns(), MAIN_TABLE_COLUMNS, defaultValues.getColumns(),
-                boundList -> {
-                    putStringList(COLUMN_NAMES, getColumnNamesAsStringList(mainTableColumnPreferences));
-                    putStringList(COLUMN_WIDTHS, getColumnWidthsAsStringList(mainTableColumnPreferences));
-                    putStringList(COLUMN_SORT_TYPES, getColumnSortTypesAsStringList(mainTableColumnPreferences));
-                },
-                () -> {
-                    List<MainTableColumnModel> stored = getColumns(COLUMN_NAMES, COLUMN_WIDTHS, COLUMN_SORT_TYPES, ColumnPreferences.DEFAULT_COLUMN_WIDTH);
-                    return stored.isEmpty() ? defaultValues.getColumns() : stored;
-                });
-        bindCustomList(mainTableColumnPreferences.getColumnSortOrder(), COLUMN_SORT_ORDER, defaultValues.getColumnSortOrder(),
-                boundList -> putStringList(COLUMN_SORT_ORDER, getColumnSortOrderAsStringList(mainTableColumnPreferences)),
-                () -> {
-                    List<MainTableColumnModel> stored = getColumnSortOrder(COLUMN_SORT_ORDER, mainTableColumnPreferences.getColumns());
-                    return stored.isEmpty() ? defaultValues.getColumnSortOrder() : stored;
+        // The columns list is persisted across COLUMN_NAMES/COLUMN_WIDTHS/COLUMN_SORT_TYPES.
+        bindColumnPreferences(mainTableColumnPreferences, MAIN_TABLE_COLUMNS, COLUMN_NAMES, COLUMN_WIDTHS, COLUMN_SORT_TYPES, COLUMN_SORT_ORDER,
+                columnPreferences -> {
+                    putStringList(COLUMN_NAMES, getColumnNamesAsStringList(columnPreferences));
+                    putStringList(COLUMN_WIDTHS, getColumnWidthsAsStringList(columnPreferences));
+                    putStringList(COLUMN_SORT_TYPES, getColumnSortTypesAsStringList(columnPreferences));
                 });
 
         return mainTableColumnPreferences;
@@ -1108,25 +1098,37 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 columnSortOrder.isEmpty() ? defaultValues.getColumnSortOrder() : columnSortOrder
         );
 
-        // Column names are shared with the main table (COLUMN_NAMES) and owned there, so only widths and sort types are
-        // persisted here. Registered before the sort order, so its import runs first and the sort order can resolve.
-        bindCustomList(searchDialogColumnPreferences.getColumns(), SEARCH_DIALOG_COLUMNS, defaultValues.getColumns(),
-                boundList -> {
-                    putStringList(SEARCH_DIALOG_COLUMN_WIDTHS, getColumnWidthsAsStringList(searchDialogColumnPreferences));
-                    putStringList(SEARCH_DIALOG_COLUMN_SORT_TYPES, getColumnSortTypesAsStringList(searchDialogColumnPreferences));
-                },
-                () -> {
-                    List<MainTableColumnModel> stored = getColumns(COLUMN_NAMES, SEARCH_DIALOG_COLUMN_WIDTHS, SEARCH_DIALOG_COLUMN_SORT_TYPES, ColumnPreferences.DEFAULT_COLUMN_WIDTH);
-                    return stored.isEmpty() ? defaultValues.getColumns() : stored;
-                });
-        bindCustomList(searchDialogColumnPreferences.getColumnSortOrder(), SEARCH_DIALOG_COLUMN_SORT_ORDER, defaultValues.getColumnSortOrder(),
-                boundList -> putStringList(SEARCH_DIALOG_COLUMN_SORT_ORDER, getColumnSortOrderAsStringList(searchDialogColumnPreferences)),
-                () -> {
-                    List<MainTableColumnModel> stored = getColumnSortOrder(SEARCH_DIALOG_COLUMN_SORT_ORDER, searchDialogColumnPreferences.getColumns());
-                    return stored.isEmpty() ? defaultValues.getColumnSortOrder() : stored;
+        // Column names are shared with the main table (COLUMN_NAMES) and owned there, so only widths and sort types are persisted here.
+        bindColumnPreferences(searchDialogColumnPreferences, SEARCH_DIALOG_COLUMNS, COLUMN_NAMES, SEARCH_DIALOG_COLUMN_WIDTHS, SEARCH_DIALOG_COLUMN_SORT_TYPES, SEARCH_DIALOG_COLUMN_SORT_ORDER,
+                columnPreferences -> {
+                    putStringList(SEARCH_DIALOG_COLUMN_WIDTHS, getColumnWidthsAsStringList(columnPreferences));
+                    putStringList(SEARCH_DIALOG_COLUMN_SORT_TYPES, getColumnSortTypesAsStringList(columnPreferences));
                 });
 
         return searchDialogColumnPreferences;
+    }
+
+    private void bindColumnPreferences(ColumnPreferences columnPreferences,
+                                       String columnsReportKey,
+                                       String namesKey,
+                                       String widthsKey,
+                                       String sortTypesKey,
+                                       String sortOrderKey,
+                                       Consumer<ColumnPreferences> persistColumns) {
+        ColumnPreferences defaultValues = ColumnPreferences.getDefault();
+
+        bindCustomList(columnPreferences.getColumns(), columnsReportKey, defaultValues.getColumns(),
+                _ -> persistColumns.accept(columnPreferences),
+                () -> {
+                    List<MainTableColumnModel> stored = getColumns(namesKey, widthsKey, sortTypesKey, ColumnPreferences.DEFAULT_COLUMN_WIDTH);
+                    return stored.isEmpty() ? defaultValues.getColumns() : stored;
+                });
+        bindCustomList(columnPreferences.getColumnSortOrder(), sortOrderKey, defaultValues.getColumnSortOrder(),
+                _ -> putStringList(sortOrderKey, getColumnSortOrderAsStringList(columnPreferences)),
+                () -> {
+                    List<MainTableColumnModel> stored = getColumnSortOrder(sortOrderKey, columnPreferences.getColumns());
+                    return stored.isEmpty() ? defaultValues.getColumnSortOrder() : stored;
+                });
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -213,6 +213,10 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     // endregion
 
     // region EntryEditorPreferences
+    // The tab list is persisted across the many SHOW_* flags and the CUSTOM_TAB_* series below; this synthetic key is
+    // never written to the backing store and only serves as the tabModels binding's reporting key in
+    // getPreferences()/getDefaults() (see bindMap/PUSH_APPLICATIONS_PATHS_KEY for the same pattern).
+    private static final String ENTRY_EDITOR_TABS = "entryEditorTabs";
     private static final String CUSTOM_TAB_NAME = "customTabName_";
     private static final String CUSTOM_TAB_FIELDS = "customTabFields_";
     private static final String AUTO_OPEN_FORM = "autoOpenForm";
@@ -287,11 +291,11 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     public void clear() throws BackingStoreException {
         // ensure registration of bindings
         getCopyToPreferences();
+        getEntryEditorPreferences();
 
         super.clear();
 
         getDonationPreferences().setAll(DonationPreferences.getDefault());
-        getEntryEditorPreferences().setAll(EntryEditorPreferences.getDefault());
         getGroupsPreferences().setAll(GroupsPreferences.getDefault());
         getGuiPreferences().setAll(CoreGuiPreferences.getDefault());
         getSpecialFieldsPreferences().setAll(SpecialFieldsPreferences.getDefault());
@@ -317,12 +321,12 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     public void importPreferences(Path path) throws JabRefException {
         // ensure registration of bindings
         getCopyToPreferences();
+        getEntryEditorPreferences();
 
         super.importPreferences(path);
 
         // in case of incomplete or corrupt xml fall back to current preferences
         getDonationPreferences().setAll(getDonationPreferencesFromBackingStore(getDonationPreferences()));
-        getEntryEditorPreferences().setAll(getEntryEditorPreferencesFromBackingStore(getEntryEditorPreferences()));
         getGroupsPreferences().setAll(getGroupsPreferencesFromBackingStore(getGroupsPreferences()));
         getGuiPreferences().setAll(getCoreGuiPreferencesFromBackingStore(getGuiPreferences()));
         getSpecialFieldsPreferences().setAll(getSpecialFieldsPreferencesFromBackingStore(getSpecialFieldsPreferences()));
@@ -365,36 +369,40 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         if (entryEditorPreferences != null) {
             return entryEditorPreferences;
         }
-        entryEditorPreferences = getEntryEditorPreferencesFromBackingStore(EntryEditorPreferences.getDefault());
 
-        entryEditorPreferences.getTabModels().addListener((InvalidationListener) _ -> storeTabConfigs(entryEditorPreferences.getTabModels()));
-        EasyBind.listen(entryEditorPreferences.shouldOpenOnNewEntryProperty(), (_, _, newValue) -> putBoolean(AUTO_OPEN_FORM, newValue));
-        EasyBind.listen(entryEditorPreferences.showSourceTabByDefaultProperty(), (_, _, newValue) -> putBoolean(DEFAULT_SHOW_SOURCE, newValue));
-        EasyBind.listen(entryEditorPreferences.enableValidationProperty(), (_, _, newValue) -> putBoolean(VALIDATE_IN_ENTRY_EDITOR, newValue));
-        EasyBind.listen(entryEditorPreferences.allowIntegerEditionBibtexProperty(), (_, _, newValue) -> putBoolean(ALLOW_INTEGER_EDITION_BIBTEX, newValue));
-        EasyBind.listen(entryEditorPreferences.autoLinkEnabledProperty(), (_, _, newValue) -> putBoolean(AUTOLINK_FILES_ENABLED, newValue));
-        EasyBind.listen(entryEditorPreferences.enableJournalPopupProperty(), (_, _, newValue) -> put(JOURNAL_POPUP, newValue.toString()));
-        EasyBind.listen(entryEditorPreferences.previewWidthDividerPositionProperty(), (_, _, newValue) -> putDouble(ENTRY_EDITOR_PREVIEW_DIVIDER_POS, newValue.doubleValue()));
-        EasyBind.listen(entryEditorPreferences.citationFetcherTypeProperty(), (_, _, newValue) -> put(CITATION_FETCHER_TYPE, newValue.name()));
-        EasyBind.listen(entryEditorPreferences.showUserCommentsFieldsProperty(), (_, _, newValue) -> putBoolean(SHOW_USER_COMMENTS_FIELDS, newValue));
-        EasyBind.listen(entryEditorPreferences.citationCountFetcherTypeProperty(), (_, _, newValue) -> put(CITATION_COUNT_FETCHER_TYPE, newValue.name()));
-        return entryEditorPreferences;
-    }
+        EntryEditorPreferences defaultValues = EntryEditorPreferences.getDefault();
 
-    private EntryEditorPreferences getEntryEditorPreferencesFromBackingStore(EntryEditorPreferences defaults) {
-        return new EntryEditorPreferences(
-                getEntryEditorTabs(defaults),
-                getBoolean(AUTO_OPEN_FORM, defaults.shouldOpenOnNewEntry()),
-                getBoolean(DEFAULT_SHOW_SOURCE, defaults.showSourceTabByDefault()),
-                getBoolean(VALIDATE_IN_ENTRY_EDITOR, defaults.shouldEnableValidation()),
-                getBoolean(ALLOW_INTEGER_EDITION_BIBTEX, defaults.shouldAllowIntegerEditionBibtex()),
-                getBoolean(AUTOLINK_FILES_ENABLED, defaults.autoLinkFilesEnabled()),
-                EntryEditorPreferences.JournalPopupEnabled.fromString(get(JOURNAL_POPUP, defaults.shouldEnableJournalPopup().name())),
-                CitationFetcherType.valueOf(get(CITATION_FETCHER_TYPE, defaults.getCitationFetcherType().name())),
-                CitationCountFetcherType.valueOf(get(CITATION_COUNT_FETCHER_TYPE, defaults.getCitationCountFetcherType().name())),
-                getBoolean(SHOW_USER_COMMENTS_FIELDS, defaults.shouldShowUserCommentsFields()),
-                getDouble(ENTRY_EDITOR_PREVIEW_DIVIDER_POS, defaults.getPreviewWidthDividerPosition())
+        entryEditorPreferences = new EntryEditorPreferences(
+                getEntryEditorTabs(defaultValues),
+                getBoolean(AUTO_OPEN_FORM, defaultValues.shouldOpenOnNewEntry()),
+                getBoolean(DEFAULT_SHOW_SOURCE, defaultValues.showSourceTabByDefault()),
+                getBoolean(VALIDATE_IN_ENTRY_EDITOR, defaultValues.shouldEnableValidation()),
+                getBoolean(ALLOW_INTEGER_EDITION_BIBTEX, defaultValues.shouldAllowIntegerEditionBibtex()),
+                getBoolean(AUTOLINK_FILES_ENABLED, defaultValues.autoLinkFilesEnabled()),
+                EntryEditorPreferences.JournalPopupEnabled.fromString(get(JOURNAL_POPUP, defaultValues.shouldEnableJournalPopup().name())),
+                CitationFetcherType.valueOf(get(CITATION_FETCHER_TYPE, defaultValues.getCitationFetcherType().name())),
+                CitationCountFetcherType.valueOf(get(CITATION_COUNT_FETCHER_TYPE, defaultValues.getCitationCountFetcherType().name())),
+                getBoolean(SHOW_USER_COMMENTS_FIELDS, defaultValues.shouldShowUserCommentsFields()),
+                getDouble(ENTRY_EDITOR_PREVIEW_DIVIDER_POS, defaultValues.getPreviewWidthDividerPosition())
         );
+
+        bindCustomList(entryEditorPreferences.getTabModels(), ENTRY_EDITOR_TABS, defaultValues.getTabModels(),
+                this::storeTabConfigs, () -> getEntryEditorTabs(defaultValues));
+        bindBoolean(entryEditorPreferences.shouldOpenOnNewEntryProperty(), AUTO_OPEN_FORM, defaultValues.shouldOpenOnNewEntry());
+        bindBoolean(entryEditorPreferences.showSourceTabByDefaultProperty(), DEFAULT_SHOW_SOURCE, defaultValues.showSourceTabByDefault());
+        bindBoolean(entryEditorPreferences.enableValidationProperty(), VALIDATE_IN_ENTRY_EDITOR, defaultValues.shouldEnableValidation());
+        bindBoolean(entryEditorPreferences.allowIntegerEditionBibtexProperty(), ALLOW_INTEGER_EDITION_BIBTEX, defaultValues.shouldAllowIntegerEditionBibtex());
+        bindBoolean(entryEditorPreferences.autoLinkEnabledProperty(), AUTOLINK_FILES_ENABLED, defaultValues.autoLinkFilesEnabled());
+        bindObject(entryEditorPreferences.enableJournalPopupProperty(), JOURNAL_POPUP, defaultValues.shouldEnableJournalPopup(),
+                EntryEditorPreferences.JournalPopupEnabled::name, EntryEditorPreferences.JournalPopupEnabled::fromString);
+        bindDouble(entryEditorPreferences.previewWidthDividerPositionProperty(), ENTRY_EDITOR_PREVIEW_DIVIDER_POS, defaultValues.getPreviewWidthDividerPosition());
+        bindObject(entryEditorPreferences.citationFetcherTypeProperty(), CITATION_FETCHER_TYPE, defaultValues.getCitationFetcherType(),
+                CitationFetcherType::name, CitationFetcherType::valueOf);
+        bindBoolean(entryEditorPreferences.showUserCommentsFieldsProperty(), SHOW_USER_COMMENTS_FIELDS, defaultValues.shouldShowUserCommentsFields());
+        bindObject(entryEditorPreferences.citationCountFetcherTypeProperty(), CITATION_COUNT_FETCHER_TYPE, defaultValues.getCitationCountFetcherType(),
+                CitationCountFetcherType::name, CitationCountFetcherType::valueOf);
+
+        return entryEditorPreferences;
     }
 
     /// The single source of truth for the entry editor's tab list: the user-configured field-set tabs,

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -13,7 +13,6 @@ import java.util.prefs.BackingStoreException;
 import java.util.stream.Collectors;
 
 import javafx.beans.InvalidationListener;
-import javafx.collections.ListChangeListener;
 import javafx.collections.SetChangeListener;
 import javafx.scene.control.TableColumn;
 
@@ -295,6 +294,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getMergeDialogPreferences();
         getAutoCompletePreferences();
         getGuiPreferences();
+        getWorkspacePreferences();
 
         super.clear();
 
@@ -307,7 +307,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getNewEntryPreferences().setAll(NewEntryPreferences.getDefault());
         getSearchDialogColumnPreferences().setAll(ColumnPreferences.getDefault());
         getUnlinkedFilesDialogPreferences().setAll(UnlinkedFilesDialogPreferences.getDefault());
-        getWorkspacePreferences().setAll(WorkspacePreferences.getDefault());
         getSidePanePreferences().setAll(SidePanePreferences.getDefault());
         getNameDisplayPreferences().setAll(NameDisplayPreferences.getDefault());
         getPreviewPreferences().setAll(PreviewPreferences.getDefaultWithStyles(
@@ -325,6 +324,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getMergeDialogPreferences();
         getAutoCompletePreferences();
         getGuiPreferences();
+        getWorkspacePreferences();
 
         super.importPreferences(path);
 
@@ -338,7 +338,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getNewEntryPreferences().setAll(getNewEntryPreferencesFromBackingStore(getNewEntryPreferences()));
         getSearchDialogColumnPreferences().setAll(getSearchDialogColumnPreferencesFromBackingStore(getSearchDialogColumnPreferences()));
         getUnlinkedFilesDialogPreferences().setAll(getUnlinkedFilesDialogPreferences());
-        getWorkspacePreferences().setAll(getWorkspacePreferencesFromBackingStore(getWorkspacePreferences()));
         getSidePanePreferences().setAll(getSidePanePreferencesFromBackingStore(getSidePanePreferences()));
         getNameDisplayPreferences().setAll(getNameDisplayPreferencesFromBackingStore(getNameDisplayPreferences()));
         getPreviewPreferences().setAll(getPreviewPreferencesFromBackingStore(getPreviewPreferences()));
@@ -630,48 +629,43 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return workspacePreferences;
         }
 
-        workspacePreferences = getWorkspacePreferencesFromBackingStore(WorkspacePreferences.getDefault());
+        WorkspacePreferences defaultValues = WorkspacePreferences.getDefault();
 
-        EasyBind.listen(workspacePreferences.languageProperty(), (_, oldValue, newValue) -> {
-            put(LANGUAGE, newValue.getId());
-            if (oldValue != newValue) {
-                Localization.setLanguage(newValue);
-            }
-        });
-
-        EasyBind.listen(workspacePreferences.shouldOverrideDefaultFontSizeProperty(), (_, _, newValue) ->
-                putBoolean(OVERRIDE_DEFAULT_FONT_SIZE, newValue));
-        EasyBind.listen(workspacePreferences.mainFontSizeProperty(), (_, _, newValue) ->
-                putInt(MAIN_FONT_SIZE, newValue));
-        EasyBind.listen(workspacePreferences.themeProperty(), (_, _, newValue) ->
-                put(THEME, newValue.getName()));
-        EasyBind.listen(workspacePreferences.themeSyncOsProperty(), (_, _, newValue) ->
-                putBoolean(THEME_SYNC_OS, newValue));
-        EasyBind.listen(workspacePreferences.openLastEditedProperty(), (_, _, newValue) ->
-                putBoolean(OPEN_LAST_EDITED, newValue));
-        EasyBind.listen(workspacePreferences.showAdvancedHintsProperty(), (_, _, newValue) ->
-                putBoolean(SHOW_ADVANCED_HINTS, newValue));
-        EasyBind.listen(workspacePreferences.confirmDeleteProperty(), (_, _, newValue) ->
-                putBoolean(CONFIRM_DELETE, newValue));
-        EasyBind.listen(workspacePreferences.hideTabBarProperty(), (_, _, newValue) ->
-                putBoolean(CONFIRM_HIDE_TAB_BAR, newValue));
-        workspacePreferences.getSelectedSlrCatalogs().addListener((ListChangeListener<String>) _ ->
-                putStringList(SELECTED_SLR_CATALOGS, workspacePreferences.getSelectedSlrCatalogs()));
-        return workspacePreferences;
-    }
-
-    private WorkspacePreferences getWorkspacePreferencesFromBackingStore(WorkspacePreferences defaults) {
-        return new WorkspacePreferences(
+        workspacePreferences = new WorkspacePreferences(
                 getLanguage(),
-                getBoolean(OVERRIDE_DEFAULT_FONT_SIZE, defaults.shouldOverrideDefaultFontSize()),
-                getInt(MAIN_FONT_SIZE, defaults.getMainFontSize()),
+                getBoolean(OVERRIDE_DEFAULT_FONT_SIZE, defaultValues.shouldOverrideDefaultFontSize()),
+                getInt(MAIN_FONT_SIZE, defaultValues.getMainFontSize()),
                 new Theme(get(THEME, Theme.SYSTEM)),
-                getBoolean(THEME_SYNC_OS, defaults.shouldThemeSyncOs()),
-                getBoolean(OPEN_LAST_EDITED, defaults.shouldOpenLastEdited()),
-                getBoolean(SHOW_ADVANCED_HINTS, defaults.shouldShowAdvancedHints()),
-                getBoolean(CONFIRM_DELETE, defaults.shouldConfirmDelete()),
-                getBoolean(CONFIRM_HIDE_TAB_BAR, defaults.shouldHideTabBar()),
+                getBoolean(THEME_SYNC_OS, defaultValues.shouldThemeSyncOs()),
+                getBoolean(OPEN_LAST_EDITED, defaultValues.shouldOpenLastEdited()),
+                getBoolean(SHOW_ADVANCED_HINTS, defaultValues.shouldShowAdvancedHints()),
+                getBoolean(CONFIRM_DELETE, defaultValues.shouldConfirmDelete()),
+                getBoolean(CONFIRM_HIDE_TAB_BAR, defaultValues.shouldHideTabBar()),
                 getStringList(SELECTED_SLR_CATALOGS));
+
+        bindCustom(workspacePreferences.languageProperty(), LANGUAGE, defaultValues.getLanguage(),
+                (_, oldValue, newValue) -> {
+                    put(LANGUAGE, newValue.getId());
+                    if (oldValue != newValue) {
+                        Localization.setLanguage(newValue);
+                    }
+                },
+                () -> workspacePreferences.languageProperty().set(getLanguage()),
+                () -> workspacePreferences.languageProperty().set(defaultValues.getLanguage()));
+        bindBoolean(workspacePreferences.shouldOverrideDefaultFontSizeProperty(), OVERRIDE_DEFAULT_FONT_SIZE, defaultValues.shouldOverrideDefaultFontSize());
+        bindInt(workspacePreferences.mainFontSizeProperty(), MAIN_FONT_SIZE, defaultValues.getMainFontSize());
+        bindObject(workspacePreferences.themeProperty(), THEME, defaultValues.getTheme(),
+                Theme::getName, Theme::new);
+        bindBoolean(workspacePreferences.themeSyncOsProperty(), THEME_SYNC_OS, defaultValues.shouldThemeSyncOs());
+        bindBoolean(workspacePreferences.openLastEditedProperty(), OPEN_LAST_EDITED, defaultValues.shouldOpenLastEdited());
+        bindBoolean(workspacePreferences.showAdvancedHintsProperty(), SHOW_ADVANCED_HINTS, defaultValues.shouldShowAdvancedHints());
+        bindBoolean(workspacePreferences.confirmDeleteProperty(), CONFIRM_DELETE, defaultValues.shouldConfirmDelete());
+        bindBoolean(workspacePreferences.hideTabBarProperty(), CONFIRM_HIDE_TAB_BAR, defaultValues.shouldHideTabBar());
+        bindCustomList(workspacePreferences.getSelectedSlrCatalogs(), SELECTED_SLR_CATALOGS, defaultValues.getSelectedSlrCatalogs(),
+                boundList -> putStringList(SELECTED_SLR_CATALOGS, boundList),
+                () -> getStringList(SELECTED_SLR_CATALOGS));
+
+        return workspacePreferences;
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -308,12 +308,12 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getSpecialFieldsPreferences();
         getPreviewPreferences();
         getNameDisplayPreferences();
+        getMainTablePreferences();
 
         super.clear();
 
         getDonationPreferences().setAll(DonationPreferences.getDefault());
         getMainTableColumnPreferences().setAll(ColumnPreferences.getDefault());
-        getMainTablePreferences().setAll(MainTablePreferences.getDefault());
         getNewEntryPreferences().setAll(NewEntryPreferences.getDefault());
         getSearchDialogColumnPreferences().setAll(ColumnPreferences.getDefault());
         getMrDlibPreferences().setAll(MrDlibPreferences.getDefault());
@@ -335,13 +335,13 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getSpecialFieldsPreferences();
         getPreviewPreferences();
         getNameDisplayPreferences();
+        getMainTablePreferences();
 
         super.importPreferences(path);
 
         // in case of incomplete or corrupt xml fall back to current preferences
         getDonationPreferences().setAll(getDonationPreferencesFromBackingStore(getDonationPreferences()));
         getMainTableColumnPreferences().setAll(getMainTableColumnPreferencesFromBackingStore(getMainTableColumnPreferences()));
-        getMainTablePreferences().setAll(getMainTablePreferencesFromBackingStore(getMainTablePreferences()));
         getNewEntryPreferences().setAll(getNewEntryPreferencesFromBackingStore(getNewEntryPreferences()));
         getSearchDialogColumnPreferences().setAll(getSearchDialogColumnPreferencesFromBackingStore(getSearchDialogColumnPreferences()));
         getMrDlibPreferences().setAll(getMrDlibPreferencesFromBackingStore(getMrDlibPreferences()));
@@ -1037,22 +1037,18 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return mainTablePreferences;
         }
 
-        mainTablePreferences = getMainTablePreferencesFromBackingStore(MainTablePreferences.getDefault());
+        MainTablePreferences defaultValues = MainTablePreferences.getDefault();
 
-        EasyBind.listen(mainTablePreferences.resizeColumnsToFitProperty(),
-                (_, _, newValue) -> putBoolean(AUTO_RESIZE_MODE, newValue));
-        EasyBind.listen(mainTablePreferences.extraFileColumnsEnabledProperty(),
-                (_, _, newValue) -> putBoolean(EXTRA_FILE_COLUMNS, newValue));
+        mainTablePreferences = new MainTablePreferences(
+                getMainTableColumnPreferences(),
+                getBoolean(AUTO_RESIZE_MODE, defaultValues.getResizeColumnsToFit()),
+                getBoolean(EXTRA_FILE_COLUMNS, defaultValues.getExtraFileColumnsEnabled())
+        );
+
+        bindBoolean(mainTablePreferences.resizeColumnsToFitProperty(), AUTO_RESIZE_MODE, defaultValues.getResizeColumnsToFit());
+        bindBoolean(mainTablePreferences.extraFileColumnsEnabledProperty(), EXTRA_FILE_COLUMNS, defaultValues.getExtraFileColumnsEnabled());
 
         return mainTablePreferences;
-    }
-
-    private MainTablePreferences getMainTablePreferencesFromBackingStore(MainTablePreferences defaults) {
-        return new MainTablePreferences(
-                getMainTableColumnPreferences(),
-                getBoolean(AUTO_RESIZE_MODE, defaults.getResizeColumnsToFit()),
-                getBoolean(EXTRA_FILE_COLUMNS, defaults.getExtraFileColumnsEnabled())
-        );
     }
 
     public ColumnPreferences getMainTableColumnPreferences() {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.prefs.BackingStoreException;
 import java.util.stream.Collectors;
 
 import javafx.scene.control.TableColumn;
@@ -42,7 +41,6 @@ import org.jabref.gui.preview.PreviewPreferences;
 import org.jabref.gui.sidepane.SidePaneType;
 import org.jabref.gui.specialfields.SpecialFieldsPreferences;
 import org.jabref.gui.theme.Theme;
-import org.jabref.logic.JabRefException;
 import org.jabref.logic.citationstyle.CSLStyleLoader;
 import org.jabref.logic.exporter.BibDatabaseWriter;
 import org.jabref.logic.exporter.ExportPreferences;
@@ -88,6 +86,11 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     public static final String PREVIEW_COVER_IMAGE_DOWNLOAD = "coverDownload";
     // endregion
 
+    // region keybindings - public because needed for pref migration
+    public static final String BIND_NAMES = "bindNames";
+    public static final String BINDINGS = "bindings";
+    // endregion
+
     // region column names
     // public because of migration
     // Variable names have changed to ensure backward compatibility with pre 5.0 releases of JabRef
@@ -99,11 +102,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     // The column list spans the COLUMN_NAMES/COLUMN_WIDTHS/COLUMN_SORT_TYPES keys above; this synthetic key is never
     // written to the backing store and only serves as the binding's reporting key in getPreferences()/getDefaults().
     private static final String MAIN_TABLE_COLUMNS = "mainTableColumns";
-    // endregion
-
-    // region keybindings - public because needed for pref migration
-    public static final String BIND_NAMES = "bindNames";
-    public static final String BINDINGS = "bindings";
     // endregion
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JabRefGuiPreferences.class);
@@ -299,8 +297,8 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     }
 
     @Override
-    public void clear() throws BackingStoreException {
-        // ensure registration of bindings
+    protected void initializeAll() {
+        super.initializeAll();
         getCopyToPreferences();
         getEntryEditorPreferences();
         getMergeDialogPreferences();
@@ -320,34 +318,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getNewEntryPreferences();
         getDonationPreferences();
         getMrDlibPreferences();
-
-        super.clear();
-    }
-
-    @Override
-    public void importPreferences(Path path) throws JabRefException {
-        // ensure registration of bindings
-        getCopyToPreferences();
-        getEntryEditorPreferences();
-        getMergeDialogPreferences();
-        getAutoCompletePreferences();
-        getGuiPreferences();
-        getWorkspacePreferences();
-        getUnlinkedFilesDialogPreferences();
-        getSidePanePreferences();
-        getExternalApplicationsPreferences();
-        getGroupsPreferences();
-        getSpecialFieldsPreferences();
-        getPreviewPreferences();
-        getNameDisplayPreferences();
-        getMainTableColumnPreferences();
-        getMainTablePreferences();
-        getSearchDialogColumnPreferences();
-        getNewEntryPreferences();
-        getDonationPreferences();
-        getMrDlibPreferences();
-
-        super.importPreferences(path);
     }
 
     // region CopyToPreferences

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -318,10 +318,10 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getMainTablePreferences();
         getSearchDialogColumnPreferences();
         getNewEntryPreferences();
+        getDonationPreferences();
 
         super.clear();
 
-        getDonationPreferences().setAll(DonationPreferences.getDefault());
         getMrDlibPreferences().setAll(MrDlibPreferences.getDefault());
     }
 
@@ -345,11 +345,11 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getMainTablePreferences();
         getSearchDialogColumnPreferences();
         getNewEntryPreferences();
+        getDonationPreferences();
 
         super.importPreferences(path);
 
         // in case of incomplete or corrupt xml fall back to current preferences
-        getDonationPreferences().setAll(getDonationPreferencesFromBackingStore(getDonationPreferences()));
         getMrDlibPreferences().setAll(getMrDlibPreferencesFromBackingStore(getMrDlibPreferences()));
     }
 
@@ -1264,17 +1264,16 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return donationPreferences;
         }
 
-        donationPreferences = getDonationPreferencesFromBackingStore(DonationPreferences.getDefault());
+        DonationPreferences defaultValues = DonationPreferences.getDefault();
 
-        EasyBind.listen(donationPreferences.neverShowAgainProperty(), (_, _, newValue) -> putBoolean(DONATION_NEVER_SHOW, newValue));
-        EasyBind.listen(donationPreferences.lastShownEpochDayProperty(), (_, _, newValue) -> putInt(DONATION_LAST_SHOWN_EPOCH_DAY, newValue.intValue()));
+        donationPreferences = new DonationPreferences(
+                getBoolean(DONATION_NEVER_SHOW, defaultValues.isNeverShowAgain()),
+                getInt(DONATION_LAST_SHOWN_EPOCH_DAY, defaultValues.getLastShownEpochDay()));
+
+        bindBoolean(donationPreferences.neverShowAgainProperty(), DONATION_NEVER_SHOW, defaultValues.isNeverShowAgain());
+        bindInt(donationPreferences.lastShownEpochDayProperty(), DONATION_LAST_SHOWN_EPOCH_DAY, defaultValues.getLastShownEpochDay());
+
         return donationPreferences;
-    }
-
-    private DonationPreferences getDonationPreferencesFromBackingStore(DonationPreferences defaults) {
-        return new DonationPreferences(
-                getBoolean(DONATION_NEVER_SHOW, defaults.isNeverShowAgain()),
-                getInt(DONATION_LAST_SHOWN_EPOCH_DAY, defaults.getLastShownEpochDay()));
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -25,7 +25,6 @@ import org.jabref.gui.edit.CopyToPreferences;
 import org.jabref.gui.entryeditor.EntryEditorPreferences;
 import org.jabref.gui.entryeditor.EntryEditorTabModel;
 import org.jabref.gui.externalfiles.UnlinkedFilesDialogPreferences;
-import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.frame.ExternalApplicationsPreferences;
 import org.jabref.gui.frame.SidePanePreferences;
@@ -302,13 +301,13 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getWorkspacePreferences();
         getUnlinkedFilesDialogPreferences();
         getSidePanePreferences();
+        getExternalApplicationsPreferences();
 
         super.clear();
 
         getDonationPreferences().setAll(DonationPreferences.getDefault());
         getGroupsPreferences().setAll(GroupsPreferences.getDefault());
         getSpecialFieldsPreferences().setAll(SpecialFieldsPreferences.getDefault());
-        getExternalApplicationsPreferences().setAll(ExternalApplicationsPreferences.getDefault());
         getMainTableColumnPreferences().setAll(ColumnPreferences.getDefault());
         getMainTablePreferences().setAll(MainTablePreferences.getDefault());
         getNewEntryPreferences().setAll(NewEntryPreferences.getDefault());
@@ -332,6 +331,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getWorkspacePreferences();
         getUnlinkedFilesDialogPreferences();
         getSidePanePreferences();
+        getExternalApplicationsPreferences();
 
         super.importPreferences(path);
 
@@ -339,7 +339,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getDonationPreferences().setAll(getDonationPreferencesFromBackingStore(getDonationPreferences()));
         getGroupsPreferences().setAll(getGroupsPreferencesFromBackingStore(getGroupsPreferences()));
         getSpecialFieldsPreferences().setAll(getSpecialFieldsPreferencesFromBackingStore(getSpecialFieldsPreferences()));
-        getExternalApplicationsPreferences().setAll(getExternalApplicationsPreferencesFromBackingStore(getExternalApplicationsPreferences()));
         getMainTableColumnPreferences().setAll(getMainTableColumnPreferencesFromBackingStore(getMainTableColumnPreferences()));
         getMainTablePreferences().setAll(getMainTablePreferencesFromBackingStore(getMainTablePreferences()));
         getNewEntryPreferences().setAll(getNewEntryPreferencesFromBackingStore(getNewEntryPreferences()));
@@ -794,39 +793,39 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return externalApplicationsPreferences;
         }
 
-        externalApplicationsPreferences = getExternalApplicationsPreferencesFromBackingStore(ExternalApplicationsPreferences.getDefault());
+        ExternalApplicationsPreferences defaultValues = ExternalApplicationsPreferences.getDefault();
 
-        EasyBind.listen(externalApplicationsPreferences.eMailSubjectProperty(),
-                (_, _, newValue) -> put(EMAIL_SUBJECT, newValue));
-        EasyBind.listen(externalApplicationsPreferences.autoOpenEmailAttachmentsFolderProperty(),
-                (_, _, newValue) -> putBoolean(OPEN_FOLDERS_OF_ATTACHED_FILES, newValue));
-        EasyBind.listen(externalApplicationsPreferences.useCustomTerminalProperty(),
-                (_, _, newValue) -> putBoolean(USE_DEFAULT_CONSOLE_APPLICATION, !newValue)); // mind the !
-        externalApplicationsPreferences.getExternalFileTypes().addListener((SetChangeListener<ExternalFileType>) _ ->
-                put(EXTERNAL_FILE_TYPES, ExternalFileTypes.toStringList(externalApplicationsPreferences.getExternalFileTypes())));
-        EasyBind.listen(externalApplicationsPreferences.customTerminalCommandProperty(),
-                (_, _, newValue) -> put(CONSOLE_COMMAND, newValue));
-        EasyBind.listen(externalApplicationsPreferences.useCustomFileBrowserProperty(),
-                (_, _, newValue) -> putBoolean(USE_DEFAULT_FILE_BROWSER_APPLICATION, !newValue)); // mind the !
-        EasyBind.listen(externalApplicationsPreferences.customFileBrowserCommandProperty(),
-                (_, _, newValue) -> put(FILE_BROWSER_COMMAND, newValue));
-        EasyBind.listen(externalApplicationsPreferences.kindleEmailProperty(),
-                (_, _, newValue) -> put(KINDLE_EMAIL, newValue));
+        externalApplicationsPreferences = new ExternalApplicationsPreferences(
+                get(EMAIL_SUBJECT, defaultValues.getEmailSubject()),
+                getBoolean(OPEN_FOLDERS_OF_ATTACHED_FILES, defaultValues.shouldAutoOpenEmailAttachmentsFolder()),
+                ExternalFileTypes.fromString(get(EXTERNAL_FILE_TYPES, ExternalFileTypes.toStringList(defaultValues.getExternalFileTypes()))),
+                !getBoolean(USE_DEFAULT_CONSOLE_APPLICATION, !defaultValues.useCustomTerminal()), // mind the !
+                get(CONSOLE_COMMAND, defaultValues.getCustomTerminalCommand()),
+                !getBoolean(USE_DEFAULT_FILE_BROWSER_APPLICATION, !defaultValues.useCustomFileBrowser()), // mind the !
+                get(FILE_BROWSER_COMMAND, defaultValues.getCustomFileBrowserCommand()),
+                get(KINDLE_EMAIL, defaultValues.getKindleEmail())
+        );
+
+        bindString(externalApplicationsPreferences.eMailSubjectProperty(), EMAIL_SUBJECT, defaultValues.getEmailSubject());
+        bindBoolean(externalApplicationsPreferences.autoOpenEmailAttachmentsFolderProperty(), OPEN_FOLDERS_OF_ATTACHED_FILES, defaultValues.shouldAutoOpenEmailAttachmentsFolder());
+        // useCustomTerminal is persisted inverted, under the legacy USE_DEFAULT_CONSOLE_APPLICATION key.
+        bindCustom(externalApplicationsPreferences.useCustomTerminalProperty(), USE_DEFAULT_CONSOLE_APPLICATION, defaultValues.useCustomTerminal(),
+                (_, _, newValue) -> putBoolean(USE_DEFAULT_CONSOLE_APPLICATION, !newValue),
+                () -> externalApplicationsPreferences.useCustomTerminalProperty().set(!getBoolean(USE_DEFAULT_CONSOLE_APPLICATION, !defaultValues.useCustomTerminal())),
+                () -> externalApplicationsPreferences.useCustomTerminalProperty().set(defaultValues.useCustomTerminal()));
+        bindString(externalApplicationsPreferences.customTerminalCommandProperty(), CONSOLE_COMMAND, defaultValues.getCustomTerminalCommand());
+        // useCustomFileBrowser is persisted inverted, under the legacy USE_DEFAULT_FILE_BROWSER_APPLICATION key.
+        bindCustom(externalApplicationsPreferences.useCustomFileBrowserProperty(), USE_DEFAULT_FILE_BROWSER_APPLICATION, defaultValues.useCustomFileBrowser(),
+                (_, _, newValue) -> putBoolean(USE_DEFAULT_FILE_BROWSER_APPLICATION, !newValue),
+                () -> externalApplicationsPreferences.useCustomFileBrowserProperty().set(!getBoolean(USE_DEFAULT_FILE_BROWSER_APPLICATION, !defaultValues.useCustomFileBrowser())),
+                () -> externalApplicationsPreferences.useCustomFileBrowserProperty().set(defaultValues.useCustomFileBrowser()));
+        bindString(externalApplicationsPreferences.customFileBrowserCommandProperty(), FILE_BROWSER_COMMAND, defaultValues.getCustomFileBrowserCommand());
+        bindString(externalApplicationsPreferences.kindleEmailProperty(), KINDLE_EMAIL, defaultValues.getKindleEmail());
+        bindSet(externalApplicationsPreferences.getExternalFileTypes(), EXTERNAL_FILE_TYPES, defaultValues.getExternalFileTypes(),
+                set -> put(EXTERNAL_FILE_TYPES, ExternalFileTypes.toStringList(set)),
+                () -> ExternalFileTypes.fromString(get(EXTERNAL_FILE_TYPES, ExternalFileTypes.toStringList(defaultValues.getExternalFileTypes()))));
 
         return externalApplicationsPreferences;
-    }
-
-    private ExternalApplicationsPreferences getExternalApplicationsPreferencesFromBackingStore(ExternalApplicationsPreferences defaults) {
-        return new ExternalApplicationsPreferences(
-                get(EMAIL_SUBJECT, defaults.getEmailSubject()),
-                getBoolean(OPEN_FOLDERS_OF_ATTACHED_FILES, defaults.shouldAutoOpenEmailAttachmentsFolder()),
-                ExternalFileTypes.fromString(get(EXTERNAL_FILE_TYPES, ExternalFileTypes.toStringList(defaults.getExternalFileTypes()))),
-                !getBoolean(USE_DEFAULT_CONSOLE_APPLICATION, !defaults.useCustomTerminal()), // mind the !
-                get(CONSOLE_COMMAND, defaults.getCustomTerminalCommand()),
-                !getBoolean(USE_DEFAULT_FILE_BROWSER_APPLICATION, !defaults.useCustomFileBrowser()), // mind the !
-                get(FILE_BROWSER_COMMAND, defaults.getCustomFileBrowserCommand()),
-                get(KINDLE_EMAIL, defaults.getKindleEmail())
-        );
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -12,7 +12,6 @@ import java.util.Set;
 import java.util.prefs.BackingStoreException;
 import java.util.stream.Collectors;
 
-import javafx.beans.InvalidationListener;
 import javafx.scene.control.TableColumn;
 
 import org.jabref.gui.CoreGuiPreferences;
@@ -96,6 +95,9 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     public static final String COLUMN_WIDTHS = "mainTableColumnWidths";
     public static final String COLUMN_SORT_TYPES = "mainTableColumnSortTypes";
     public static final String COLUMN_SORT_ORDER = "mainTableColumnSortOrder";
+    // The column list spans the COLUMN_NAMES/COLUMN_WIDTHS/COLUMN_SORT_TYPES keys above; this synthetic key is never
+    // written to the backing store and only serves as the binding's reporting key in getPreferences()/getDefaults().
+    private static final String MAIN_TABLE_COLUMNS = "mainTableColumns";
     // endregion
 
     // region keybindings - public because needed for pref migration
@@ -137,6 +139,9 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     private static final String SEARCH_DIALOG_COLUMN_WIDTHS = "searchTableColumnWidths";
     private static final String SEARCH_DIALOG_COLUMN_SORT_TYPES = "searchDialogColumnSortTypes";
     private static final String SEARCH_DIALOG_COLUMN_SORT_ORDER = "searchDalogColumnSortOrder";
+    // The column list spans COLUMN_NAMES (shared with the main table) plus the SEARCH_DIALOG_COLUMN_WIDTHS/_SORT_TYPES
+    // keys; this synthetic key is never written to the backing store and only serves as the binding's reporting key.
+    private static final String SEARCH_DIALOG_COLUMNS = "searchDialogColumns";
     // endregion
 
     // region NameDisplayPreferences
@@ -308,14 +313,14 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getSpecialFieldsPreferences();
         getPreviewPreferences();
         getNameDisplayPreferences();
+        getMainTableColumnPreferences();
         getMainTablePreferences();
+        getSearchDialogColumnPreferences();
 
         super.clear();
 
         getDonationPreferences().setAll(DonationPreferences.getDefault());
-        getMainTableColumnPreferences().setAll(ColumnPreferences.getDefault());
         getNewEntryPreferences().setAll(NewEntryPreferences.getDefault());
-        getSearchDialogColumnPreferences().setAll(ColumnPreferences.getDefault());
         getMrDlibPreferences().setAll(MrDlibPreferences.getDefault());
     }
 
@@ -335,15 +340,15 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getSpecialFieldsPreferences();
         getPreviewPreferences();
         getNameDisplayPreferences();
+        getMainTableColumnPreferences();
         getMainTablePreferences();
+        getSearchDialogColumnPreferences();
 
         super.importPreferences(path);
 
         // in case of incomplete or corrupt xml fall back to current preferences
         getDonationPreferences().setAll(getDonationPreferencesFromBackingStore(getDonationPreferences()));
-        getMainTableColumnPreferences().setAll(getMainTableColumnPreferencesFromBackingStore(getMainTableColumnPreferences()));
         getNewEntryPreferences().setAll(getNewEntryPreferencesFromBackingStore(getNewEntryPreferences()));
-        getSearchDialogColumnPreferences().setAll(getSearchDialogColumnPreferencesFromBackingStore(getSearchDialogColumnPreferences()));
         getMrDlibPreferences().setAll(getMrDlibPreferencesFromBackingStore(getMrDlibPreferences()));
     }
 
@@ -949,8 +954,8 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         bindCustomList(previewPreferences.getBstPreviewLayoutPaths(), PREVIEW_BST_LAYOUT_PATHS, defaultValues.getBstPreviewLayoutPaths(),
                 this::storeBstPaths,
                 () -> hasKey(PREVIEW_BST_LAYOUT_PATHS)
-                        ? getStringList(PREVIEW_BST_LAYOUT_PATHS).stream().map(Path::of).toList()
-                        : defaultValues.getBstPreviewLayoutPaths());
+                      ? getStringList(PREVIEW_BST_LAYOUT_PATHS).stream().map(Path::of).toList()
+                      : defaultValues.getBstPreviewLayoutPaths());
         bindBoolean(previewPreferences.shouldDownloadCoversProperty(), PREVIEW_COVER_IMAGE_DOWNLOAD, defaultValues.shouldDownloadCovers());
 
         return this.previewPreferences;
@@ -1056,26 +1061,35 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return mainTableColumnPreferences;
         }
 
-        mainTableColumnPreferences = getMainTableColumnPreferencesFromBackingStore(ColumnPreferences.getDefault());
+        ColumnPreferences defaultValues = ColumnPreferences.getDefault();
 
-        mainTableColumnPreferences.getColumns().addListener((InvalidationListener) _ -> {
-            putStringList(COLUMN_NAMES, getColumnNamesAsStringList(mainTableColumnPreferences));
-            putStringList(COLUMN_WIDTHS, getColumnWidthsAsStringList(mainTableColumnPreferences));
-            putStringList(COLUMN_SORT_TYPES, getColumnSortTypesAsStringList(mainTableColumnPreferences));
-        });
-        mainTableColumnPreferences.getColumnSortOrder().addListener((InvalidationListener) _ ->
-                putStringList(COLUMN_SORT_ORDER, getColumnSortOrderAsStringList(mainTableColumnPreferences)));
-
-        return mainTableColumnPreferences;
-    }
-
-    private ColumnPreferences getMainTableColumnPreferencesFromBackingStore(ColumnPreferences defaults) {
         List<MainTableColumnModel> columns = getColumns(COLUMN_NAMES, COLUMN_WIDTHS, COLUMN_SORT_TYPES, ColumnPreferences.DEFAULT_COLUMN_WIDTH);
         List<MainTableColumnModel> columnSortOrder = getColumnSortOrder(COLUMN_SORT_ORDER, columns);
-        return new ColumnPreferences(
-                columns.isEmpty() ? defaults.getColumns() : columns,
-                columnSortOrder.isEmpty() ? defaults.getColumnSortOrder() : columnSortOrder
+        mainTableColumnPreferences = new ColumnPreferences(
+                columns.isEmpty() ? defaultValues.getColumns() : columns,
+                columnSortOrder.isEmpty() ? defaultValues.getColumnSortOrder() : columnSortOrder
         );
+
+        // The columns list is persisted across COLUMN_NAMES/COLUMN_WIDTHS/COLUMN_SORT_TYPES; registered before the sort
+        // order, so its import runs first and the sort order can resolve against the loaded columns.
+        bindCustomList(mainTableColumnPreferences.getColumns(), MAIN_TABLE_COLUMNS, defaultValues.getColumns(),
+                boundList -> {
+                    putStringList(COLUMN_NAMES, getColumnNamesAsStringList(mainTableColumnPreferences));
+                    putStringList(COLUMN_WIDTHS, getColumnWidthsAsStringList(mainTableColumnPreferences));
+                    putStringList(COLUMN_SORT_TYPES, getColumnSortTypesAsStringList(mainTableColumnPreferences));
+                },
+                () -> {
+                    List<MainTableColumnModel> stored = getColumns(COLUMN_NAMES, COLUMN_WIDTHS, COLUMN_SORT_TYPES, ColumnPreferences.DEFAULT_COLUMN_WIDTH);
+                    return stored.isEmpty() ? defaultValues.getColumns() : stored;
+                });
+        bindCustomList(mainTableColumnPreferences.getColumnSortOrder(), COLUMN_SORT_ORDER, defaultValues.getColumnSortOrder(),
+                boundList -> putStringList(COLUMN_SORT_ORDER, getColumnSortOrderAsStringList(mainTableColumnPreferences)),
+                () -> {
+                    List<MainTableColumnModel> stored = getColumnSortOrder(COLUMN_SORT_ORDER, mainTableColumnPreferences.getColumns());
+                    return stored.isEmpty() ? defaultValues.getColumnSortOrder() : stored;
+                });
+
+        return mainTableColumnPreferences;
     }
     // endregion
 
@@ -1085,27 +1099,34 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return searchDialogColumnPreferences;
         }
 
-        searchDialogColumnPreferences = getSearchDialogColumnPreferencesFromBackingStore(ColumnPreferences.getDefault());
+        ColumnPreferences defaultValues = ColumnPreferences.getDefault();
 
-        searchDialogColumnPreferences.getColumns().addListener((InvalidationListener) _ -> {
-            // MainTable and SearchResultTable use the same set of columnNames
-            // putStringList(SEARCH_DIALOG_COLUMN_NAMES, getColumnNamesAsStringList(columnPreferences));
-            putStringList(SEARCH_DIALOG_COLUMN_WIDTHS, getColumnWidthsAsStringList(searchDialogColumnPreferences));
-            putStringList(SEARCH_DIALOG_COLUMN_SORT_TYPES, getColumnSortTypesAsStringList(searchDialogColumnPreferences));
-        });
-        searchDialogColumnPreferences.getColumnSortOrder().addListener((InvalidationListener) _ ->
-                putStringList(SEARCH_DIALOG_COLUMN_SORT_ORDER, getColumnSortOrderAsStringList(searchDialogColumnPreferences)));
-
-        return searchDialogColumnPreferences;
-    }
-
-    private ColumnPreferences getSearchDialogColumnPreferencesFromBackingStore(ColumnPreferences defaults) {
         List<MainTableColumnModel> columns = getColumns(COLUMN_NAMES, SEARCH_DIALOG_COLUMN_WIDTHS, SEARCH_DIALOG_COLUMN_SORT_TYPES, ColumnPreferences.DEFAULT_COLUMN_WIDTH);
         List<MainTableColumnModel> columnSortOrder = getColumnSortOrder(SEARCH_DIALOG_COLUMN_SORT_ORDER, columns);
-        return new ColumnPreferences(
-                columns.isEmpty() ? defaults.getColumns() : columns,
-                columnSortOrder.isEmpty() ? defaults.getColumnSortOrder() : columnSortOrder
+        searchDialogColumnPreferences = new ColumnPreferences(
+                columns.isEmpty() ? defaultValues.getColumns() : columns,
+                columnSortOrder.isEmpty() ? defaultValues.getColumnSortOrder() : columnSortOrder
         );
+
+        // Column names are shared with the main table (COLUMN_NAMES) and owned there, so only widths and sort types are
+        // persisted here. Registered before the sort order, so its import runs first and the sort order can resolve.
+        bindCustomList(searchDialogColumnPreferences.getColumns(), SEARCH_DIALOG_COLUMNS, defaultValues.getColumns(),
+                boundList -> {
+                    putStringList(SEARCH_DIALOG_COLUMN_WIDTHS, getColumnWidthsAsStringList(searchDialogColumnPreferences));
+                    putStringList(SEARCH_DIALOG_COLUMN_SORT_TYPES, getColumnSortTypesAsStringList(searchDialogColumnPreferences));
+                },
+                () -> {
+                    List<MainTableColumnModel> stored = getColumns(COLUMN_NAMES, SEARCH_DIALOG_COLUMN_WIDTHS, SEARCH_DIALOG_COLUMN_SORT_TYPES, ColumnPreferences.DEFAULT_COLUMN_WIDTH);
+                    return stored.isEmpty() ? defaultValues.getColumns() : stored;
+                });
+        bindCustomList(searchDialogColumnPreferences.getColumnSortOrder(), SEARCH_DIALOG_COLUMN_SORT_ORDER, defaultValues.getColumnSortOrder(),
+                boundList -> putStringList(SEARCH_DIALOG_COLUMN_SORT_ORDER, getColumnSortOrderAsStringList(searchDialogColumnPreferences)),
+                () -> {
+                    List<MainTableColumnModel> stored = getColumnSortOrder(SEARCH_DIALOG_COLUMN_SORT_ORDER, searchDialogColumnPreferences.getColumns());
+                    return stored.isEmpty() ? defaultValues.getColumnSortOrder() : stored;
+                });
+
+        return searchDialogColumnPreferences;
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -317,11 +317,11 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getMainTableColumnPreferences();
         getMainTablePreferences();
         getSearchDialogColumnPreferences();
+        getNewEntryPreferences();
 
         super.clear();
 
         getDonationPreferences().setAll(DonationPreferences.getDefault());
-        getNewEntryPreferences().setAll(NewEntryPreferences.getDefault());
         getMrDlibPreferences().setAll(MrDlibPreferences.getDefault());
     }
 
@@ -344,12 +344,12 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getMainTableColumnPreferences();
         getMainTablePreferences();
         getSearchDialogColumnPreferences();
+        getNewEntryPreferences();
 
         super.importPreferences(path);
 
         // in case of incomplete or corrupt xml fall back to current preferences
         getDonationPreferences().setAll(getDonationPreferencesFromBackingStore(getDonationPreferences()));
-        getNewEntryPreferences().setAll(getNewEntryPreferencesFromBackingStore(getNewEntryPreferences()));
         getMrDlibPreferences().setAll(getMrDlibPreferencesFromBackingStore(getMrDlibPreferences()));
     }
 
@@ -1209,45 +1209,52 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return newEntryPreferences;
         }
 
-        newEntryPreferences = getNewEntryPreferencesFromBackingStore(NewEntryPreferences.getDefault());
+        NewEntryPreferences defaultValues = NewEntryPreferences.getDefault();
 
-        EasyBind.listen(newEntryPreferences.latestApproachProperty(), (_, _, newValue) -> putInt(CREATE_ENTRY_APPROACH, List.of(NewEntryDialogTab.values()).indexOf(newValue)));
-        EasyBind.listen(newEntryPreferences.typesRecommendedExpandedProperty(), (_, _, newValue) -> putBoolean(CREATE_ENTRY_EXPAND_RECOMMENDED, newValue));
-        EasyBind.listen(newEntryPreferences.typesOtherExpandedProperty(), (_, _, newValue) -> putBoolean(CREATE_ENTRY_EXPAND_OTHER, newValue));
-        EasyBind.listen(newEntryPreferences.typesCustomExpandedProperty(), (_, _, newValue) -> putBoolean(CREATE_ENTRY_EXPAND_CUSTOM, newValue));
-        EasyBind.listen(newEntryPreferences.latestImmediateTypeProperty(), (_, _, newValue) -> put(CREATE_ENTRY_IMMEDIATE_TYPE, newValue.getDisplayName()));
-        EasyBind.listen(newEntryPreferences.idLookupGuessingProperty(), (_, _, newValue) -> putBoolean(CREATE_ENTRY_ID_LOOKUP_GUESSING, newValue));
-        EasyBind.listen(newEntryPreferences.latestIdFetcherProperty(), (_, _, newValue) -> put(CREATE_ENTRY_ID_FETCHER_NAME, newValue));
-        EasyBind.listen(newEntryPreferences.latestInterpretParserProperty(), (_, _, newValue) -> put(CREATE_ENTRY_INTERPRET_PARSER_NAME, newValue));
+        newEntryPreferences = new NewEntryPreferences(
+                readNewEntryApproach(defaultValues.getLatestApproach()),
+                getBoolean(CREATE_ENTRY_EXPAND_RECOMMENDED, defaultValues.getTypesRecommendedExpanded()),
+                getBoolean(CREATE_ENTRY_EXPAND_OTHER, defaultValues.getTypesOtherExpanded()),
+                getBoolean(CREATE_ENTRY_EXPAND_CUSTOM, defaultValues.getTypesCustomExpanded()),
+                parseNewEntryImmediateType(get(CREATE_ENTRY_IMMEDIATE_TYPE, defaultValues.getLatestImmediateType().getDisplayName())),
+                getBoolean(CREATE_ENTRY_ID_LOOKUP_GUESSING, defaultValues.getIdLookupGuessing()),
+                get(CREATE_ENTRY_ID_FETCHER_NAME, defaultValues.getLatestIdFetcher()),
+                get(CREATE_ENTRY_INTERPRET_PARSER_NAME, defaultValues.getLatestInterpretParser())
+        );
+
+        // latestApproach is persisted as the index into NewEntryDialogTab.values(), so it needs a custom binding.
+        bindCustom(newEntryPreferences.latestApproachProperty(), CREATE_ENTRY_APPROACH, defaultValues.getLatestApproach(),
+                (_, _, newValue) -> putInt(CREATE_ENTRY_APPROACH, List.of(NewEntryDialogTab.values()).indexOf(newValue)),
+                () -> newEntryPreferences.latestApproachProperty().set(readNewEntryApproach(defaultValues.getLatestApproach())),
+                () -> newEntryPreferences.latestApproachProperty().set(defaultValues.getLatestApproach()));
+        bindBoolean(newEntryPreferences.typesRecommendedExpandedProperty(), CREATE_ENTRY_EXPAND_RECOMMENDED, defaultValues.getTypesRecommendedExpanded());
+        bindBoolean(newEntryPreferences.typesOtherExpandedProperty(), CREATE_ENTRY_EXPAND_OTHER, defaultValues.getTypesOtherExpanded());
+        bindBoolean(newEntryPreferences.typesCustomExpandedProperty(), CREATE_ENTRY_EXPAND_CUSTOM, defaultValues.getTypesCustomExpanded());
+        // latestImmediateType is persisted by its display name.
+        bindObject(newEntryPreferences.latestImmediateTypeProperty(), CREATE_ENTRY_IMMEDIATE_TYPE, defaultValues.getLatestImmediateType(),
+                EntryType::getDisplayName, this::parseNewEntryImmediateType);
+        bindBoolean(newEntryPreferences.idLookupGuessingProperty(), CREATE_ENTRY_ID_LOOKUP_GUESSING, defaultValues.getIdLookupGuessing());
+        bindString(newEntryPreferences.latestIdFetcherProperty(), CREATE_ENTRY_ID_FETCHER_NAME, defaultValues.getLatestIdFetcher());
+        bindString(newEntryPreferences.latestInterpretParserProperty(), CREATE_ENTRY_INTERPRET_PARSER_NAME, defaultValues.getLatestInterpretParser());
 
         return newEntryPreferences;
     }
 
-    private NewEntryPreferences getNewEntryPreferencesFromBackingStore(NewEntryPreferences defaults) {
-        final int approachIndex = getInt(CREATE_ENTRY_APPROACH, List.of(NewEntryDialogTab.values()).indexOf(defaults.getLatestApproach()));
-        NewEntryDialogTab approach = NewEntryDialogTab.values().length > approachIndex
-                                     ? NewEntryDialogTab.values()[approachIndex]
-                                     : NewEntryDialogTab.values()[0];
+    private NewEntryDialogTab readNewEntryApproach(NewEntryDialogTab defaultValue) {
+        int approachIndex = getInt(CREATE_ENTRY_APPROACH, List.of(NewEntryDialogTab.values()).indexOf(defaultValue));
+        return NewEntryDialogTab.values().length > approachIndex
+               ? NewEntryDialogTab.values()[approachIndex]
+               : NewEntryDialogTab.values()[0];
+    }
 
-        final String immediateTypeName = get(CREATE_ENTRY_IMMEDIATE_TYPE, defaults.getLatestImmediateType().getDisplayName());
-        EntryType immediateType = StandardEntryType.Article;
+    /// Resolves a [StandardEntryType] from its display name, falling back to [StandardEntryType#Article].
+    private EntryType parseNewEntryImmediateType(String displayName) {
         for (StandardEntryType type : StandardEntryType.values()) {
-            if (type.getDisplayName().equals(immediateTypeName)) {
-                immediateType = type;
-                break;
+            if (type.getDisplayName().equals(displayName)) {
+                return type;
             }
         }
-
-        return new NewEntryPreferences(
-                approach,
-                getBoolean(CREATE_ENTRY_EXPAND_RECOMMENDED, defaults.getTypesRecommendedExpanded()),
-                getBoolean(CREATE_ENTRY_EXPAND_OTHER, defaults.getTypesOtherExpanded()),
-                getBoolean(CREATE_ENTRY_EXPAND_CUSTOM, defaults.getTypesCustomExpanded()),
-                immediateType,
-                getBoolean(CREATE_ENTRY_ID_LOOKUP_GUESSING, defaults.getIdLookupGuessing()),
-                get(CREATE_ENTRY_ID_FETCHER_NAME, defaults.getLatestIdFetcher()),
-                get(CREATE_ENTRY_INTERPRET_PARSER_NAME, defaults.getLatestInterpretParser())
-        );
+        return StandardEntryType.Article;
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -294,12 +294,12 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getEntryEditorPreferences();
         getMergeDialogPreferences();
         getAutoCompletePreferences();
+        getGuiPreferences();
 
         super.clear();
 
         getDonationPreferences().setAll(DonationPreferences.getDefault());
         getGroupsPreferences().setAll(GroupsPreferences.getDefault());
-        getGuiPreferences().setAll(CoreGuiPreferences.getDefault());
         getSpecialFieldsPreferences().setAll(SpecialFieldsPreferences.getDefault());
         getExternalApplicationsPreferences().setAll(ExternalApplicationsPreferences.getDefault());
         getMainTableColumnPreferences().setAll(ColumnPreferences.getDefault());
@@ -324,13 +324,13 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getEntryEditorPreferences();
         getMergeDialogPreferences();
         getAutoCompletePreferences();
+        getGuiPreferences();
 
         super.importPreferences(path);
 
         // in case of incomplete or corrupt xml fall back to current preferences
         getDonationPreferences().setAll(getDonationPreferencesFromBackingStore(getDonationPreferences()));
         getGroupsPreferences().setAll(getGroupsPreferencesFromBackingStore(getGroupsPreferences()));
-        getGuiPreferences().setAll(getCoreGuiPreferencesFromBackingStore(getGuiPreferences()));
         getSpecialFieldsPreferences().setAll(getSpecialFieldsPreferencesFromBackingStore(getSpecialFieldsPreferences()));
         getExternalApplicationsPreferences().setAll(getExternalApplicationsPreferencesFromBackingStore(getExternalApplicationsPreferences()));
         getMainTableColumnPreferences().setAll(getMainTableColumnPreferencesFromBackingStore(getMainTableColumnPreferences()));
@@ -600,28 +600,26 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return coreGuiPreferences;
         }
 
-        coreGuiPreferences = getCoreGuiPreferencesFromBackingStore(CoreGuiPreferences.getDefault());
+        CoreGuiPreferences defaultValues = CoreGuiPreferences.getDefault();
 
-        EasyBind.listen(coreGuiPreferences.positionXProperty(), (_, _, newValue) -> putDouble(MAIN_WINDOW_POS_X, newValue.doubleValue()));
-        EasyBind.listen(coreGuiPreferences.positionYProperty(), (_, _, newValue) -> putDouble(MAIN_WINDOW_POS_Y, newValue.doubleValue()));
-        EasyBind.listen(coreGuiPreferences.sizeXProperty(), (_, _, newValue) -> putDouble(MAIN_WINDOW_WIDTH, newValue.doubleValue()));
-        EasyBind.listen(coreGuiPreferences.sizeYProperty(), (_, _, newValue) -> putDouble(MAIN_WINDOW_HEIGHT, newValue.doubleValue()));
-        EasyBind.listen(coreGuiPreferences.windowMaximisedProperty(), (_, _, newValue) -> putBoolean(MAIN_WINDOW_MAXIMISED, newValue));
-        EasyBind.listen(coreGuiPreferences.horizontalDividerPositionProperty(), (_, _, newValue) -> putDouble(MAIN_WINDOW_SIDEPANE_WIDTH, newValue.doubleValue()));
-        EasyBind.listen(coreGuiPreferences.getVerticalDividerPositionProperty(), (_, _, newValue) -> putDouble(MAIN_WINDOW_EDITOR_HEIGHT, newValue.doubleValue()));
+        coreGuiPreferences = new CoreGuiPreferences(
+                getDouble(MAIN_WINDOW_POS_X, defaultValues.getPositionX()),
+                getDouble(MAIN_WINDOW_POS_Y, defaultValues.getPositionY()),
+                getDouble(MAIN_WINDOW_WIDTH, defaultValues.getSizeX()),
+                getDouble(MAIN_WINDOW_HEIGHT, defaultValues.getSizeY()),
+                getBoolean(MAIN_WINDOW_MAXIMISED, defaultValues.isWindowMaximised()),
+                getDouble(MAIN_WINDOW_SIDEPANE_WIDTH, defaultValues.getHorizontalDividerPosition()),
+                getDouble(MAIN_WINDOW_EDITOR_HEIGHT, defaultValues.getVerticalDividerPosition()));
+
+        bindDouble(coreGuiPreferences.positionXProperty(), MAIN_WINDOW_POS_X, defaultValues.getPositionX());
+        bindDouble(coreGuiPreferences.positionYProperty(), MAIN_WINDOW_POS_Y, defaultValues.getPositionY());
+        bindDouble(coreGuiPreferences.sizeXProperty(), MAIN_WINDOW_WIDTH, defaultValues.getSizeX());
+        bindDouble(coreGuiPreferences.sizeYProperty(), MAIN_WINDOW_HEIGHT, defaultValues.getSizeY());
+        bindBoolean(coreGuiPreferences.windowMaximisedProperty(), MAIN_WINDOW_MAXIMISED, defaultValues.isWindowMaximised());
+        bindDouble(coreGuiPreferences.horizontalDividerPositionProperty(), MAIN_WINDOW_SIDEPANE_WIDTH, defaultValues.getHorizontalDividerPosition());
+        bindDouble(coreGuiPreferences.getVerticalDividerPositionProperty(), MAIN_WINDOW_EDITOR_HEIGHT, defaultValues.getVerticalDividerPosition());
 
         return coreGuiPreferences;
-    }
-
-    private CoreGuiPreferences getCoreGuiPreferencesFromBackingStore(CoreGuiPreferences defaults) {
-        return new CoreGuiPreferences(
-                getDouble(MAIN_WINDOW_POS_X, defaults.getPositionX()),
-                getDouble(MAIN_WINDOW_POS_Y, defaults.getPositionY()),
-                getDouble(MAIN_WINDOW_WIDTH, defaults.getSizeX()),
-                getDouble(MAIN_WINDOW_HEIGHT, defaults.getSizeY()),
-                getBoolean(MAIN_WINDOW_MAXIMISED, defaults.isWindowMaximised()),
-                getDouble(MAIN_WINDOW_SIDEPANE_WIDTH, defaults.getHorizontalDividerPosition()),
-                getDouble(MAIN_WINDOW_EDITOR_HEIGHT, defaults.getVerticalDividerPosition()));
     }
     // endregion
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -172,6 +172,11 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     private static final String WEB_SEARCH_VISIBLE = "webSearchVisible";
     private static final String OO_SHOW_PANEL = "showOOPanel";
     private static final String GROUP_SIDEPANE_VISIBLE = "groupSidepaneVisible";
+    // The visible panes span the three *_VISIBLE flags above and the preferred positions span the two
+    // SIDE_PANE_COMPONENT_* series; these synthetic keys are never written to the backing store and only serve as the
+    // respective bindings' reporting keys in getPreferences()/getDefaults() (see bindMap/PUSH_APPLICATIONS_PATHS_KEY).
+    private static final String SIDE_PANE_VISIBLE_PANES = "sidePaneVisiblePanes";
+    private static final String SIDE_PANE_PREFERRED_POSITIONS = "sidePanePreferredPositions";
     // endregion
 
     // region GroupsPreferences
@@ -296,6 +301,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getGuiPreferences();
         getWorkspacePreferences();
         getUnlinkedFilesDialogPreferences();
+        getSidePanePreferences();
 
         super.clear();
 
@@ -307,7 +313,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getMainTablePreferences().setAll(MainTablePreferences.getDefault());
         getNewEntryPreferences().setAll(NewEntryPreferences.getDefault());
         getSearchDialogColumnPreferences().setAll(ColumnPreferences.getDefault());
-        getSidePanePreferences().setAll(SidePanePreferences.getDefault());
         getNameDisplayPreferences().setAll(NameDisplayPreferences.getDefault());
         getPreviewPreferences().setAll(PreviewPreferences.getDefaultWithStyles(
                 getLayoutFormatterPreferences(),
@@ -326,6 +331,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getGuiPreferences();
         getWorkspacePreferences();
         getUnlinkedFilesDialogPreferences();
+        getSidePanePreferences();
 
         super.importPreferences(path);
 
@@ -338,7 +344,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getMainTablePreferences().setAll(getMainTablePreferencesFromBackingStore(getMainTablePreferences()));
         getNewEntryPreferences().setAll(getNewEntryPreferencesFromBackingStore(getNewEntryPreferences()));
         getSearchDialogColumnPreferences().setAll(getSearchDialogColumnPreferencesFromBackingStore(getSearchDialogColumnPreferences()));
-        getSidePanePreferences().setAll(getSidePanePreferencesFromBackingStore(getSidePanePreferences()));
         getNameDisplayPreferences().setAll(getNameDisplayPreferencesFromBackingStore(getNameDisplayPreferences()));
         getPreviewPreferences().setAll(getPreviewPreferencesFromBackingStore(getPreviewPreferences()));
         getMrDlibPreferences().setAll(getMrDlibPreferencesFromBackingStore(getMrDlibPreferences()));
@@ -701,25 +706,23 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return sidePanePreferences;
         }
 
-        sidePanePreferences = getSidePanePreferencesFromBackingStore(SidePanePreferences.getDefault());
+        SidePanePreferences defaultValues = SidePanePreferences.getDefault();
 
-        sidePanePreferences.visiblePanes().addListener((InvalidationListener) _ ->
-                storeVisibleSidePanes(sidePanePreferences.visiblePanes()));
-        sidePanePreferences.getPreferredPositions().addListener((InvalidationListener) _ ->
-                storeSidePanePreferredPositions(sidePanePreferences.getPreferredPositions()));
-        EasyBind.listen(sidePanePreferences.webSearchFetcherSelectedProperty(), (_, _, newValue) -> putInt(SELECTED_FETCHER_INDEX, newValue));
+        sidePanePreferences = new SidePanePreferences(
+                getVisibleSidePanes(defaultValues.visiblePanes()),
+                getSidePanePreferredPositions(defaultValues),
+                getInt(SELECTED_FETCHER_INDEX, defaultValues.getWebSearchFetcherSelected())
+        );
+
+        bindSet(sidePanePreferences.visiblePanes(), SIDE_PANE_VISIBLE_PANES, defaultValues.visiblePanes(),
+                this::storeVisibleSidePanes,
+                () -> getVisibleSidePanes(defaultValues.visiblePanes()));
+        bindMap(sidePanePreferences.getPreferredPositions(), SIDE_PANE_PREFERRED_POSITIONS, defaultValues.getPreferredPositions(),
+                _ -> storeSidePanePreferredPositions(sidePanePreferences.getPreferredPositions()),
+                _ -> getSidePanePreferredPositions(defaultValues));
+        bindInt(sidePanePreferences.webSearchFetcherSelectedProperty(), SELECTED_FETCHER_INDEX, defaultValues.getWebSearchFetcherSelected());
 
         return sidePanePreferences;
-    }
-
-    private SidePanePreferences getSidePanePreferencesFromBackingStore(SidePanePreferences defaults) {
-        Set<SidePaneType> backingStoreVisiblePanes = getVisibleSidePanes(defaults.visiblePanes());
-        Map<SidePaneType, Integer> backingStorePreferredPositions = getSidePanePreferredPositions(defaults);
-        return new SidePanePreferences(
-                backingStoreVisiblePanes,
-                backingStorePreferredPositions,
-                getInt(SELECTED_FETCHER_INDEX, defaults.getWebSearchFetcherSelected())
-        );
     }
 
     private Set<SidePaneType> getVisibleSidePanes(Set<SidePaneType> defaults) {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -943,6 +943,10 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 () -> previewPreferences.layoutCyclePositionProperty().set(getPreviewCyclePosition(previewPreferences.getLayoutCycle(), defaultValues.getLayoutCyclePosition())),
                 () -> previewPreferences.layoutCyclePositionProperty().set(defaultValues.getLayoutCyclePosition()));
         // customPreviewLayout is stored with __NEWLINE__ instead of \n so that our migration correctly triggers; in getText it is replaced back by \n.
+        // FIXME: serializer/deserializer are not inverse: the persist listener encodes \n -> __NEWLINE__, but the load
+        //   does not decode __NEWLINE__ -> \n. The property therefore holds the encoded form after a load but the raw
+        //   \n form once the preview editor sets it, so PreferencesFilter reports a false deviation from the default.
+        //   Followup: pick one canonical in-memory form (decode on load, encode on persist, default in the same form).
         bindCustom(previewPreferences.customPreviewLayoutProperty(), PREVIEW_STYLE, defaultValues.getCustomPreviewLayout(),
                 (_, _, newValue) -> put(PREVIEW_STYLE, newValue.replace("\n", "__NEWLINE__")),
                 () -> previewPreferences.customPreviewLayoutProperty().set(get(PREVIEW_STYLE, defaultValues.getCustomPreviewLayout())),

--- a/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesFilter.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesFilter.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.jabref.logic.preferences.CliPreferences;
@@ -36,7 +37,7 @@ public class PreferencesFilter {
     }
 
     public enum PreferenceType {
-        BOOLEAN, INTEGER, STRING
+        BOOLEAN, INTEGER, DOUBLE, STRING, LIST, SET, MAP
     }
 
     public static class PreferenceOption implements Comparable<PreferenceOption> {
@@ -64,6 +65,14 @@ public class PreferencesFilter {
                 return PreferenceType.BOOLEAN;
             } else if (value instanceof Integer) {
                 return PreferenceType.INTEGER;
+            } else if (value instanceof Double) {
+                return PreferenceType.DOUBLE;
+            } else if (value instanceof Map) {
+                return PreferenceType.MAP;
+            } else if (value instanceof Set) {
+                return PreferenceType.SET;
+            } else if (value instanceof List) {
+                return PreferenceType.LIST;
             } else {
                 return PreferenceType.STRING;
             }

--- a/jabgui/src/main/java/org/jabref/gui/preview/PreviewPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preview/PreviewPreferences.java
@@ -79,16 +79,6 @@ public class PreviewPreferences {
         return defaults;
     }
 
-    public void setAll(PreviewPreferences previewPreferences) {
-        this.layoutCycle.setAll(previewPreferences.layoutCycle);
-        this.layoutCyclePosition.setValue(previewPreferences.layoutCyclePosition.getValue());
-        this.customPreviewLayout.setValue(previewPreferences.customPreviewLayout.getValue());
-        this.showPreviewAsExtraTab.setValue(previewPreferences.showPreviewAsExtraTab.getValue());
-        this.showPreviewEntryTableTooltip.setValue(previewPreferences.showPreviewEntryTableTooltip.getValue());
-        this.bstPreviewLayoutPaths.setAll(previewPreferences.bstPreviewLayoutPaths);
-        this.shouldDownloadCovers.setValue(previewPreferences.shouldDownloadCovers.getValue());
-    }
-
     public ObservableList<PreviewLayout> getLayoutCycle() {
         return layoutCycle;
     }

--- a/jabgui/src/main/java/org/jabref/gui/specialfields/SpecialFieldsPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/specialfields/SpecialFieldsPreferences.java
@@ -22,10 +22,6 @@ public class SpecialFieldsPreferences {
         return new SpecialFieldsPreferences();
     }
 
-    public void setAll(SpecialFieldsPreferences preferences) {
-        this.specialFieldsEnabled.set(preferences.isSpecialFieldsEnabled());
-    }
-
     public boolean isSpecialFieldsEnabled() {
         return specialFieldsEnabled.getValue();
     }

--- a/jablib/src/main/java/org/jabref/logic/importer/ImporterPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ImporterPreferences.java
@@ -56,10 +56,10 @@ public class ImporterPreferences {
                 Set.of(),                                      // Custom importers
                 Set.of(),                                      // API keys
                 false,                                         // Persist custom keys
-                List.of(ACMPortalFetcher.FETCHER_NAME,         // Catalogs
-                        SpringerNatureWebFetcher.FETCHER_NAME,
+                List.of(ACMPortalFetcher.FETCHER_NAME,         // Alphabetically sorted list of Catalogs
                         DBLPFetcher.FETCHER_NAME,
-                        IEEE.FETCHER_NAME),
+                        IEEE.FETCHER_NAME,
+                        SpringerNatureWebFetcher.FETCHER_NAME),
                 PlainCitationParserChoice.RULE_BASED_GENERAL,  // Default plain citation parser
                 30,                                            // Citations relations store TTL
                 Map.of()                                       // Search engine URL templates

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/MrDlibPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/MrDlibPreferences.java
@@ -30,13 +30,6 @@ public class MrDlibPreferences {
         return new MrDlibPreferences();
     }
 
-    public void setAll(MrDlibPreferences preferences) {
-        this.acceptRecommendations.set(preferences.shouldAcceptRecommendations());
-        this.sendLanguage.set(preferences.shouldSendLanguage());
-        this.sendOs.set(preferences.shouldSendOs());
-        this.sendTimezone.set(preferences.shouldSendTimezone());
-    }
-
     public boolean shouldAcceptRecommendations() {
         return acceptRecommendations.get();
     }

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/citation/CitationCountFetcherType.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/citation/CitationCountFetcherType.java
@@ -27,6 +27,15 @@ public enum CitationCountFetcherType {
         return name;
     }
 
+    /// Parses a constant by name, falling back to {@link #SEMANTIC_SCHOLAR} for unknown/corrupted values.
+    public static CitationCountFetcherType safeValueOf(String name) {
+        try {
+            return CitationCountFetcherType.valueOf(name);
+        } catch (IllegalArgumentException e) {
+            return SEMANTIC_SCHOLAR;
+        }
+    }
+
     public static CitationCountFetcher getCitationCountFetcher(CitationCountFetcherType type, ImporterPreferences importerPreferences) {
         return switch (type) {
             case SEMANTIC_SCHOLAR ->

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/citation/CitationFetcherType.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/citation/CitationFetcherType.java
@@ -33,6 +33,15 @@ public enum CitationFetcherType {
         return name;
     }
 
+    /// Parses a constant by name, falling back to {@link #SEMANTIC_SCHOLAR} for unknown/corrupted values.
+    public static CitationFetcherType safeValueOf(String name) {
+        try {
+            return CitationFetcherType.valueOf(name);
+        } catch (IllegalArgumentException e) {
+            return SEMANTIC_SCHOLAR;
+        }
+    }
+
     /// @param aiService required for {@link org.jabref.logic.importer.plaincitation.PlainCitationParser}
     public static CitationFetcher getCitationFetcher(
             CitationFetcherType citationFetcherName,

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -683,7 +683,7 @@ public class JabRefCliPreferences implements CliPreferences {
                 resetToDefaults));
     }
 
-    private void bindBoolean(BooleanProperty property, String key, boolean defaultValue) {
+    protected void bindBoolean(BooleanProperty property, String key, boolean defaultValue) {
         bindCustom(property, key, defaultValue,
                 (_, _, v) -> putBoolean(key, v),
                 () -> property.set(getBoolean(key, defaultValue)),

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -690,6 +690,17 @@ public class JabRefCliPreferences implements CliPreferences {
                 () -> property.set(defaultValue));
     }
 
+    /// Binds a boolean persisted inverted: the backing store holds `!property`. Useful for legacy keys whose stored
+    /// meaning is the negation of the property (e.g. a `useDefault…` key backing a `useCustom…` property). The property
+    /// (not its stored form) is the binding's reporting value in [#getPreferences()] and [#getDefaults()]. Should not
+    /// be used for new preference options.
+    protected void bindBooleanInverted(BooleanProperty property, String key, boolean defaultValue) {
+        bindCustom(property, key, defaultValue,
+                (_, _, v) -> putBoolean(key, !v),
+                () -> property.set(!getBoolean(key, !defaultValue)),
+                () -> property.set(defaultValue));
+    }
+
     protected void bindInt(IntegerProperty property, String key, int defaultValue) {
         bindCustom(property, key, defaultValue,
                 (_, _, v) -> putInt(key, v),
@@ -1709,11 +1720,7 @@ public class JabRefCliPreferences implements CliPreferences {
                 List.copyOf(FieldFactory.parseFieldList(get(NON_WRAPPABLE_FIELDS,
                         FieldFactory.serializeFieldsList(defaultValues.getNonWrappableFields())))));
 
-        // resolveStrings is persisted inverted as DO_NOT_RESOLVE_STRINGS, so it needs a custom binding.
-        bindCustom(fieldPreferences.resolveStringsProperty(), DO_NOT_RESOLVE_STRINGS, defaultValues.shouldResolveStrings(),
-                (_, _, newValue) -> putBoolean(DO_NOT_RESOLVE_STRINGS, !newValue),
-                () -> fieldPreferences.resolveStringsProperty().set(!getBoolean(DO_NOT_RESOLVE_STRINGS, !defaultValues.shouldResolveStrings())),
-                () -> fieldPreferences.resolveStringsProperty().set(defaultValues.shouldResolveStrings()));
+        bindBooleanInverted(fieldPreferences.resolveStringsProperty(), DO_NOT_RESOLVE_STRINGS, defaultValues.shouldResolveStrings());
         bindCustomList(fieldPreferences.getResolvableFields(), RESOLVE_STRINGS_FOR_FIELDS, List.copyOf(defaultValues.getResolvableFields()),
                 FieldFactory::serializeFieldsList, FieldFactory::parseFieldList);
         bindCustomList(fieldPreferences.getNonWrappableFields(), NON_WRAPPABLE_FIELDS, List.copyOf(defaultValues.getNonWrappableFields()),

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -697,7 +697,7 @@ public class JabRefCliPreferences implements CliPreferences {
                 () -> property.set(defaultValue));
     }
 
-    private void bindDouble(DoubleProperty property, String key, double defaultValue) {
+    protected void bindDouble(DoubleProperty property, String key, double defaultValue) {
         bindCustom(property, key, defaultValue,
                 (_, _, v) -> putDouble(key, v.doubleValue()),
                 () -> property.set(getDouble(key, defaultValue)),
@@ -715,7 +715,7 @@ public class JabRefCliPreferences implements CliPreferences {
     ///
     /// @param serializer   converts a value to its stored String form
     /// @param deserializer reconstructs a value from its stored String form
-    private <T> void bindObject(ObjectProperty<T> property,
+    protected <T> void bindObject(ObjectProperty<T> property,
                                 String key,
                                 T defaultValue,
                                 Function<T, String> serializer,
@@ -819,7 +819,7 @@ public class JabRefCliPreferences implements CliPreferences {
     /// @param defaultList   restored on reset and reported as the default
     /// @param persist       rewrites the whole list to the backing store; receives the bound list, runs on every change
     /// @param loadFromStore reads the stored list, falling back to `defaultList` for absent entries
-    private <T> void bindCustomList(ObservableList<T> list,
+    protected <T> void bindCustomList(ObservableList<T> list,
                                     String key,
                                     List<T> defaultList,
                                     Consumer<? super ObservableList<T>> persist,

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -668,7 +668,7 @@ public class JabRefCliPreferences implements CliPreferences {
     /// @param persistListener writes value changes to the backing store
     /// @param importFromStore loads the stored value (or the default) into the property
     /// @param resetToDefaults restores the property to its default value
-    private <T> void bindCustom(Property<T> property,
+    protected <T> void bindCustom(Property<T> property,
                                 String key,
                                 T defaultValue,
                                 ChangeListener<? super T> persistListener,
@@ -690,7 +690,7 @@ public class JabRefCliPreferences implements CliPreferences {
                 () -> property.set(defaultValue));
     }
 
-    private void bindInt(IntegerProperty property, String key, int defaultValue) {
+    protected void bindInt(IntegerProperty property, String key, int defaultValue) {
         bindCustom(property, key, defaultValue,
                 (_, _, v) -> putInt(key, v),
                 () -> property.set(getInt(key, defaultValue)),

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -868,7 +868,7 @@ public class JabRefCliPreferences implements CliPreferences {
     /// @param defaultSet   restored on reset and reported as the default
     /// @param serializer   rewrites the whole set to the backing store; receives the bound set, runs on every change
     /// @param deserializer reads the stored set, falling back to `defaultSet` for absent entries
-    private <T> void bindSet(ObservableSet<T> set,
+    protected <T> void bindSet(ObservableSet<T> set,
                              String key,
                              Set<T> defaultSet,
                              Consumer<? super ObservableSet<T>> serializer,

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -1065,35 +1065,7 @@ public class JabRefCliPreferences implements CliPreferences {
         PREFS_NODE.clear();
         new SharedDatabasePreferences().clear();
 
-        // ensure registration of bindings
-        getInternalPreferences();
-        getFieldPreferences();
-        getFilePreferences();
-        getProxyPreferences();
-        getLibraryPreferences();
-        getDOIPreferences();
-        getOwnerPreferences();
-        getTimestampPreferences();
-        getRemotePreferences();
-        getPushToApplicationPreferences();
-        getAbbreviationPreferences();
-        getGitPreferences();
-        getSSLPreferences();
-        getBibEntryPreferences();
-        getCitationKeyPatternPreferences();
-        getAutoLinkPreferences();
-        getExportPreferences();
-        getCleanupPreferences();
-        getLastFilesOpenedPreferences();
-        getAiPreferences();
-        getOcrPreferences();
-        getSearchPreferences();
-        getXmpPreferences();
-        getProtectedTermsPreferences();
-        getNameFormatterPreferences();
-        getImporterPreferences();
-        getGrobidPreferences();
-        getOpenOfficePreferences(JournalAbbreviationLoader.loadRepository(getAbbreviationPreferences()));
+        initializeAll();
 
         allBindings.forEach(binding -> binding.resetToDefaults().run());
     }
@@ -1106,7 +1078,14 @@ public class JabRefCliPreferences implements CliPreferences {
     public void importPreferences(Path path) throws JabRefException {
         importPreferencesToBackingStore(path);
 
-        // ensure registration of bindings
+        initializeAll();
+
+        allBindings.forEach(binding -> binding.importFromStore().run());
+    }
+
+    /// Instantiates every preference group so its bindings are registered in [#allBindings] before a bulk reset/import
+    /// runs. Overridden by subclasses to additionally register their own preference groups.
+    protected void initializeAll() {
         getInternalPreferences();
         getFieldPreferences();
         getFilePreferences();
@@ -1135,8 +1114,6 @@ public class JabRefCliPreferences implements CliPreferences {
         getImporterPreferences();
         getGrobidPreferences();
         getOpenOfficePreferences(JournalAbbreviationLoader.loadRepository(getAbbreviationPreferences()));
-
-        allBindings.forEach(binding -> binding.importFromStore().run());
     }
 
     private static void importPreferencesToBackingStore(Path path) throws JabRefException {

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -704,7 +704,7 @@ public class JabRefCliPreferences implements CliPreferences {
                 () -> property.set(defaultValue));
     }
 
-    private void bindString(StringProperty property, String key, String defaultValue) {
+    protected void bindString(StringProperty property, String key, String defaultValue) {
         bindCustom(property, key, defaultValue,
                 (_, _, v) -> put(key, v),
                 () -> property.set(get(key, defaultValue)),

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -33,13 +33,13 @@ import javafx.beans.Observable;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.MapProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
 import javafx.collections.ObservableSet;
 
 import org.jabref.logic.FilePreferences;
@@ -669,11 +669,11 @@ public class JabRefCliPreferences implements CliPreferences {
     /// @param importFromStore loads the stored value (or the default) into the property
     /// @param resetToDefaults restores the property to its default value
     protected <T> void bindCustom(Property<T> property,
-                                String key,
-                                T defaultValue,
-                                ChangeListener<? super T> persistListener,
-                                Runnable importFromStore,
-                                Runnable resetToDefaults) {
+                                  String key,
+                                  T defaultValue,
+                                  ChangeListener<? super T> persistListener,
+                                  Runnable importFromStore,
+                                  Runnable resetToDefaults) {
         EasyBind.listen(property, persistListener);
         allBindings.add(new PreferenceBinding(
                 property,
@@ -716,10 +716,10 @@ public class JabRefCliPreferences implements CliPreferences {
     /// @param serializer   converts a value to its stored String form
     /// @param deserializer reconstructs a value from its stored String form
     protected <T> void bindObject(ObjectProperty<T> property,
-                                String key,
-                                T defaultValue,
-                                Function<T, String> serializer,
-                                Function<String, T> deserializer) {
+                                  String key,
+                                  T defaultValue,
+                                  Function<T, String> serializer,
+                                  Function<String, T> deserializer) {
         bindCustom(property, key, defaultValue,
                 (_, _, v) -> put(key, serializer.apply(v)),
                 () -> property.set(deserializer.apply(get(key, serializer.apply(defaultValue)))),
@@ -789,12 +789,12 @@ public class JabRefCliPreferences implements CliPreferences {
     ///
     /// @param serializer   persists individual entry changes to the backing store
     /// @param deserializer reads the stored map, falling back to `defaultMap` for missing entries
-    private void bindMap(MapProperty<String, String> map,
-                         String key,
-                         Map<String, String> defaultMap,
-                         MapChangeListener<? super String, ? super String> serializer,
-                         Function<Map<String, String>, Map<String, String>> deserializer) {
-        Map<String, String> defaultCopy = Map.copyOf(defaultMap);
+    protected <K, V> void bindMap(ObservableMap<K, V> map,
+                                  String key,
+                                  Map<K, V> defaultMap,
+                                  MapChangeListener<? super K, ? super V> serializer,
+                                  Function<Map<K, V>, Map<K, V>> deserializer) {
+        Map<K, V> defaultCopy = Map.copyOf(defaultMap);
         map.addListener(serializer);
         allBindings.add(new PreferenceBinding(
                 map,
@@ -820,10 +820,10 @@ public class JabRefCliPreferences implements CliPreferences {
     /// @param persist       rewrites the whole list to the backing store; receives the bound list, runs on every change
     /// @param loadFromStore reads the stored list, falling back to `defaultList` for absent entries
     protected <T> void bindCustomList(ObservableList<T> list,
-                                    String key,
-                                    List<T> defaultList,
-                                    Consumer<? super ObservableList<T>> persist,
-                                    Supplier<? extends Collection<? extends T>> loadFromStore) {
+                                      String key,
+                                      List<T> defaultList,
+                                      Consumer<? super ObservableList<T>> persist,
+                                      Supplier<? extends Collection<? extends T>> loadFromStore) {
         List<T> defaultCopy = List.copyOf(defaultList);
         list.addListener((InvalidationListener) _ -> persist.accept(list));
         allBindings.add(new PreferenceBinding(
@@ -869,10 +869,10 @@ public class JabRefCliPreferences implements CliPreferences {
     /// @param serializer   rewrites the whole set to the backing store; receives the bound set, runs on every change
     /// @param deserializer reads the stored set, falling back to `defaultSet` for absent entries
     protected <T> void bindSet(ObservableSet<T> set,
-                             String key,
-                             Set<T> defaultSet,
-                             Consumer<? super ObservableSet<T>> serializer,
-                             Supplier<? extends Collection<? extends T>> deserializer) {
+                               String key,
+                               Set<T> defaultSet,
+                               Consumer<? super ObservableSet<T>> serializer,
+                               Supplier<? extends Collection<? extends T>> deserializer) {
         Set<T> defaultCopy = Set.copyOf(defaultSet);
         set.addListener((InvalidationListener) _ -> serializer.accept(set));
         allBindings.add(new PreferenceBinding(
@@ -985,8 +985,8 @@ public class JabRefCliPreferences implements CliPreferences {
             return observableList;
         } else if (observable instanceof ObservableSet<?> observableSet) {
             return observableSet;
-        } else if (observable instanceof MapProperty<?, ?> mapProperty) {
-            return mapProperty.get();
+        } else if (observable instanceof ObservableMap<?, ?> observableMap) {
+            return observableMap;
         } else if (observable instanceof ObjectProperty<?> objectProperty) {
             return objectProperty.get();
         }
@@ -1195,7 +1195,7 @@ public class JabRefCliPreferences implements CliPreferences {
                 CitationCommandString::toString, CitationCommandString::from);
 
         // Command paths are persisted under per-application keys (see storePushToApplicationPath), not under a single preferences key
-        bindMap(pushToApplicationPreferences.getCommandPaths(), PUSH_APPLICATIONS_PATHS_KEY, defaultValues.getCommandPaths(),
+        this.<String, String>bindMap(pushToApplicationPreferences.getCommandPaths(), PUSH_APPLICATIONS_PATHS_KEY, defaultValues.getCommandPaths(),
                 this::storePushToApplicationPath, this::readPushToApplicationPath);
 
         return pushToApplicationPreferences;

--- a/jablib/src/main/java/org/jabref/model/groups/GroupHierarchyType.java
+++ b/jablib/src/main/java/org/jabref/model/groups/GroupHierarchyType.java
@@ -28,6 +28,15 @@ public enum GroupHierarchyType {
         }
     }
 
+    /// Parses a constant by name, falling back to {@link #INDEPENDENT} for unknown/corrupted values.
+    public static GroupHierarchyType safeValueOf(String name) {
+        try {
+            return GroupHierarchyType.valueOf(name);
+        } catch (IllegalArgumentException e) {
+            return INDEPENDENT;
+        }
+    }
+
     public String getDisplayName() {
         return displayName;
     }


### PR DESCRIPTION
### Related issues and pull requests

Follow-up to #16101

### PR Description

- Migrated every *Preferences group in JabRefGuiPreferences to the bind* helpers
- Generalized bindMap to ObservableMap<K, V> and taught getObject to report it.
- Added bindBooleanInverted for legacy negated keys (terminal, file browser, resolveStrings).
- Deduplicated the main-table/search-dialog column getters into loadColumnPreferences/bindColumnPreferences.
- PreferencesFilter filled with GUI preferences

<img width="1184" height="789" alt="grafik" src="https://github.com/user-attachments/assets/8ad37567-94c7-4ee5-926d-0b3cb8e573fd" />

        `jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

This is an internal refactor with no intended behavior change. To sanity-check:
1. Launch JabRef, open File → Preferences, change values across several GUI tabs (Entry editor, Groups, Web search, Preview, Table columns…), save, restart — confirm values persist.
2. Preferences → reset and confirm defaults come back.

### AI usage

Claude Code (model claude-opus-4-8) and a much human design and reworking.

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
