### PR TITLE
Add Agent Skills for JabKit usage and JabRef development

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,26 @@
+# Agent Skills for JabRef
+
+This directory contains [Agent Skills](https://agentskills.io/) usable by AI agents such as Claude Code, Cursor, and other tools supporting the SKILL.md convention.
+
+Skills are grouped in two categories:
+
+- `users/` — skills for working *with* JabRef and its CLI `jabkit`: managing BibTeX/biblatex libraries, extracting references from PDF papers, fetching entries.
+- `developers/` — skills for working *on* the JabRef codebase.
+
+## Installation
+
+Install all skills:
+
+```bash
+npx skills add JabRef/jabref
+```
+
+Install a single skill:
+
+```bash
+npx skills add JabRef/jabref --skill pdf-to-bibtex
+```
+
+## Contributing
+
+Each skill is a directory containing a `SKILL.md` with YAML frontmatter (`name`, `description`) followed by instructions for the agent. Keep instructions in sync with the actual `jabkit` commands (see `jabkit/src/main/java/org/jabref/toolkit/commands/`).

--- a/skills/developers/jabref-contributor/SKILL.md
+++ b/skills/developers/jabref-contributor/SKILL.md
@@ -34,7 +34,7 @@ Requires JDK 25+ for Gradle (the wrapper downloads a JDK itself):
 
 ## Conventions
 
-- **Terminology:** say "library", not "database" — prefer `Library*` over `Database*` in new identifiers.
+- **Terminology:** say "library", not "database" — prefer `Library*` over `Database*` in new identifiers (see the [glossary](https://github.com/JabRef/jabref/tree/main/docs/glossary), in particular [library](https://github.com/JabRef/jabref/blob/main/docs/glossary/library.md)).
 - **Tests:** plain JUnit 5 assertions only (see ADR-0009); do not introduce Hamcrest or AssertJ. Mock `*Preferences` classes and stub only the getters the test needs.
 - **Minimal diffs:** no reformatting of existing code, no speculative refactoring, no drive-by cleanups.
 - **Dependencies:** do not add new ones without justification.

--- a/skills/developers/jabref-contributor/SKILL.md
+++ b/skills/developers/jabref-contributor/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 Conventions for working on the [JabRef](https://github.com/JabRef/jabref) codebase.
 
-> **AI policy — read first.** JabRef does not accept fully AI-generated pull requests. AI tools may only assist; a human must understand and take responsibility for every change. See `CONTRIBUTING.md` and `AGENTS.md` in the repository root.
+> **AI policy — read first.** JabRef does not accept fully AI-generated pull requests. AI tools may only assist; a human must understand and take responsibility for every change. See [CONTRIBUTING.md](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md) and [AGENTS.md](https://github.com/JabRef/jabref/blob/main/AGENTS.md) in the repository root — when working in a JabRef checkout, read both files before making changes.
 
 ## Modules
 
@@ -51,7 +51,8 @@ Work through every point of `CHECKLIST.md` in the repository root — it is the 
 
 ## Further reading
 
-- `AGENTS.md` — rules for automated agents in this repository
-- `CONTRIBUTING.md` — full contribution guide, including the AI usage policy
+- [AGENTS.md](https://github.com/JabRef/jabref/blob/main/AGENTS.md) — rules for automated agents in this repository
+- [CONTRIBUTING.md](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md) — full contribution guide, including the AI usage policy
+- [CHECKLIST.md](https://github.com/JabRef/jabref/blob/main/CHECKLIST.md) — the mandatory pre-PR quality gate
 - <https://devdocs.jabref.org/> — developer documentation
 - <https://deepwiki.com/JabRef/jabref> — architecture Q&A

--- a/skills/developers/jabref-contributor/SKILL.md
+++ b/skills/developers/jabref-contributor/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: jabref-contributor
+description: Development conventions for contributing to JabRef, the open-source BibTeX/biblatex reference manager. Use when working on the JabRef codebase - covers the Gradle build, module layout (jablib, jabgui, jabkit, jabls, jabsrv), testing rules (JUnit 5, no Hamcrest), naming conventions, and the mandatory pre-PR checklist.
+license: MIT
+---
+
+# Contributing to JabRef
+
+Conventions for working on the [JabRef](https://github.com/JabRef/jabref) codebase.
+
+> **AI policy — read first.** JabRef does not accept fully AI-generated pull requests. AI tools may only assist; a human must understand and take responsibility for every change. See `CONTRIBUTING.md` and `AGENTS.md` in the repository root.
+
+## Modules
+
+| Module | Purpose |
+|---|---|
+| `jablib` | Core library — logic, model, importers/exporters |
+| `jabgui` | JavaFX desktop GUI |
+| `jabkit` | CLI application |
+| `jabls` | Language Server Protocol implementation |
+| `jabsrv` | HTTP server |
+
+Key paths: `jablib/src/main/java/org/jabref/logic/` (business logic), `jablib/src/main/java/org/jabref/model/` (data model), `jabgui/src/main/java/org/jabref/gui/` (GUI), `docs/` (developer docs and ADRs).
+
+## Build and run
+
+Requires JDK 25+ for Gradle (the wrapper downloads a JDK itself):
+
+```bash
+./gradlew build            # build all modules
+./gradlew :jabgui:run      # launch the GUI
+./gradlew :jablib:test     # run core tests
+```
+
+## Conventions
+
+- **Terminology:** say "library", not "database" — prefer `Library*` over `Database*` in new identifiers.
+- **Tests:** plain JUnit 5 assertions only (see ADR-0009); do not introduce Hamcrest or AssertJ. Mock `*Preferences` classes and stub only the getters the test needs.
+- **Minimal diffs:** no reformatting of existing code, no speculative refactoring, no drive-by cleanups.
+- **Dependencies:** do not add new ones without justification.
+- **Architecture decisions:** documented as ADRs in `docs/decisions/`; add a new ADR when making an architecturally significant choice.
+- **Localization:** user-visible strings go through `Localization.lang(...)`; add keys to `jablib/src/main/resources/l10n/JabRef_en.properties` only — other languages are translated via Crowdin.
+
+## Before opening a PR
+
+Work through every point of `CHECKLIST.md` in the repository root — it is the mandatory quality gate. Also:
+
+- Add a `CHANGELOG.md` entry (unreleased section) for user-visible changes.
+- Reference the issue the PR fixes.
+- Run `./gradlew rewriteRun` if the build reports OpenRewrite violations.
+
+## Further reading
+
+- `AGENTS.md` — rules for automated agents in this repository
+- `CONTRIBUTING.md` — full contribution guide, including the AI usage policy
+- <https://devdocs.jabref.org/> — developer documentation
+- <https://deepwiki.com/JabRef/jabref> — architecture Q&A

--- a/skills/users/bibtex-library-management/SKILL.md
+++ b/skills/users/bibtex-library-management/SKILL.md
@@ -10,8 +10,20 @@ Maintain BibTeX/biblatex libraries (`.bib` files) from the command line using `j
 
 ## Setup
 
+`jabkit` runs via [JBang](https://www.jbang.dev/) — no JDK setup needed. Install JBang if missing:
+
 ```bash
-jbang app install --fresh --force jabkit@jabref   # requires JBang: https://www.jbang.dev/download/
+curl -Ls https://sh.jbang.dev | bash -s - app setup   # Linux/macOS
+```
+
+```powershell
+iex "& { $(iwr -useb https://ps.jbang.dev) } app setup"   # Windows
+```
+
+Then install `jabkit` on the PATH (the same command also updates it):
+
+```bash
+jbang app install --fresh --force jabkit@jabref
 ```
 
 Global flags (place before the subcommand): `-p`/`--porcelain` for script-friendly output, `-d`/`--debug` for verbose logging.

--- a/skills/users/bibtex-library-management/SKILL.md
+++ b/skills/users/bibtex-library-management/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: bibtex-library-management
+description: Check, clean, and maintain BibTeX and biblatex libraries with JabRef's jabkit CLI. Use when the user wants to validate a .bib file (integrity and consistency checks), generate citation keys, search a bibliography, convert between bibliography formats, or pseudonymize a library before sharing.
+license: MIT
+---
+
+# BibTeX Library Management
+
+Maintain BibTeX/biblatex libraries (`.bib` files) from the command line using `jabkit`, JabRef's CLI toolkit.
+
+## Setup
+
+```bash
+jbang app install --fresh --force jabkit@jabref   # requires JBang: https://www.jbang.dev/download/
+```
+
+Global flags (place before the subcommand): `-p`/`--porcelain` for script-friendly output, `-d`/`--debug` for verbose logging.
+
+## Validate a library
+
+Run both consistency and integrity checks:
+
+```bash
+jabkit check library.bib
+```
+
+Or individually:
+
+```bash
+jabkit check consistency library.bib --output-format txt
+jabkit check integrity library.bib --output-format txt
+```
+
+`--output-format` accepts `csv`, `errorformat` (default; machine-readable, suitable for editors), `github-actions`, or `txt`. Exit code signals whether problems were found — use it in CI.
+
+## Generate citation keys
+
+```bash
+jabkit citationkeys generate library.bib --output library.bib
+```
+
+Useful options:
+
+- `--pattern "[auth][year]"` — override the citation key pattern
+- `--avoid-overwrite` — keep existing keys
+- `--suffix SECOND_WITH_A` — duplicate-key suffix strategy (`ALWAYS`, `SECOND_WITH_A`, `SECOND_WITH_B`)
+- `--transliterate` — transliterate non-Latin fields before key generation
+
+## Search a library
+
+```bash
+jabkit search --query "author=smith" --input library.bib --output results.bib
+```
+
+The query uses JabRef's search syntax (field=value pairs, boolean operators). Default output format is `bibtex`.
+
+## Convert between formats
+
+```bash
+jabkit convert --input library.bib --output library.html --output-format html
+```
+
+`--output-format` defaults to `bibtex`. Use `--input-format "*"` to auto-detect the input. Apply field formatters during conversion with `--field-formatters`.
+
+## Pseudonymize before sharing
+
+Replace identifying data for bug reports or datasets; writes a key file for de-pseudonymization:
+
+```bash
+jabkit pseudonymize library.bib --output library.pseudo.bib --key library.pseudo.keys.csv
+```
+
+## Look up references
+
+```bash
+jabkit doi-to-bibtex 10.1145/3149935.3149942          # DOI → BibTeX entry
+jabkit fetch --provider ArXiv --query "quantum computing" --output results.bib
+jabkit get-cited-works 10.1145/3149935.3149942         # bibliography of a work
+jabkit get-citing-works 10.1145/3149935.3149942        # works citing it
+```
+
+## Related
+
+- Extracting entries from PDF papers: the `pdf-to-bibtex` skill in this repository.
+- Full CLI reference: the `jabkit` skill in this repository.

--- a/skills/users/jabkit/SKILL.md
+++ b/skills/users/jabkit/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: jabkit
+description: Command-line reference for jabkit, JabRef's CLI for BibTeX and biblatex bibliographies. Use for any reference-management task from the terminal - fetching entries from online providers, converting DOIs to BibTeX, extracting references from PDF papers, checking libraries, generating citation keys, writing XMP metadata into PDFs, and searching .bib files.
+license: MIT
+---
+
+# jabkit — JabRef's CLI Toolkit
+
+`jabkit` exposes JabRef's BibTeX/biblatex handling as a command-line application.
+
+## Installation
+
+Via [JBang](https://www.jbang.dev/download/) (`brew install jbangdev/tap/jbang` or `choco install jbang`):
+
+```bash
+jbang app install --fresh --force jabkit@jabref   # installs `jabkit` on PATH; also updates it
+```
+
+One-off run without installation:
+
+```bash
+jbang --fresh jabkit@jabref --help
+```
+
+## Global flags
+
+Place before the subcommand:
+
+- `-p`, `--porcelain` — script-friendly output (no banners/progress)
+- `-d`, `--debug` — debug logging
+- `-v`, `--version` — version info
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `check [FILE]` | Run consistency and integrity checks on a library; subcommands `consistency` and `integrity` run one of them |
+| `citationkeys generate` | Generate citation keys for entries in a `.bib` file |
+| `convert` | Convert between bibliography formats (including PDF → BibTeX) |
+| `doi-to-bibtex DOI...` | Convert one or more DOIs to BibTeX entries |
+| `fetch` | Query an online provider (ArXiv, Crossref, ...) and output matching entries |
+| `generate-bib-from-aux` | Extract the subset of a library cited in a LaTeX `.aux` file |
+| `get-cited-works DOI` | List the works cited by a publication |
+| `get-citing-works DOI` | List the works citing a publication |
+| `pdf update` | Write XMP metadata and/or embedded BibTeX into linked PDFs |
+| `preferences reset\|import\|export` | Manage jabkit preferences |
+| `pseudonymize` | Replace identifying data in a library (writes a key file for reversal) |
+| `search` | Search in a library using JabRef's search syntax |
+
+Input files are passed positionally or via `--input`; both forms are equivalent. `--input-format "*"` auto-detects the input format.
+
+## Examples
+
+```bash
+# DOI to BibTeX
+jabkit doi-to-bibtex 10.1145/3149935.3149942
+
+# Fetch from an online catalogue into a file
+jabkit fetch --provider ArXiv --query "test driven development" --output tdd.bib
+
+# PDF paper to BibTeX entry (see the pdf-to-bibtex skill for details)
+jabkit convert --input paper.pdf --input-format pdfMerged --output paper.bib
+
+# Validate in CI (errorformat output, non-zero exit on findings)
+jabkit -p check library.bib --output-format github-actions
+
+# Citation keys with a custom pattern
+jabkit citationkeys generate library.bib --pattern "[auth][year]" --output library.bib
+
+# Write BibTeX + XMP metadata into the PDFs linked from an entry
+jabkit pdf update --citation-key Smith2020 --input library.bib --input-format bibtex
+
+# Library subset actually cited in a LaTeX document
+jabkit generate-bib-from-aux --aux paper.aux --input full-library.bib --output paper.bib
+```
+
+## Notes for agents
+
+- Always use `-p`/`--porcelain` when parsing output programmatically.
+- `fetch --provider` matches JabRef's web-search fetcher names case-insensitively; on an unknown name, jabkit reports `Could not find fetcher`.
+- URLs are accepted as input: `jabkit convert --input https://example.org/refs.ris --input-format ris`.

--- a/skills/users/jabkit/SKILL.md
+++ b/skills/users/jabkit/SKILL.md
@@ -10,10 +10,20 @@ license: MIT
 
 ## Installation
 
-Via [JBang](https://www.jbang.dev/download/) (`brew install jbangdev/tap/jbang` or `choco install jbang`):
+`jabkit` runs via [JBang](https://www.jbang.dev/) — no JDK setup needed. Install JBang if missing:
 
 ```bash
-jbang app install --fresh --force jabkit@jabref   # installs `jabkit` on PATH; also updates it
+curl -Ls https://sh.jbang.dev | bash -s - app setup   # Linux/macOS
+```
+
+```powershell
+iex "& { $(iwr -useb https://ps.jbang.dev) } app setup"   # Windows
+```
+
+Then install `jabkit` on the PATH (the same command also updates it):
+
+```bash
+jbang app install --fresh --force jabkit@jabref
 ```
 
 One-off run without installation:

--- a/skills/users/pdf-to-bibtex/SKILL.md
+++ b/skills/users/pdf-to-bibtex/SKILL.md
@@ -10,13 +10,23 @@ Extract bibliographic data from PDF files and produce BibTeX entries using `jabk
 
 ## Setup
 
-`jabkit` runs via [JBang](https://www.jbang.dev/download/) — no JDK setup needed:
+`jabkit` runs via [JBang](https://www.jbang.dev/) — no JDK setup needed. Install JBang if missing:
 
 ```bash
-jbang app install --fresh --force jabkit@jabref   # install permanently as `jabkit`
+curl -Ls https://sh.jbang.dev | bash -s - app setup   # Linux/macOS
 ```
 
-Or run once without installing:
+```powershell
+iex "& { $(iwr -useb https://ps.jbang.dev) } app setup"   # Windows
+```
+
+Then install `jabkit` on the PATH (the same command also updates it):
+
+```bash
+jbang app install --fresh --force jabkit@jabref
+```
+
+One-off run without installation:
 
 ```bash
 jbang --fresh jabkit@jabref --help

--- a/skills/users/pdf-to-bibtex/SKILL.md
+++ b/skills/users/pdf-to-bibtex/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: pdf-to-bibtex
+description: Extract BibTeX entries from PDF papers using JabRef's jabkit CLI. Use when the user wants to import academic papers (PDFs) into a BibTeX or biblatex library, generate .bib entries from PDF metadata (XMP, embedded BibTeX, GROBID, text heuristics), or turn a folder of papers into a bibliography.
+license: MIT
+---
+
+# PDF to BibTeX
+
+Extract bibliographic data from PDF files and produce BibTeX entries using `jabkit`, JabRef's command-line toolkit.
+
+## Setup
+
+`jabkit` runs via [JBang](https://www.jbang.dev/download/) — no JDK setup needed:
+
+```bash
+jbang app install --fresh --force jabkit@jabref   # install permanently as `jabkit`
+```
+
+Or run once without installing:
+
+```bash
+jbang --fresh jabkit@jabref --help
+```
+
+## Basic usage
+
+```bash
+jabkit convert --input paper.pdf --input-format pdfMerged --output paper.bib
+```
+
+Omit `--output` to print BibTeX to stdout. Add `--porcelain` before the subcommand for script-friendly output:
+
+```bash
+jabkit -p convert --input paper.pdf --input-format pdfMerged
+```
+
+## PDF importer formats
+
+Pass one of these as `--input-format`:
+
+| Format id | Strategy |
+|---|---|
+| `pdfMerged` | Merges results of the other importers into one best-effort entry — **use this by default** |
+| `pdfXmp` | Reads XMP metadata stored in the PDF |
+| `pdfEmbeddedBibFile` | Reads a BibTeX file embedded as PDF attachment |
+| `pdfVerbatimBibtex` | Parses BibTeX printed verbatim on the first page |
+| `pdfContent` | Heuristic extraction from the text of the first page |
+| `pdfGrobid` | Sends the PDF to a [GROBID](https://github.com/kermitt2/grobid) service (requires GROBID to be enabled/reachable) |
+| `pdfBibiliography` | Rule-based parsing of the bibliography section |
+
+`--input-format "*"` auto-detects the format (also works for non-PDF inputs).
+
+## Recommended workflow
+
+1. Run with `pdfMerged` first.
+2. Check the result for a `doi` field. If a DOI is present but fields look incomplete, fetch clean metadata instead:
+
+   ```bash
+   jabkit doi-to-bibtex 10.1145/3149935.3149942
+   ```
+
+3. Validate the resulting library:
+
+   ```bash
+   jabkit check paper.bib
+   ```
+
+## Batch conversion
+
+```bash
+for f in papers/*.pdf; do
+  jabkit -p convert --input "$f" --input-format pdfMerged >> library.bib
+done
+```
+
+Afterwards generate citation keys for all entries:
+
+```bash
+jabkit citationkeys generate library.bib --output library.bib
+```
+
+## Related
+
+- Write metadata back into PDFs (reverse direction): `jabkit pdf update --citation-key <key> --input library.bib --input-format bibtex`
+- Full CLI reference: the `jabkit` skill in this repository.


### PR DESCRIPTION
TL;DR: With this, we are listed at https://www.skills.sh/

---

### Related issues and pull requests

None — searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for related issues on agent skills; no match found.

### PR Description

Adds [Agent Skills](https://agentskills.io/) (`SKILL.md` files) to the repository so AI agents such as Claude Code can discover how to use `jabkit` and how to work on the JabRef codebase. Skills are grouped into `skills/users/` (`pdf-to-bibtex`, `bibtex-library-management`, `jabkit`) and `skills/developers/` (`jabref-contributor`) — a two-level catalog layout supported by the [skills CLI](https://github.com/vercel-labs/skills), which also makes them installable via `npx skills add JabRef/jabref` and discoverable on [skills.sh](https://www.skills.sh/) for searches such as "bibtex", "biblatex", "papers", and "jabref". All command examples were written against the current `jabkit` picocli command classes (e.g. `citationkeys generate`, `--input-format "*"` for auto-detection), not against possibly stale docs.

#### Analogies

Like honey, this PR is the product of many small foraging trips (through the picocli command classes) concentrated into something that keeps. Like chocolate, it is best consumed one square at a time - one skill per task. And like the moon, it emits no light of its own: it only reflects what jabkit already does.

jabref-contrib-policy:4.2:reviewed​:ok

### Steps to test

1. Run `npx skills add JabRef/jabref@add-agent-skills` (or point the CLI at a local checkout) and confirm all four skills are discovered, including the category subdirectories.
2. Spot-check the command examples in the skill files against `jabkit --help` output, e.g.:

   ```bash
   jbang --fresh jabkit@jabref convert --input paper.pdf --input-format pdfMerged
   jbang --fresh jabkit@jabref citationkeys generate library.bib --output library.bib
   ```

3. `npx markdownlint-cli2 "skills/**/*.md"` — passes with 0 errors.

### AI usage

Claude Code (models claude-sonnet-5 and claude-fable-5). The skill contents were derived from the `jabkit` source code, `AGENTS.md`, `CHECKLIST.md`, and `docs/` and reviewed by the contributor.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

This change adds Markdown files only (new `skills/` directory; no Java, no build files, no application behavior change), so code and Gradle items are marked not applicable. Markdown was verified with `npx markdownlint-cli2 "skills/**/*.md"` (0 errors; the new files are outside the default globs).

## 1. Code self-review

Read your own diff once, top to bottom, and confirm each point.

### Nullability and control flow

- [/] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [/] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [/] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [/] No `catch (Exception e)` — only specific exceptions are caught.
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [/] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [/] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [/] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.

## 2. Verification commands

Run in this order — cheapest first. Each must pass.

- [/] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [/] `./gradlew modernizer`.
- [/] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [/] `./gradlew javadoc`.
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.

## 3. Documentation

- [/] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when no issue is known and the PR is not yet created — never a fake number.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [/] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder, it was replaced with the real PR-number link after PR creation, then committed and pushed.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required) — no application change; verified via markdownlint and against `jabkit` command sources instead
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
