### PR TITLE
Fix jabkit -p/-d flags not propagating across command levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where `jabkit`'s `-p`/`--porcelain` and `-d`/`--debug` flags only took effect when placed at the exact command level where they were parsed, so e.g. `jabkit -p check consistency file.bib` silently ran without porcelain output. [#TODO](https://github.com/JabRef/jabref/pull/TODO)
+- We fixed an issue where `jabkit`'s `-p`/`--porcelain` and `-d`/`--debug` flags only took effect when placed at the exact command level where they were parsed, so e.g. `jabkit -p check consistency file.bib` silently ran without porcelain output. [#16164](https://github.com/JabRef/jabref/pull/16164)
 - We fixed an issue where cleanup did not detect an arXiv entry when its `url` field ended with a fragment anchor (e.g. `https://arxiv.org/html/2510.26275v2#bib`). [#16150](https://github.com/JabRef/jabref/pull/16150)
 - We fixed an issue where fetchers sent an empty API-key parameter (e.g. `api_key=`) to the remote service when no key was configured. [#16044](https://github.com/JabRef/jabref/pull/16044)
 - We fixed an issue where the global search dialog kept showing the previous entry preview when the search returned no results. [#15613](https://github.com/JabRef/jabref/issues/15613)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where `jabkit`'s `-p`/`--porcelain` and `-d`/`--debug` flags only took effect when placed at the exact command level where they were parsed, so e.g. `jabkit -p check consistency file.bib` silently ran without porcelain output. [#TODO](https://github.com/JabRef/jabref/pull/TODO)
 - We fixed an issue where cleanup did not detect an arXiv entry when its `url` field ended with a fragment anchor (e.g. `https://arxiv.org/html/2510.26275v2#bib`). [#16150](https://github.com/JabRef/jabref/pull/16150)
 - We fixed an issue where fetchers sent an empty API-key parameter (e.g. `api_key=`) to the remote service when no key was configured. [#16044](https://github.com/JabRef/jabref/pull/16044)
 - We fixed an issue where the global search dialog kept showing the previous entry preview when the search returned no results. [#15613](https://github.com/JabRef/jabref/issues/15613)

--- a/jabkit/src/main/java/org/jabref/toolkit/JabKitLauncher.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/JabKitLauncher.java
@@ -79,7 +79,20 @@ public class JabKitLauncher {
             Injector.setModelOrService(BibEntryTypesManager.class, entryTypesManager);
 
             JabKit jabKit = new JabKit(preferences, entryTypesManager);
-            CommandLine commandLine = new CommandLine(jabKit);
+            // All (sub)commands mix in JabKit.SharedOptions to allow -p/-d/-h at any command depth.
+            // Resolving them through one shared instance (instead of picocli's default of one instance
+            // per mixin site) ensures e.g. `jabkit -p check consistency` and `jabkit check consistency -p`
+            // both enable porcelain output, instead of setting an unrelated, unread copy of the flag.
+            JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+            CommandLine commandLine = new CommandLine(jabKit, new CommandLine.IFactory() {
+                @Override
+                public <K> K create(Class<K> cls) throws Exception {
+                    if (cls == JabKit.SharedOptions.class) {
+                        return cls.cast(sharedOptions);
+                    }
+                    return CommandLine.defaultFactory().create(cls);
+                }
+            });
             commandLine.setExecutionExceptionHandler(new CliExceptionHandler(commandLine.getExecutionExceptionHandler()));
             // [impl->req~jabkit.cli.banner-shown~1]
             String usageHeader = BuildInfo.JABREF_BANNER.formatted(buildInfo.version) + "\n" + JABKIT_BRAND;
@@ -169,9 +182,9 @@ public class JabKitLauncher {
 
         // We must configure logging as soon as possible, which is why we cannot wait for the usual
         // argument parsing workflow to parse logging options e.g. --debug or --porcelain
-        boolean isPorcelain = Arrays.stream(args).anyMatch("--porcelain"::equalsIgnoreCase);
+        boolean isPorcelain = Arrays.stream(args).anyMatch(arg -> "--porcelain".equalsIgnoreCase(arg) || "-p".equalsIgnoreCase(arg));
         Level logLevel;
-        if (Arrays.stream(args).anyMatch("--debug"::equalsIgnoreCase)) {
+        if (Arrays.stream(args).anyMatch(arg -> "--debug".equalsIgnoreCase(arg) || "-d".equalsIgnoreCase(arg))) {
             logLevel = Level.DEBUG;
         } else {
             logLevel = Level.INFO;

--- a/jabkit/src/main/java/org/jabref/toolkit/JabKitLauncher.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/JabKitLauncher.java
@@ -79,20 +79,7 @@ public class JabKitLauncher {
             Injector.setModelOrService(BibEntryTypesManager.class, entryTypesManager);
 
             JabKit jabKit = new JabKit(preferences, entryTypesManager);
-            // All (sub)commands mix in JabKit.SharedOptions to allow -p/-d/-h at any command depth.
-            // Resolving them through one shared instance (instead of picocli's default of one instance
-            // per mixin site) ensures e.g. `jabkit -p check consistency` and `jabkit check consistency -p`
-            // both enable porcelain output, instead of setting an unrelated, unread copy of the flag.
-            JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
-            CommandLine commandLine = new CommandLine(jabKit, new CommandLine.IFactory() {
-                @Override
-                public <K> K create(Class<K> cls) throws Exception {
-                    if (cls == JabKit.SharedOptions.class) {
-                        return cls.cast(sharedOptions);
-                    }
-                    return CommandLine.defaultFactory().create(cls);
-                }
-            });
+            CommandLine commandLine = new CommandLine(jabKit, JabKit.createFactory());
             commandLine.setExecutionExceptionHandler(new CliExceptionHandler(commandLine.getExecutionExceptionHandler()));
             // [impl->req~jabkit.cli.banner-shown~1]
             String usageHeader = BuildInfo.JABREF_BANNER.formatted(buildInfo.version) + "\n" + JABKIT_BRAND;

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/Check.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/Check.java
@@ -31,7 +31,7 @@ class Check implements Callable<Integer> {
     protected JabKit jabKit;
 
     @Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     /// Optional positional input file. When supplied directly to `check` (without a
     /// `consistency` or `integrity` subcommand), both checks run against it.

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/CheckConsistency.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/CheckConsistency.java
@@ -33,7 +33,7 @@ class CheckConsistency implements Callable<Integer> {
     private Check check;
 
     @Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @Mixin
     private InputOption inputOption = new InputOption();

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/CheckIntegrity.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/CheckIntegrity.java
@@ -39,7 +39,7 @@ class CheckIntegrity implements Callable<Integer> {
     private Check check;
 
     @Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @Mixin
     private InputOption inputOption = new InputOption();

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/Convert.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/Convert.java
@@ -26,7 +26,7 @@ class Convert implements Callable<Integer> {
     private JabKit jabKit;
 
     @Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @Mixin
     private InputOption inputOption = new InputOption();

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/DoiToBibtex.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/DoiToBibtex.java
@@ -28,7 +28,7 @@ class DoiToBibtex implements Callable<Integer> {
     private JabKit argumentProcessor;
 
     @CommandLine.Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @Parameters(paramLabel = "DOI", description = "one or more DOIs to fetch", arity = "1..*")
     private String[] dois;

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/Fetch.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/Fetch.java
@@ -35,7 +35,7 @@ class Fetch implements Callable<Integer> {
     private JabKit argumentProcessor;
 
     @Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @Option(names = "--provider", required = true)
     private String provider;

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/GenerateBibFromAux.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/GenerateBibFromAux.java
@@ -33,7 +33,7 @@ class GenerateBibFromAux implements Callable<Integer> {
     private JabKit argumentProcessor;
 
     @Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @Option(names = "--aux", required = true)
     private Path auxFile;

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/GenerateCitationKeys.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/GenerateCitationKeys.java
@@ -38,7 +38,7 @@ class GenerateCitationKeys implements Callable<Integer> {
     private CitationKeys parentCommand;
 
     @Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @Mixin
     private InputOption inputOption = new InputOption();

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/GetCitedWorks.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/GetCitedWorks.java
@@ -32,7 +32,7 @@ class GetCitedWorks implements Callable<Integer> {
     private JabKit argumentProcessor;
 
     @CommandLine.Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @CommandLine.Option(
             names = "--output",

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/GetCitingWorks.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/GetCitingWorks.java
@@ -32,7 +32,7 @@ class GetCitingWorks implements Callable<Integer> {
     private JabKit argumentProcessor;
 
     @CommandLine.Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @CommandLine.Option(
             names = "--output",

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/JabKit.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/JabKit.java
@@ -4,6 +4,8 @@ import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.util.BuildInfo;
 import org.jabref.model.entry.BibEntryTypesManager;
 
+import picocli.CommandLine;
+
 import static picocli.CommandLine.Command;
 import static picocli.CommandLine.Mixin;
 import static picocli.CommandLine.Option;
@@ -51,6 +53,24 @@ public class JabKit implements Runnable {
             return;
         }
         System.out.printf(BuildInfo.JABREF_BANNER + "%n", new BuildInfo().version);
+    }
+
+    /// Every (sub)command mixes in [SharedOptions] to allow `-p`/`-d`/`-h` at any command depth
+    /// (e.g. both `jabkit -p check consistency` and `jabkit check consistency -p`). picocli
+    /// resolves each mixin site independently, so without this factory each site would get its
+    /// own, disconnected `SharedOptions` instance. Use the returned factory for every
+    /// `CommandLine` built over a `JabKit` command tree, so all sites share one instance instead.
+    public static CommandLine.IFactory createFactory() {
+        SharedOptions sharedOptions = new SharedOptions();
+        return new CommandLine.IFactory() {
+            @Override
+            public <K> K create(Class<K> cls) throws Exception {
+                if (cls == SharedOptions.class) {
+                    return cls.cast(sharedOptions);
+                }
+                return CommandLine.defaultFactory().create(cls);
+            }
+        };
     }
 
     public static class SharedOptions {

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/JabKit.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/JabKit.java
@@ -31,8 +31,10 @@ public class JabKit implements Runnable {
     protected final CliPreferences cliPreferences;
     protected final BibEntryTypesManager entryTypesManager;
 
+    /// Left uninitialized so picocli's factory supplies the same shared instance
+    /// used by every (sub)command in the tree; see JabKitLauncher.
     @Mixin
-    private SharedOptions sharedOptions = new SharedOptions();
+    private SharedOptions sharedOptions;
 
     @Option(names = {"-v", "--version"}, versionHelp = true, description = "display version info")
     private boolean versionInfoRequested;

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/Pdf.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/Pdf.java
@@ -20,7 +20,7 @@ class Pdf implements Callable<Integer> {
     protected JabKit argumentProcessor;
 
     @Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @Override
     public Integer call() {

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/PdfUpdate.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/PdfUpdate.java
@@ -43,7 +43,7 @@ class PdfUpdate implements Callable<Integer> {
     protected Pdf pdf;
 
     @Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @Option(names = "--format", description = "Format to update (xmp, bibtex-attachment)", split = ",")
     private List<String> formats = List.of("xmp", "bibtex-attachment"); // ToDO: default value?

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/Preferences.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/Preferences.java
@@ -29,7 +29,7 @@ class Preferences implements Callable<Integer> {
     protected JabKit argumentProcessor;
 
     @Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @Override
     public Integer call() {

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/Pseudonymize.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/Pseudonymize.java
@@ -35,7 +35,7 @@ class Pseudonymize implements Callable<Integer> {
     private JabKit argumentProcessor;
 
     @Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @Mixin
     private InputOption inputOption = new InputOption();

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/Search.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/Search.java
@@ -34,7 +34,7 @@ class Search implements Callable<Integer> {
     private JabKit argumentProcessor;
 
     @Mixin
-    private JabKit.SharedOptions sharedOptions = new JabKit.SharedOptions();
+    private JabKit.SharedOptions sharedOptions;
 
     @Option(names = {"--query"}, description = "Search query", required = true)
     private String query;

--- a/jabkit/src/test/java/org/jabref/toolkit/commands/AbstractJabKitTest.java
+++ b/jabkit/src/test/java/org/jabref/toolkit/commands/AbstractJabKitTest.java
@@ -75,7 +75,7 @@ public abstract class AbstractJabKitTest {
         when(preferences.getAiPreferences()).thenReturn(aiPreferences);
 
         JabKit jabKit = new JabKit(preferences, entryTypesManager);
-        commandLine = new CapturingCommandLine(jabKit);
+        commandLine = new CapturingCommandLine(jabKit, JabKit.createFactory());
     }
 
     /// Gets class resource as fully qualified string.

--- a/jabkit/src/test/java/org/jabref/toolkit/commands/JabKitTest.java
+++ b/jabkit/src/test/java/org/jabref/toolkit/commands/JabKitTest.java
@@ -61,6 +61,22 @@ class JabKitTest extends AbstractJabKitTest {
     }
 
     @Test
+    void globalPorcelainBeforeSubcommandAppliesToNestedSubcommand() {
+        Path testBib = getClassResourceAsPath("origin.bib");
+        String testBibFile = testBib.toAbsolutePath().toString();
+
+        // "--porcelain" is placed before the "check"/"consistency" subcommands, at the root
+        // command level, instead of after them at the level where "consistency" reads it.
+        List<String> args = List.of("--porcelain", "check", "consistency", "--input", testBibFile);
+
+        int executionResult = commandLine.executeToLog(args.toArray(String[]::new));
+
+        String output = commandLine.getStandardOutput();
+        assertEquals("", output);
+        assertEquals(0, executionResult);
+    }
+
+    @Test
     void checkConsistencyGitHubActionsFormat() {
         Path testBib = getClassResourceAsPath("origin.bib");
         String testBibFile = testBib.toAbsolutePath().toString();


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/pull/16162#discussion_r3524468264

`--porcelain` did not work

---

Each jabkit (sub)command mixed in its own `new SharedOptions()` instance, so e.g. `jabkit -p check consistency` set the root command's copy of `porcelain` while `check`/`consistency` read their own, always-false copy. Resolve the mixin through a single shared instance (via a custom picocli IFactory) so the flag has one value across the whole command tree, regardless of where it's placed.

Also detect the short forms -p/-d (not just --porcelain/--debug) during early logging setup, which runs before picocli parses arguments.

### Related issues and pull requests

https://github.com/JabRef/jabref/pull/16162#discussion_r3524468264

### PR Description

Fix JabKit

### Steps to test

USe `--porcelain`

### AI usage

Claude was my friend

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- x.] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
