### PR TITLE
Add madrlint MADR linter to test workflow

### DIFF
--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -180,8 +180,11 @@ jobs:
         shell: bash
         run: |
           echo "cache_key=jbang-madrlint-$(date +%Y-%m)" >> $GITHUB_OUTPUT
-      - name: Use cache
-        uses: actions/cache/restore@v6
+      - name: Cache JBang
+        # Combined cache action: restores at start and saves ~/.jbang on a
+        # cache miss in the post-job step. A madrlint-specific key keeps this
+        # cache separate from the shared "jbang-" cache used by setup-gradle.
+        uses: actions/cache@v6
         with:
           path: ~/.jbang
           key: ${{ steps.cache-key.outputs.cache_key }}

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -165,6 +165,50 @@ jobs:
             *.md
             docs/**/*.md
 
+  madr:
+    name: MADR ADRs
+    # JBang needs a JDK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          submodules: 'false'
+          show-progress: 'false'
+      - name: Generate JBang cache key
+        id: cache-key
+        shell: bash
+        run: |
+          echo "cache_key=jbang-madrlint-$(date +%Y-%m)" >> $GITHUB_OUTPUT
+      - name: Use cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.jbang
+          key: ${{ steps.cache-key.outputs.cache_key }}
+          restore-keys:
+            jbang-madrlint-
+      - name: Setup JBang
+        uses: jbangdev/setup-jbang@main
+      - name: Trust madrlint source
+        run: jbang trust add https://github.com/adr/
+      - name: Lint ADRs
+        run: |
+          report="$(mktemp)"
+          # Each ADR file is checked against the per-file rules; the docs/decisions directory itself
+          # is checked against the directory rules (numbering, naming, collisions). Non-ADR files
+          # (adr-template.md, index.md) are excluded via .madrlintignore.
+          # -n11 disables the external-link check (MADR11); JabRef verifies external links elsewhere.
+          for target in docs/decisions/*.md docs/decisions; do
+            jbang madrlint@adr/madrlint -n11 --quiet --output-format github-actions "$target"
+          done | tee "$report"
+
+          error_count=$(grep -c '^::error' "$report" || true)
+          if [ "$error_count" -ne 0 ]; then
+            echo "❌ madrlint reported $error_count MADR violation(s). See the annotations above."
+            exit 1
+          fi
+          echo "✅ No MADR violations."
+
   changelog:
     name: CHANGELOG.md
     # JBang needs a JDK

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -191,10 +191,16 @@ jobs:
           restore-keys:
             jbang-madrlint-
       - name: Setup JBang
-        uses: jbangdev/setup-jbang@main
+        # Pinned to a commit for deterministic CI; comment tracks the tag.
+        uses: jbangdev/setup-jbang@2b1b465a7b75f4222b81426f23a01e013aa7b95c # v0.1.1
       - name: Trust madrlint source
         run: jbang trust add https://github.com/adr/
       - name: Lint ADRs
+        # madrlint is pinned to a commit (not the moving `madrlint@adr/madrlint` alias) so
+        # upstream changes cannot alter lint results without a deliberate bump here.
+        # To update: point MADRLINT at a newer https://github.com/adr/madrlint commit.
+        env:
+          MADRLINT: https://github.com/adr/madrlint/blob/e37d19b6699e45dd1543bccd858f4f49af350e49/madrlint.java
         run: |
           report="$(mktemp)"
           # Each ADR file is checked against the per-file rules; the docs/decisions directory itself
@@ -202,7 +208,7 @@ jobs:
           # (adr-template.md, index.md) are excluded via .madrlintignore.
           # -n11 disables the external-link check (MADR11); JabRef verifies external links elsewhere.
           for target in docs/decisions/*.md docs/decisions; do
-            jbang madrlint@adr/madrlint -n11 --quiet --output-format github-actions "$target"
+            jbang "$MADRLINT" -n11 --quiet --output-format github-actions "$target"
           done | tee "$report"
 
           error_count=$(grep -c '^::error' "$report" || true)

--- a/.madrlintignore
+++ b/.madrlintignore
@@ -1,0 +1,4 @@
+# Files in docs/decisions/ that are not ADRs and therefore not linted by madrlint.
+# See https://github.com/adr/madrlint
+adr-template.md
+index.md

--- a/docs/decisions/0017-allow-model-access-logic.md
+++ b/docs/decisions/0017-allow-model-access-logic.md
@@ -6,19 +6,19 @@ nav_order: 17
 
 ## Context and Problem Statement
 
-- How to create a maintainable architecture?
-- How to split model, logic, and UI
+* How to create a maintainable architecture?
+* How to split model, logic, and UI
 
 ## Decision Drivers
 
-- Newcomers should find the architecture "split" natural
-- The architecture should be a help (and not a burden)
+* Newcomers should find the architecture "split" natural
+* The architecture should be a help (and not a burden)
 
 ## Considered Options
 
-- `org.jabref.model` uses `org.jabref.model` (and external libraries) only
-- `org.jabref.model` may use `org.jabref.logic` in defined cases
-- `org.jabref.model` and `org.jabref.logic` may access each other freely
+* `org.jabref.model` uses `org.jabref.model` (and external libraries) only
+* `org.jabref.model` may use `org.jabref.logic` in defined cases
+* `org.jabref.model` and `org.jabref.logic` may access each other freely
 
 ## Decision Outcome
 
@@ -32,17 +32,17 @@ The model package does not access logic or other packages of JabRef.
 Access to classes of external libraries is allowed.
 The logic package may use the model package.
 
-- Good, because clear separation of model and logic
-- Bad, because this leads to an [Anemic Domain Model](https://martinfowler.com/bliki/AnemicDomainModel.html)
+* Good, because clear separation of model and logic
+* Bad, because this leads to an [Anemic Domain Model](https://martinfowler.com/bliki/AnemicDomainModel.html)
 
 ### `org.jabref.model` may use `org.jabref.logic` in defined cases
 
-- Good, because model and logic are still separated
-- Neutral, because each exception has to be discussed and agreed
-- Bad, because newcomers have to be informed that there are certain (agreed) exceptions for model to access logic
+* Good, because model and logic are still separated
+* Neutral, because each exception has to be discussed and agreed
+* Bad, because newcomers have to be informed that there are certain (agreed) exceptions for model to access logic
 
 ### `org.jabref.model` and `org.jabref.logic` may access each other freely
 
-- Bad, because may lead to spaghetti code
-- Bad, because coupling between model and logic is increased
-- Bad, because cohesion inside model is decreased
+* Bad, because may lead to spaghetti code
+* Bad, because coupling between model and logic is increased
+* Bad, because cohesion inside model is decreased

--- a/docs/decisions/0024-use-#-as-indicator-for-BibTeX-string-constants.md
+++ b/docs/decisions/0024-use-#-as-indicator-for-BibTeX-string-constants.md
@@ -4,6 +4,8 @@ nav_order: 24
 ---
 # Use `#` as indicator for BibTeX string constants
 
+## Context and Problem Statement
+
 Bibtex supports string constants. The entry editor should support that, too.
 Affected code is (at least) `org.jabref.logic.importer.fileformat.BibtexParser#parseFieldContent` and `org.jabref.logic.bibtex.FieldWriter#formatAndResolveStrings`
 

--- a/docs/decisions/0027-synchronization.md
+++ b/docs/decisions/0027-synchronization.md
@@ -11,16 +11,16 @@ Synchronize the data in a library to a remote database, while handling conflicts
 
 ## Decision Drivers
 
-- Updates from the remote should be pulled in
-- No updates should get lost
-- Easy to implement
-- Easy to maintain
+* Updates from the remote should be pulled in
+* No updates should get lost
+* Easy to implement
+* Easy to maintain
 
 ## Considered Options
 
-- "Optimistic offline lock" with hashes for local file support
-- Algorithm based on "optimistic offline lock"
-- Use CRDTs
+* "Optimistic offline lock" with hashes for local file support
+* Algorithm based on "optimistic offline lock"
+* Use CRDTs
 
 ## Decision Outcome
 
@@ -48,12 +48,12 @@ Implementation details are found at <https://www.baeldung.com/cs/offline-concurr
 
 This is implemented for the SQL database synchronization, which is described at [Remote SQL Storage](../code-howtos/remote-storage-sql.md).
 
-- Good, because this algorithm is already in place since 2016 for JabRef synchronizing with a PostgreSQL backend and a MySQL backend.
-- Bad, because it assumes the client to be online 100% and does not have handlings of cases where the client disconnects and alters data in other ways.
+* Good, because this algorithm is already in place since 2016 for JabRef synchronizing with a PostgreSQL backend and a MySQL backend.
+* Bad, because it assumes the client to be online 100% and does not have handlings of cases where the client disconnects and alters data in other ways.
 
 ### Use CRDTs
 
 See <https://automerge.org/blog/automerge-2/> for details.
 
-- Bad, because one needs to locally store a lot more metadata (e.g. for operational CRDTs you essentially need to have the full history of all edits). So you would need another file next to the bib file to store these.
-- Bad, because CRDTs are mainly used when you need low latency and high frequency of edits (e.g. multi-user chat or text editing). Not really something we care about.
+* Bad, because one needs to locally store a lot more metadata (e.g. for operational CRDTs you essentially need to have the full history of all edits). So you would need another file next to the bib file to store these.
+* Bad, because CRDTs are mainly used when you need low latency and high frequency of edits (e.g. multi-user chat or text editing). Not really something we care about.

--- a/docs/decisions/0029-cff-export-multiple-entries.md
+++ b/docs/decisions/0029-cff-export-multiple-entries.md
@@ -31,6 +31,8 @@ The need for an [exporter](https://github.com/JabRef/jabref/issues/10661) to [CF
 
 ## Decision Outcome
 
+Chosen option: export with a dummy topmost `software` element and all other entries as `references` (with per-type variations), because this keeps exported files compatible with official CFF tools while keeping the export behavior predictable for users.
+
 The decision outcome is the following.
 
 * When exporting, JabRef will have a different behavior depending on entries type.

--- a/docs/decisions/0037-rag-architecture-implementation.md
+++ b/docs/decisions/0037-rag-architecture-implementation.md
@@ -56,7 +56,7 @@ required to install some separate software (or even Python runtime).
 
 ## Decision Outcome
 
-Chosen option: mix of "Use a hand-crafted RAG" and "Use a third-party Java library".
+Chosen option: mix of "Use a hand-crafted RAG" and "Use a third-party Java library", because third-party libraries provide the machinery for connecting to an LLM and extracting text, while some parts still need to be hand-crafted (see below).
 
 Third-party libraries provide excellent resources for connecting to an LLM or extracting text from PDF files. For RAG,
 we mostly used all the machinery provided by `langchain4j`, but there were moments that should be hand-crafted:

--- a/docs/decisions/0039-use-apache-velocity-as-template-engine.md
+++ b/docs/decisions/0039-use-apache-velocity-as-template-engine.md
@@ -43,9 +43,9 @@ Update from 20.10.2025: added pebble
 
 ### Apache Velocity
 
-- Main page: <https://velocity.apache.org/>.
-- User guide: <https://velocity.apache.org/engine/devel/user-guide.html>.
-- Developer guide: <https://velocity.apache.org/engine/devel/developer-guide.html>.
+* Main page: <https://velocity.apache.org/>.
+* User guide: <https://velocity.apache.org/engine/devel/user-guide.html>.
+* Developer guide: <https://velocity.apache.org/engine/devel/developer-guide.html>.
 
 Example:
 
@@ -67,9 +67,9 @@ ${CanonicalBibEntry.getCanonicalRepresentation($entry)}
 
 ### Apache FreeMarker
 
-- Main page: <https://freemarker.apache.org/index.html>.
-- User guide: <https://freemarker.apache.org/docs/dgui.html>.
-- Developer guide: <https://freemarker.apache.org/docs/pgui_quickstart.html>.
+* Main page: <https://freemarker.apache.org/index.html>.
+* User guide: <https://freemarker.apache.org/docs/dgui.html>.
+* Developer guide: <https://freemarker.apache.org/docs/pgui_quickstart.html>.
 
 Example:
 
@@ -94,8 +94,8 @@ Note: There is a modern implementation [FreshMarker](https://gitlab.com/schegge/
 
 ### Thymeleaf
 
-- Main page: <https://www.thymeleaf.org/>.
-- Documentation: <https://www.thymeleaf.org/doc/tutorials/3.1/usingthymeleaf.html>.
+* Main page: <https://www.thymeleaf.org/>.
+* Documentation: <https://www.thymeleaf.org/doc/tutorials/3.1/usingthymeleaf.html>.
 
 Example:
 
@@ -119,9 +119,9 @@ Here are the papers you are analyzing:
 
 Because Handlebars and Mustache have similar syntax, and library mentioned below supports both languages, we decided to merge Handlebars and Mustache into one option.
 
-- Main page: <https://handlebarsjs.com/>.
-- Java port repository and developer guide: <https://github.com/jknack/handlebars.java>.
-- User guide: <https://handlebarsjs.com/guide/>.
+* Main page: <https://handlebarsjs.com/>.
+* Java port repository and developer guide: <https://github.com/jknack/handlebars.java>.
+* User guide: <https://handlebarsjs.com/guide/>.
 
 Example:
 
@@ -143,9 +143,9 @@ Here are the papers you are analyzing:
 
 ### Jinja
 
-- Main page: <https://palletsprojects.com/projects/jinja/>.
-- Java port repository and developer guide: <https://github.com/HubSpot/jinjava>.
-- User guide: <https://jinja.palletsprojects.com/en/stable/templates/>.
+* Main page: <https://palletsprojects.com/projects/jinja/>.
+* Java port repository and developer guide: <https://github.com/HubSpot/jinjava>.
+* User guide: <https://jinja.palletsprojects.com/en/stable/templates/>.
 
 ```text
 You are an AI assistant that analyses research papers. You answer questions about papers.
@@ -168,9 +168,9 @@ Here are the papers you are analyzing:
 
 ### Pebble
 
-- Main page: <https://pebbletemplates.io/>
-- Repository and developer guide: <https://github.com/PebbleTemplates/pebble>
-- User guide: <https://pebbletemplates.io/wiki/>
+* Main page: <https://pebbletemplates.io/>
+* Repository and developer guide: <https://github.com/PebbleTemplates/pebble>
+* User guide: <https://pebbletemplates.io/wiki/>
 
 ```text
 {% for entry in entries %}

--- a/docs/decisions/0040-display-front-cover-in-preview-tab.md
+++ b/docs/decisions/0040-display-front-cover-in-preview-tab.md
@@ -27,7 +27,7 @@ Place the book cover in:
 
 ## Decision Outcome
 
-Chosen option: "The PreviewPanel of the EntryEditor".
+Chosen option: "The PreviewPanel of the EntryEditor", because it would not be obtrusive or distracting.
 
 ## Pros and Cons of the Options
 

--- a/docs/decisions/0041-use-one-form-for-singular-and-plural.md
+++ b/docs/decisions/0041-use-one-form-for-singular-and-plural.md
@@ -44,9 +44,9 @@ Chosen option: "Use one form only (no explicit pluralization)", because it is th
 
 Example:
 
-- `Imported 0 entry(s)`
-- `Imported 1 entry(s)`
-- `Imported 12 entry(s)`
+* `Imported 0 entry(s)`
+* `Imported 1 entry(s)`
+* `Imported 12 entry(s)`
 
 There are sub alternatives here:
 
@@ -62,9 +62,9 @@ These arguments are for the general case of using a single text for all kinds of
 
 Example:
 
-- `Imported 0 entries`
-- `Imported 1 entry`
-- `Imported 12 entries`
+* `Imported 0 entries`
+* `Imported 1 entry`
+* `Imported 12 entries`
 
 * Good, because reads well in English
 * Bad, because all localizations need to take an `if` check for the count
@@ -74,9 +74,9 @@ Example:
 
 Example:
 
-- `Imported 0 entries`
-- `Imported 1 entry`
-- `Imported 12 entries`
+* `Imported 0 entries`
+* `Imported 1 entry`
+* `Imported 12 entries`
 
 Code: `Localization.lang("Imported %0 entries", "Imported %0 entry.", "Imported %0 entries.", "Imported %0 entries.", "Imported %0 entries.", "Imported %0 entries.", count)`
 
@@ -87,10 +87,10 @@ Code: `Localization.lang("Imported %0 entries", "Imported %0 entry.", "Imported 
 
 ## More Information
 
-- [Pluralization: A Guide to Localizing Plurals](https://phrase.com/blog/posts/pluralization/)
-- [Language Plural Rules](https://www.unicode.org/cldr/charts/43/supplemental/language_plural_rules.html)
-- [Unicode CLDR Project's Plural Rules](https://cldr.unicode.org/index/cldr-spec/plural-rules)
-- [Implementation in Mozilla Firefox](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules)
-- [SX discussion on plural forms](https://english.stackexchange.com/a/90283/66058)
+* [Pluralization: A Guide to Localizing Plurals](https://phrase.com/blog/posts/pluralization/)
+* [Language Plural Rules](https://www.unicode.org/cldr/charts/43/supplemental/language_plural_rules.html)
+* [Unicode CLDR Project's Plural Rules](https://cldr.unicode.org/index/cldr-spec/plural-rules)
+* [Implementation in Mozilla Firefox](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules)
+* [SX discussion on plural forms](https://english.stackexchange.com/a/90283/66058)
 
 <!-- markdownlint-disable-file MD004 -->

--- a/docs/decisions/0042-use-webview-for-summarization-content.md
+++ b/docs/decisions/0042-use-webview-for-summarization-content.md
@@ -11,27 +11,27 @@ This decision record concerns the UI component that is used for rendering the co
 
 ## Decision Drivers
 
-Same as in [ADR-0036](./0036-use-textarea-for-chat-content.md).
+Same as in [ADR-0036](./0036-use-markdown-for-chat-content.md).
 
 ## Considered Options
 
-Same as in [ADR-0036](./0036-use-textarea-for-chat-content.md).
+Same as in [ADR-0036](./0036-use-markdown-for-chat-content.md).
 
 ## Decision Outcome
 
-Chosen option: "Use `WebView`".
+Chosen option: "Use `WebView`", because it supports selecting and copying text as well as rendering Markdown, and there is only one summary content in the UI so performance is not a concern (see below).
 
 Some of the options does not support selecting and copying of text. Some options do not render Markdown.
 
-However, in contrary to [ADR-0036](./0036-use-textarea-for-chat-content.md), we chose here a `WebView`, instead of `TextArea`, because there is only one summary content in UI (when user switches entries, no new components are added, rather old ones are *rebinding* to new entry). It would hurt the performance if we used `WebView` for messages, as there could be a lot of messages in one chat.
+However, in contrary to [ADR-0036](./0036-use-markdown-for-chat-content.md), we chose here a `WebView`, instead of `TextArea`, because there is only one summary content in UI (when user switches entries, no new components are added, rather old ones are *rebinding* to new entry). It would hurt the performance if we used `WebView` for messages, as there could be a lot of messages in one chat.
 
 ## Pros and Cons of the Options
 
-Same as in [ADR-0036](./0036-use-textarea-for-chat-content.md).
+Same as in [ADR-0036](./0036-use-markdown-for-chat-content.md).
 
 ## More Information
 
-This ADR is highly linked to [ADR-0036](./0036-use-textarea-for-chat-content.md).
+This ADR is highly linked to [ADR-0036](./0036-use-markdown-for-chat-content.md).
 
 About the selection and copying, this goes down to fundamental issue from JavaFX.
 `Text` and `Label` as a whole or a part [cannot be selected and/or copied](https://bugs.openjdk.org/browse/JDK-8091644).

--- a/docs/decisions/0043-show-merge-dialog-when-importing-a-single-pdf.md
+++ b/docs/decisions/0043-show-merge-dialog-when-importing-a-single-pdf.md
@@ -54,8 +54,8 @@ Chosen option: "Open a merge dialog with all candidates if a single PDF is impor
 
 Explanation:
 
-- If a single PDF is imported, then open a merge dialog.
-- If several PDFs are imported, merge candidates for each PDF automatically.
+* If a single PDF is imported, then open a merge dialog.
+* If several PDFs are imported, merge candidates for each PDF automatically.
 
 Outcomes:
 

--- a/docs/decisions/0047-use-references-heading-in-citations-tab.md
+++ b/docs/decisions/0047-use-references-heading-in-citations-tab.md
@@ -41,7 +41,7 @@ Chosen option: ""References cited in {citationkey}" and "References that cite {c
 
 ## Pros and Cons of the Options
 
-## "References cited in {citationkey}" and "References that cite {citationkey}"
+### "References cited in {citationkey}" and "References that cite {citationkey}"
 
 {citationkey} - if not available, use "this entry".
 
@@ -54,7 +54,7 @@ Regarding "cited in {citationkey}" or "cited by {citationkey}", either would do,
 * Good, because no confusion regarding "References" and "Citations".
 * Good, because left and right cite are different on purpose to create contrast.
 
-## "backward (cites)" and "forward (cited by)"
+### "backward (cites)" and "forward (cited by)"
 
 Tooltip: outgoing citations - works that are cited by this work. "Backward", because looking back in time.
 
@@ -64,7 +64,7 @@ Tooltip: incoming citations - works that cite this work. "Forward", because look
 * Good, because combines two concepts in the heading
 * Bad, because uses braces
 
-## "Backward Citations" and "Forward Citations"
+### "Backward Citations" and "Forward Citations"
 
 Backward citations
 
@@ -80,7 +80,7 @@ Technical words should be defined in the tooltip explicitly. Forward and backwar
 * Bad, because "backward" and forward" sound too technical
 * Bad, because too abstract for the average user and does not have clear semantics
 
-## "References (cites)" and "Citations (cited by)"
+### "References (cites)" and "Citations (cited by)"
 
 References (cites)
 Tooltip: Works cited by the work at hand
@@ -92,7 +92,7 @@ Tooltip: Works citing the work at hand
 * Good, because combines two concepts in the heading
 * Bad, because the braces in the heading are unusual
 
-## "References" and "Cited by"
+### "References" and "Cited by"
 
 Example: <https://dblp.org/rec/conf/zeus/VoigtKW21.html>
 
@@ -101,7 +101,7 @@ Example: <https://dblp.org/rec/conf/zeus/VoigtKW21.html>
 * Good, because "Cited by" is also used by Google Scholar
 * Bad, because mix of noun and verb
 
-## "Cites" and "Cited by"
+### "Cites" and "Cited by"
 
 * Good, because verbs
 * Bad, because too close to each other

--- a/docs/decisions/0048-jbang-script-modification-for-testing-in-ci.md
+++ b/docs/decisions/0048-jbang-script-modification-for-testing-in-ci.md
@@ -15,9 +15,9 @@ Example:
 gg.cmd  https://github.com/JabRef/jabref/blob/main/.jbang/JabLsLauncher.java
 ```
 
-- JBang scripts link to `org.jabref:jablib:6.0-SNAPSHOT`.
-- JBang scripts include java files from the respective `-cli` repository and the sources of the respective server project. E.g., `JabLsLauncher.java` includes `ServerCli.java` from `jabls-cli` and all sources from `jabls`.
-- Code changes might change a) things inside the server project and b) things in JabRef's logic.
+* JBang scripts link to `org.jabref:jablib:6.0-SNAPSHOT`.
+* JBang scripts include java files from the respective `-cli` repository and the sources of the respective server project. E.g., `JabLsLauncher.java` includes `ServerCli.java` from `jabls-cli` and all sources from `jabls`.
+* Code changes might change a) things inside the server project and b) things in JabRef's logic.
 
 As a consequence, the JBang script might break.
 
@@ -28,13 +28,13 @@ We aim for checking JBang scripts in PRs and on `main`.
 
 ## Decision Drivers
 
-- Fast detection of issues at all JBang files
-- Easy CI pipeline
+* Fast detection of issues at all JBang files
+* Easy CI pipeline
 
 ## Considered Options
 
-- Have JBang script have all changed classes of `jablib` included directly
-- Use jitpack
+* Have JBang script have all changed classes of `jablib` included directly
+* Use jitpack
 -Temporary `-SNAPSHOT.jar`
 
 ## Decision Outcome
@@ -45,17 +45,17 @@ Chosen option: "Have JBang script have all changed classes of `jablib` included 
 
 ### Have JBang script have all changed classes of `jablib` included directly
 
-- `org.jabref:jablib:6.0-SNAPSHOT` provides non-modified classes
-- modified classes are included using JBang's `//SOURCES` directive.
+* `org.jabref:jablib:6.0-SNAPSHOT` provides non-modified classes
+* modified classes are included using JBang's `//SOURCES` directive.
 
 [tj-actions/changed-files](https://github.com/marketplace/actions/changed-files) can be used.
 
-- Good, because least effort
+* Good, because least effort
 
 ### Use jitpack
 
-- Bad, because jitpack is unreliable
+* Bad, because jitpack is unreliable
 
 ### Temporary `-SNAPSHOT.jar`
 
-- Bad, because setting up a temporary maven repository is effort.
+* Bad, because setting up a temporary maven repository is effort.

--- a/docs/decisions/0049-hardcode-fieldnames.md
+++ b/docs/decisions/0049-hardcode-fieldnames.md
@@ -1,5 +1,5 @@
 ---
-title: Hardcode `StandardField` names and use exact or customized names otherwise
+title: Hardcode StandardField names and use exact or customized names otherwise
 nav_order: 49
 parent: Decision Records
 status: accepted
@@ -51,11 +51,11 @@ Chosen option: "Hardcode `StandardField` names and use exact or customized names
 ### Hardcode `StandardField` names and use exact or customized names otherwise (disallow customization of `StandardField`s)
 
 <!-- markdownlint-disable-next-line MD004 -->>
-- For the build-in types (`StandardField`), the display names are hard-coded. Users cannot customize this. Optional/required can still be customized.
+* For the build-in types (`StandardField`), the display names are hard-coded. Users cannot customize this. Optional/required can still be customized.
 <!-- markdownlint-disable-next-line MD004 -->>
-- Preserve exact user/customized names for non‑standard fields
+* Preserve exact user/customized names for non‑standard fields
 <!-- markdownlint-disable-next-line MD004 -->>
-- Serialize as customized (and lower-case as standard) to `.bib` file
+* Serialize as customized (and lower-case as standard) to `.bib` file
 
 * Good, because round‑trip: UI labels ↔ preferences ↔ UI remain stable.
 * Good, because built‑in labels can be localized predictably (title case or localized form).

--- a/docs/decisions/0052-jspecify-nullable-annotations.md
+++ b/docs/decisions/0052-jspecify-nullable-annotations.md
@@ -28,7 +28,7 @@ We want to detect null-safety issues earlier at compile time and improve API cla
 
 Chosen option: "Adopt JSpecify annotations" because it comes out best (see below).
 
-## Consequences
+### Consequences
 
 * Earlier detection of potential NPEs.
 * Clearer API documentation.

--- a/docs/decisions/0053-nullness-checking-framework.md
+++ b/docs/decisions/0053-nullness-checking-framework.md
@@ -27,7 +27,7 @@ Null pointer exceptions are a pervasive source of bugs in Java. To alleviate thi
 
 Chosen option: "Error Prone + NullAway" because it comes out best (see below).
 
-## Consequences
+### Consequences
 
 * We will annotate public APIs (interfaces, service endpoints, widely used modules) using JSpecify `@Nullable` / `@NonNull` (or `@NullMarked` scoping) progressively.
 * We enable NullAway in CI builds; thus violations break the build.

--- a/docs/decisions/0056-OCR-engine-selection.md
+++ b/docs/decisions/0056-OCR-engine-selection.md
@@ -12,26 +12,26 @@ Which OCR engines should JabRef support to serve its academic user base?
 
 ## Decision Drivers
 
-- GPL and non-open-source are not acceptable (with exception to online services).
-- No engine will be bundled in JabRef's distribution. Engines should be installed by the user.
-- The output of OCR should be embeddable as a text layer in the PDF so that Lucene (or another search engine) can subsequently extract it. This allows Lucene to index the document through the existing logic with no changes.
-- OCR Engines should support the accuracy requirements of academic documents: mathematical equations, tables, and multiple languages including non-latin scripts.
+* GPL and non-open-source are not acceptable (with exception to online services).
+* No engine will be bundled in JabRef's distribution. Engines should be installed by the user.
+* The output of OCR should be embeddable as a text layer in the PDF so that Lucene (or another search engine) can subsequently extract it. This allows Lucene to index the document through the existing logic with no changes.
+* OCR Engines should support the accuracy requirements of academic documents: mathematical equations, tables, and multiple languages including non-latin scripts.
 
 ## Considered Options
 
-- OCRmyPDF subprocess, MPL-2.0
-- Tesseract via Tess4J Java API (JNA), Apache 2.0
-- Apache Tika with Tesseract Java API, Apache 2.0
-- Docling subprocess, MIT
-- olmOCR subprocess, Apache 2.0
-- Llama.cpp HTTP API, MIT
-- PaddleOCR-VL model via llama.cpp HTTP API, Apache 2.0
-- PaddleOCR HTTP API, Apache 2.0
-- TurboOCR HTTP API, MIT
-- deepdoctection subprocess, Apache 2.0
-- SimpleHTR subprocess, MIT
-- Surya subprocess, GPL-3.0
-- Kreuzberg Java API (FFI), Elastic License 2.0
+* OCRmyPDF subprocess, MPL-2.0
+* Tesseract via Tess4J Java API (JNA), Apache 2.0
+* Apache Tika with Tesseract Java API, Apache 2.0
+* Docling subprocess, MIT
+* olmOCR subprocess, Apache 2.0
+* Llama.cpp HTTP API, MIT
+* PaddleOCR-VL model via llama.cpp HTTP API, Apache 2.0
+* PaddleOCR HTTP API, Apache 2.0
+* TurboOCR HTTP API, MIT
+* deepdoctection subprocess, Apache 2.0
+* SimpleHTR subprocess, MIT
+* Surya subprocess, GPL-3.0
+* Kreuzberg Java API (FFI), Elastic License 2.0
 
 ## Decision Outcome
 
@@ -47,12 +47,12 @@ Apache Tika is not selected as a primary OCR path because it abstracts away fine
 
 ### Consequences
 
-- Good, because OCRmyPDF handles the embedding the text layer automatically.
-- Good, because OCRmyPDF will allow users to use different engines through the plugins it offers.
-- Good, because OCRmyPDF's `--skip-text` flag handles partially searchable PDFs by skipping pages that already have a valid text layer.
-- Bad, because OCRmyPDF requires Python 3.x to be installed on the user's machine, which is an additional step for non-technical users.
-- Bad, because Tess4J's JNA native library loading remains fragile.
-- Bad, because Docling and olmOCR download machine learning model weights (1–2 GB) on first use, which should be an explicit user opt-in and cannot happen silently.
+* Good, because OCRmyPDF handles the embedding the text layer automatically.
+* Good, because OCRmyPDF will allow users to use different engines through the plugins it offers.
+* Good, because OCRmyPDF's `--skip-text` flag handles partially searchable PDFs by skipping pages that already have a valid text layer.
+* Bad, because OCRmyPDF requires Python 3.x to be installed on the user's machine, which is an additional step for non-technical users.
+* Bad, because Tess4J's JNA native library loading remains fragile.
+* Bad, because Docling and olmOCR download machine learning model weights (1–2 GB) on first use, which should be an explicit user opt-in and cannot happen silently.
 
 ### Confirmation
 
@@ -71,14 +71,14 @@ Integration: Subprocess via `ProcessBuilder`
 
 OCRmyPDF is a Python command-line tool that takes a scanned PDF, OCRs each page using Tesseract internally, and outputs a new PDF with an invisible text layer. The output PDF is immediately readable by Lucene, requiring no further PDF production.
 
-- Good, because both OCR extraction and text layer embedding are handled in a single subprocess call, and no separate step is needed for embedding the text layer into the PDF.
-- Good, because it uses hOCR to position words producing accurately located invisible text, enabling correct copy-paste and PDF viewer search highlighting.
-- Good, because `--skip-text` correctly handles partially searchable PDFs without re-OCRing already-good pages.
-- Good, because it has [plugins](https://github.com/ocrmypdf/OCRmyPDF#plugins) that uses different engines from Tesseract like [OCRmyPDF-PaddleOCR](https://github.com/clefru/ocrmypdf-paddleocr) that replaces the standard Tesseract OCR engine with PaddleOCR.
-- Good, because MPL-2.0 is compatible with JabRef's MIT license for subprocess invocation with no source modification.
-- Good, because it is available via `pip`, `apt`, `brew`, and standalone installers on all three supported platforms.
-- Bad, because it requires Python 3.x and pip to be available on the user's machine.
-- Bad, because subprocess launch takes some time, which is acceptable for background tasks.
+* Good, because both OCR extraction and text layer embedding are handled in a single subprocess call, and no separate step is needed for embedding the text layer into the PDF.
+* Good, because it uses hOCR to position words producing accurately located invisible text, enabling correct copy-paste and PDF viewer search highlighting.
+* Good, because `--skip-text` correctly handles partially searchable PDFs without re-OCRing already-good pages.
+* Good, because it has [plugins](https://github.com/ocrmypdf/OCRmyPDF#plugins) that uses different engines from Tesseract like [OCRmyPDF-PaddleOCR](https://github.com/clefru/ocrmypdf-paddleocr) that replaces the standard Tesseract OCR engine with PaddleOCR.
+* Good, because MPL-2.0 is compatible with JabRef's MIT license for subprocess invocation with no source modification.
+* Good, because it is available via `pip`, `apt`, `brew`, and standalone installers on all three supported platforms.
+* Bad, because it requires Python 3.x and pip to be available on the user's machine.
+* Bad, because subprocess launch takes some time, which is acceptable for background tasks.
 
 ### Tesseract via Tess4J
 
@@ -90,12 +90,12 @@ Integration: Java API via JNA (Java Native Access)
 
 Tess4J is a Java wrapper for the Tesseract C++ OCR library. It calls `tesseract.doOCR(file)` directly from Java using JNA, returning extracted text as a `.txt` file. When used as the OCR engine, a separate step is required to embed the extracted text as an invisible layer. Correct multi-page embedding requires per-page Tesseract calls with hOCR output to obtain word coordinates instead of words distribution method as in [SearchablePdfCreator.java](https://github.com/JabRef/jabref/pull/13313/changes#diff-8cb8cef63fa6d8197687f74c560f9ab65a39a4fc566f273af98ef12dd578e25a).
 
-- Good, because it requires no Python installation pure Java with a native library dependency.
-- Good, because Apache 2.0 license is fully compatible with JabRef's MIT license.
-- Good, because Tesseract supports 100+ languages via downloadable `.traineddata` files.
-- Bad, because `module-info.java` requires explicit JNA module access declarations.
-- Bad, because correct multi-page text layer embedding requires per-page hOCR processing, adding significant implementation complexity compared to OCRmyPDF.
-- Bad, because `tessdata` path discovery differs across Windows, macOS, and Linux.
+* Good, because it requires no Python installation pure Java with a native library dependency.
+* Good, because Apache 2.0 license is fully compatible with JabRef's MIT license.
+* Good, because Tesseract supports 100+ languages via downloadable `.traineddata` files.
+* Bad, because `module-info.java` requires explicit JNA module access declarations.
+* Bad, because correct multi-page text layer embedding requires per-page hOCR processing, adding significant implementation complexity compared to OCRmyPDF.
+* Bad, because `tessdata` path discovery differs across Windows, macOS, and Linux.
 
 ### Apache Tika with Tesseract
 
@@ -106,12 +106,12 @@ Integration: Java API
 
 Apache Tika is a content extraction toolkit it can invoke Tesseract under the hood via its `TesseractOCRParser` when it encounters image-based content.
 
-- Good, because Apache 2.0 license is fully compatible.
-- Good, because Apache Tike is already used in JabRef.
-- Bad, because Tika's OCR output is raw extracted text without bounding box coordinates. A separate text layer embedding step is still required, with the same multi-page complexity as the direct Tess4J approach.
-- Bad, because Tika abstracts away fine-grained OCR settings, making expert user configuration harder than with direct Tess4J or OCRmyPDF.
-- Bad, because Tika internally still calls a system-installed Tesseract binary no installation advantage over direct Tess4J use.
-- Bad, because it is not extendable. There is no common OCR interface.
+* Good, because Apache 2.0 license is fully compatible.
+* Good, because Apache Tike is already used in JabRef.
+* Bad, because Tika's OCR output is raw extracted text without bounding box coordinates. A separate text layer embedding step is still required, with the same multi-page complexity as the direct Tess4J approach.
+* Bad, because Tika abstracts away fine-grained OCR settings, making expert user configuration harder than with direct Tess4J or OCRmyPDF.
+* Bad, because Tika internally still calls a system-installed Tesseract binary no installation advantage over direct Tess4J use.
+* Bad, because it is not extendable. There is no common OCR interface.
 
 ### Docling
 
@@ -121,11 +121,11 @@ Integration: Subprocess via `ProcessBuilder`
 
 Docling is a Python document intelligence library from IBM Research. It performs full document understanding: layout analysis, reading order detection, table structure recognition, and OCR via Tesseract or EasyOCR. It outputs clean Markdown or structured JSON.
 
-- Good, because it produces significantly better output quality for complex academic documents: correct multi-column reading order, table recognition, and formula identification.
-- Good, because MIT license is fully compatible.
-- Bad, because output is Markdown text, not a pre-built searchable PDF a text layer embedding step is still required.
-- Bad, because ML model weights (~1–2 GB) are downloaded on first use.
-- Bad, because it requires Python 3.x.
+* Good, because it produces significantly better output quality for complex academic documents: correct multi-column reading order, table recognition, and formula identification.
+* Good, because MIT license is fully compatible.
+* Bad, because output is Markdown text, not a pre-built searchable PDF a text layer embedding step is still required.
+* Bad, because ML model weights (~1–2 GB) are downloaded on first use.
+* Bad, because it requires Python 3.x.
 
 ### olmOCR
 
@@ -135,12 +135,12 @@ Integration: Subprocess via `ProcessBuilder`
 
 olmOCR is an OCR toolkit from the Allen Institute for AI (AI2), specifically trained and optimized for academic PDF documents using a vision-language model architecture.
 
-- Good, because it is specifically optimized for academic PDFs the primary document type JabRef users work with.
-- Good, because Apache 2.0 license is fully compatible.
-- Good, because subprocess integration pattern is identical to OCRmyPDF and Docling.
-- Bad, because GPU hardware is required for reasonable performance.
-- Bad, because model weights are downloaded on first use.
-- Bad, because it is newer and less tested than OCRmyPDF or Tesseract.
+* Good, because it is specifically optimized for academic PDFs the primary document type JabRef users work with.
+* Good, because Apache 2.0 license is fully compatible.
+* Good, because subprocess integration pattern is identical to OCRmyPDF and Docling.
+* Bad, because GPU hardware is required for reasonable performance.
+* Bad, because model weights are downloaded on first use.
+* Bad, because it is newer and less tested than OCRmyPDF or Tesseract.
 
 ### llama.cpp
 
@@ -151,22 +151,22 @@ Model file formats: GGUF
 
 Llama.cpp features LLM inference in C/C++, which includes Text, Audio and Vision (OCR) based language models, as well as embedding models.
 
-- Good, because MIT license is fully compatible.
-- Good, because the vast majority of model makers release models in Llama.cpp's GGUF format.
-- Good, because a great amount of inference backends are supported (CPU, CUDA, Vulkan, SYCL and others), which means compatibility with a wide range of hardware.
-- Good, because depending on hardware and backend, inference can be MUCH faster than pure CPU based inference.
-- Good, because detailed backend support status: [Table of supported operands](https://github.com/ggml-org/llama.cpp/blob/master/docs/ops.md).
-- Good, because model makers regularly release new models and llama.cpp now supports multiple OCR models.
-- Good, because users can swap models based on their needs.
-- Good, because the HTTP API integration pattern is reusable for other remote OCR engines.
-- Good, because text, audio, vision, embeddings and OCR inference is combined in a single framework.
-- Good, because it is one of the major frameworks. It has a large community; many stars on GitHub, hence fast development speed.
-- Bad, because the framework is a "can do it all" and not a dedicated OCR engine/framework.
-- Bad, because only a [limited number of OCR models](<https://github.com/ggml-org/llama.cpp/blob/master/docs/multimodal.md>) are supported at present.
-- Bad, because requires a separate framework for running a VLM.
-- Bad, because java bindings are not well supported.
-- Bad, because either the user is forced to separately install and run a llama.cpp server instance or JabRef developers have to maintain bindings to bundle it natively into JabRef.
-- Bad, because size of model weights can require users having to download several GB depending on model variant.
+* Good, because MIT license is fully compatible.
+* Good, because the vast majority of model makers release models in Llama.cpp's GGUF format.
+* Good, because a great amount of inference backends are supported (CPU, CUDA, Vulkan, SYCL and others), which means compatibility with a wide range of hardware.
+* Good, because depending on hardware and backend, inference can be MUCH faster than pure CPU based inference.
+* Good, because detailed backend support status: [Table of supported operands](https://github.com/ggml-org/llama.cpp/blob/master/docs/ops.md).
+* Good, because model makers regularly release new models and llama.cpp now supports multiple OCR models.
+* Good, because users can swap models based on their needs.
+* Good, because the HTTP API integration pattern is reusable for other remote OCR engines.
+* Good, because text, audio, vision, embeddings and OCR inference is combined in a single framework.
+* Good, because it is one of the major frameworks. It has a large community; many stars on GitHub, hence fast development speed.
+* Bad, because the framework is a "can do it all" and not a dedicated OCR engine/framework.
+* Bad, because only a [limited number of OCR models](<https://github.com/ggml-org/llama.cpp/blob/master/docs/multimodal.md>) are supported at present.
+* Bad, because requires a separate framework for running a VLM.
+* Bad, because java bindings are not well supported.
+* Bad, because either the user is forced to separately install and run a llama.cpp server instance or JabRef developers have to maintain bindings to bundle it natively into JabRef.
+* Bad, because size of model weights can require users having to download several GB depending on model variant.
 
 ### PaddleOCR-VL model via llama.cpp
 
@@ -178,11 +178,11 @@ Model file format: GGUF
 
 PaddleOCR-VL is a vision-language model achieving state-of-the-art accuracy on OCR benchmarks as of October 2025. llama.cpp PR 16701 adds support for running PaddleOCR-VL locally via llama.cpp's server, which exposes an HTTP API. For JabRef, integration is as a `RemoteOcrEngine` sending requests to a user-provisioned llama.cpp instance.
 
-- Good, because Apache 2.0 license is fully compatible.
-- Good, because users can simply download and run the model with a preconfigured fixed system prompt.
-- Bad, because llama.cpp PR 16701 is recent and less tested than OCRmyPDF or Tesseract.
-- Bad, because it has all the typical architectural drawbacks of Vision Language Models: confabulation and hallucination.
-- Bad, because there is no guarantee PaddleOCR will support successor models in llama.cpp
+* Good, because Apache 2.0 license is fully compatible.
+* Good, because users can simply download and run the model with a preconfigured fixed system prompt.
+* Bad, because llama.cpp PR 16701 is recent and less tested than OCRmyPDF or Tesseract.
+* Bad, because it has all the typical architectural drawbacks of Vision Language Models: confabulation and hallucination.
+* Bad, because there is no guarantee PaddleOCR will support successor models in llama.cpp
 
 ### PaddleOCR
 
@@ -194,14 +194,14 @@ Model file formats: PaddlePaddle static graph models, ONNX
 
 PaddleOCR turns any PDF or image document into structured data for your AI. A powerful, lightweight OCR toolkit that bridges the gap between images/PDFs and LLMs.
 
-- Good, because supports 100+ languages.
-- Good, because supports local offline option.
-- Good, because Java API bindings.
-- Good, because aspires to be a dedicated OCR framework.
-- Bad, because only supports a limited set of OCR vision language models
-- Bad, because to date, performance benchmarks for common hardware are unknown.
-- Bad, because the framework is relatively new. Maturity unknown.
-- Bad, because introduces another separate framework for running a VLM unnecessarily; At present, JabRef already has Langchain4j and DJL.
+* Good, because supports 100+ languages.
+* Good, because supports local offline option.
+* Good, because Java API bindings.
+* Good, because aspires to be a dedicated OCR framework.
+* Bad, because only supports a limited set of OCR vision language models
+* Bad, because to date, performance benchmarks for common hardware are unknown.
+* Bad, because the framework is relatively new. Maturity unknown.
+* Bad, because introduces another separate framework for running a VLM unnecessarily; At present, JabRef already has Langchain4j and DJL.
 
 ### TurboOCR
 
@@ -211,11 +211,11 @@ Integration: HTTP API
 
 TurboOCR is a C++/CUDA server wrapping PaddleOCR's PP-OCRv5 with TensorRT FP16 acceleration. It achieves 270 images/second on FUNSD benchmarks and exposes HTTP and gRPC APIs returning JSON with per-word bounding boxes. It represents the institutional/GPU-infrastructure tier of OCR integration.
 
-- Good, because MIT license is fully compatible.
-- Good, because JSON response includes bounding boxes for accurately positioned text layer embedding.
-- Good, because the HTTP adapter pattern it establishes covers TurboOCR, Google Cloud Vision, Azure Computer Vision, and any other HTTP-based OCR service a single `RemoteOcrEngine` implementation serves all.
-- Bad, because to date, it requires NVIDIA GPU hardware, thereby excluding a wide range of users, making it unsuitable as a default engine.
-- Bad, because to date, the project only supports a few select language family bundles (Latin, Chinese, Greek, Korean, Arabic, eslav, thai).
+* Good, because MIT license is fully compatible.
+* Good, because JSON response includes bounding boxes for accurately positioned text layer embedding.
+* Good, because the HTTP adapter pattern it establishes covers TurboOCR, Google Cloud Vision, Azure Computer Vision, and any other HTTP-based OCR service a single `RemoteOcrEngine` implementation serves all.
+* Bad, because to date, it requires NVIDIA GPU hardware, thereby excluding a wide range of users, making it unsuitable as a default engine.
+* Bad, because to date, the project only supports a few select language family bundles (Latin, Chinese, Greek, Korean, Arabic, eslav, thai).
 
 ### deepdoctection
 
@@ -225,10 +225,10 @@ Integration: Subprocess via `ProcessBuilder`- Good, because this setup is highly
 
 deepdoctection is a Python Document AI orchestration framework coordinating layout analysis (Detectron2/Transformers), OCR (Tesseract, DocTr, AWS Textract), table structure recognition, and token classification. It produces structured output capturing the full document hierarchy and is the most comprehensive document understanding pipeline among all evaluated options.
 
-- Good, because Apache 2.0 license is fully compatible.
-- Good, because it represents the state of the art in document understanding pipelines and serves as the reference architecture for what a comprehensive future JabRef OCR pipeline could look like.
-- Bad, because installation requires Detectron2, PyTorch, and multiple model weights.
-- Bad, because the installation complexity makes it impractical to document as a user-installable engine for most JabRef users.
+* Good, because Apache 2.0 license is fully compatible.
+* Good, because it represents the state of the art in document understanding pipelines and serves as the reference architecture for what a comprehensive future JabRef OCR pipeline could look like.
+* Bad, because installation requires Detectron2, PyTorch, and multiple model weights.
+* Bad, because the installation complexity makes it impractical to document as a user-installable engine for most JabRef users.
 
 ### SimpleHTR
 
@@ -238,11 +238,11 @@ Integration: Subprocess via `ProcessBuilder`
 
 SimpleHTR is a TensorFlow model trained specifically for handwritten text recognition on historical documents. It addresses the use case that all other evaluated engines handle poorly: handwriting in manuscripts, letters, and archival records.
 
-- Good, because MIT license is fully compatible.
-- Good, because it specifically addresses handwritten text recognition
-- Bad, because it requires TensorFlow, making it a large dependency for a narrow use case.
-- Bad, because it produces raw text output without bounding boxes, requiring simple page-level text embedding without word-level position accuracy.
-- Bad, because it is not generally applicable to scientific articles. It is relevant only for historians and archivists working with manuscripts and archival records.
+* Good, because MIT license is fully compatible.
+* Good, because it specifically addresses handwritten text recognition
+* Bad, because it requires TensorFlow, making it a large dependency for a narrow use case.
+* Bad, because it produces raw text output without bounding boxes, requiring simple page-level text embedding without word-level position accuracy.
+* Bad, because it is not generally applicable to scientific articles. It is relevant only for historians and archivists working with manuscripts and archival records.
 
 SimpleHTR is not selected for this project phase but is documented as a future optional engine for users working with handwritten historical documents.
 
@@ -253,8 +253,8 @@ License: [GPL-3.0](https://github.com/datalab-to/surya?tab=GPL-3.0-1-ov-file#rea
 
 Surya is a Python OCR engine with strong performance on non-Latin scripts and complex multi-column layouts.
 
-- Good, because it reportedly outperforms Tesseract on non-Latin scripts and complex document layouts.
-- Bad, because **GPL-3.0 license is incompatible with JabRef's policy**. Surya is excluded on license grounds.
+* Good, because it reportedly outperforms Tesseract on non-Latin scripts and complex document layouts.
+* Bad, because **GPL-3.0 license is incompatible with JabRef's policy**. Surya is excluded on license grounds.
 
 ### Kreuzberg
 
@@ -264,14 +264,14 @@ Integration: Java API
 
 Kreuzberg is a Rust-core document intelligence framework with Java bindings. It supports multiple OCR backends (Tesseract, PaddleOCR, EasyOCR) and 91+ file formats. A Java binding would eliminate the Python subprocess requirement entirely.
 
-- Good, because a native Java API binding avoids Python subprocess dependency entirely.
-- Good, because it supports multiple OCR backends through a single interface.
-- Bad, because **Elastic License 2.0 is not an OSI-approved open-source license**. ELv2 is incompatible with JabRef's MIT license and distribution model. Kreuzberg is excluded on license grounds.
+* Good, because a native Java API binding avoids Python subprocess dependency entirely.
+* Good, because it supports multiple OCR backends through a single interface.
+* Bad, because **Elastic License 2.0 is not an OSI-approved open-source license**. ELv2 is incompatible with JabRef's MIT license and distribution model. Kreuzberg is excluded on license grounds.
 
 ## More Links
 
-- Meta issue: [#13267](https://github.com/JabRef/jabref/issues/13267)
-- GSoC 2025 implementation PR (reference, not merged): [#13313](https://github.com/JabRef/jabref/pull/13313)
-- GSoC 2025 ADR PR (reference, not merged): [#13573](https://github.com/JabRef/jabref/pull/13573)
-- Scanned PDF test resource: [#15428](https://github.com/JabRef/jabref/pull/15428)
-- GSoC 2026 project description: <https://jabref.github.io/GSoC/posts/ocr/>
+* Meta issue: [#13267](https://github.com/JabRef/jabref/issues/13267)
+* GSoC 2025 implementation PR (reference, not merged): [#13313](https://github.com/JabRef/jabref/pull/13313)
+* GSoC 2025 ADR PR (reference, not merged): [#13573](https://github.com/JabRef/jabref/pull/13573)
+* Scanned PDF test resource: [#15428](https://github.com/JabRef/jabref/pull/15428)
+* GSoC 2026 project description: <https://jabref.github.io/GSoC/posts/ocr/>

--- a/docs/decisions/0064-use-citation-js-mapping.md
+++ b/docs/decisions/0064-use-citation-js-mapping.md
@@ -93,7 +93,7 @@ Zotero provides mappings from Zotero item type to BibTeX/BibLaTeX entry type. Ho
 * Good, because citation-js also supports other mappings, such as BibLaTeX to RIS.
 * Bad, because JabRef needs to track citation-js's updates, or import it as a submodule.
 
-### More information
+## More information
 
 * Implementation PR: [#15946](https://github.com/JabRef/jabref/pull/15946)
 * Implemented mapping can be found via [CSLItemTypeDefinitions.java](https://github.com/JabRef/jabref/blob/main/jablib/src/main/java/org/jabref/logic/openoffice/CSLItemTypeDefinitions.java)


### PR DESCRIPTION
### Related issues and pull requests

No associated issue — this adds ADR linting to CI on request.

### PR Description

Adds a `madr` job to the "Source Code Tests" workflow (`.github/workflows/tests-code.yml`) that lints the Architectural Decision Records under `docs/decisions/` with [madrlint](https://github.com/adr/madrlint) via JBang, and fixes the existing ADRs so the whole corpus passes. The linter always exits `0`, so the job counts emitted `::error` lines and fails when any violation is reported; `--output-format github-actions` surfaces the violations as inline annotations, and `-n11` skips external-link checks (JabRef verifies external links elsewhere). A new `.madrlintignore` excludes the non-ADR files `adr-template.md` and `index.md` from the directory naming rules.

The ADR fixes are: converting `-` list markers to `*` (MADR31, aligns with the repo's already-dominant `*` style); adding a missing Context heading, chosen-option/rationale statements, corrected heading levels and an emptied section (MADR01/02/03/04/06/07); shortening an over-long YAML front-matter title (MADR21); and fixing a broken local link in ADR-0042 that pointed to the renamed `0036` file (MADR12).

**Analogies.** Like honey, this change is a thin, sweet layer poured over the existing tests — it adds no new machinery, just coats the ADRs so they keep. Like chocolate, it has a hard structural shell (the directory rules: numbering, naming, no collisions) around a softer stylistic centre (list markers, headings). And like the moon, the linter mostly just reflects light already there — it shows the ADRs' shape without generating anything itself, and, exit-code-less, it needs the CI job to count its craters (`::error` lines) before anyone notices a dark side.

`jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

1. Open the workflow run for this PR and check the **MADR ADRs** job under "Source Code Tests" — it passes.
2. Locally, with [JBang](https://www.jbang.dev/) installed, from the repo root:
   `for f in docs/decisions/*.md docs/decisions; do jbang madrlint@adr/madrlint -n11 --quiet --output-format github-actions "$f"; done`
   No `::error` lines are emitted.
3. To see the guard work, temporarily change a `*` list marker to `-` in any ADR and re-run — the job reports the MADR31 violation and fails.

### AI usage

Claude Code (model claude-opus-4-8, 1M context).

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

This change touches only the CI workflow (`tests-code.yml`), a `.madrlintignore` file, and Markdown ADRs — no Java, no tests, no user-facing behavior. The Java, test, and Gradle-verification items are therefore marked not-applicable `[/]`; the Markdown lint check was run and passes.

# Code checklist

> [!IMPORTANT]
> **This is a mandatory final gate.** When the implementation is finished and before you open a PR, work through **every** box below and tick it. If a box cannot be ticked, fix the code first; mark a box `[/]` only if the point genuinely does not apply.
>
> `AGENTS.md` describes how to write code *while* developing — this file confirms the finished result. Do not skip the checklist and do not skip individual points.

## 1. Code self-review

Read your own diff once, top to bottom, and confirm each point.

### Nullability and control flow

- [/] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [/] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [/] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [/] No `catch (Exception e)` — only specific exceptions are caught.
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [/] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [/] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [/] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.

## 2. Verification commands

Run in this order — cheapest first. Each must pass.

- [/] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [/] `./gradlew modernizer`.
- [/] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [/] `./gradlew javadoc`.
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.

## 3. Documentation

- [/] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when no issue is known and the PR is not yet created — never a fake number.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [x] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder, it was replaced with the real PR-number link after PR creation, then committed and pushed.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required) — no runnable JabRef behavior changed; verified by running madrlint over all ADRs (0 violations) and markdownlint-cli2 (0 errors)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
