### PR TITLE
Add "Jump to field" button to entry editor toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added generic CSV export filter that exports all standard BibTeX fields. [#15711](https://github.com/JabRef/jabref/issues/15711)
 - We added OCR engine's executable path as the first OCR preference to let users specify the exact path of the engine they are using. [#15990](https://github.com/JabRef/jabref/pull/15990)
 - We added file notification to OCRed file to let users open the directory and show the new file. [#16082](https://github.com/JabRef/jabref/pull/16082)
+- We added a "Jump to field" button to the entry editor toolbar, triggering the same action as the <kbd>Ctrl</kbd>+<kbd>J</kbd> shortcut.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added generic CSV export filter that exports all standard BibTeX fields. [#15711](https://github.com/JabRef/jabref/issues/15711)
 - We added OCR engine's executable path as the first OCR preference to let users specify the exact path of the engine they are using. [#15990](https://github.com/JabRef/jabref/pull/15990)
 - We added file notification to OCRed file to let users open the directory and show the new file. [#16082](https://github.com/JabRef/jabref/pull/16082)
-- We added a "Jump to field" button to the entry editor toolbar, triggering the same action as the <kbd>Ctrl</kbd>+<kbd>J</kbd> shortcut. [TODO](TODO)
 - We added a "Jump to field" button to the entry editor toolbar, triggering the same action as the <kbd>Ctrl</kbd>+<kbd>J</kbd> shortcut. [#16169](https://github.com/JabRef/jabref/pull/16169)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added generic CSV export filter that exports all standard BibTeX fields. [#15711](https://github.com/JabRef/jabref/issues/15711)
 - We added OCR engine's executable path as the first OCR preference to let users specify the exact path of the engine they are using. [#15990](https://github.com/JabRef/jabref/pull/15990)
 - We added file notification to OCRed file to let users open the directory and show the new file. [#16082](https://github.com/JabRef/jabref/pull/16082)
-- We added a "Jump to field" button to the entry editor toolbar, triggering the same action as the <kbd>Ctrl</kbd>+<kbd>J</kbd> shortcut.
+- We added a "Jump to field" button to the entry editor toolbar, triggering the same action as the <kbd>Ctrl</kbd>+<kbd>J</kbd> shortcut. [TODO](TODO)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added generic CSV export filter that exports all standard BibTeX fields. [#15711](https://github.com/JabRef/jabref/issues/15711)
 - We added OCR engine's executable path as the first OCR preference to let users specify the exact path of the engine they are using. [#15990](https://github.com/JabRef/jabref/pull/15990)
 - We added file notification to OCRed file to let users open the directory and show the new file. [#16082](https://github.com/JabRef/jabref/pull/16082)
-- We added a "Jump to field" button to the entry editor toolbar, triggering the same action as the <kbd>Ctrl</kbd>+<kbd>J</kbd> shortcut.
+- We added a "Jump to field" button to the entry editor toolbar, triggering the same action as the <kbd>Ctrl</kbd>+<kbd>J</kbd> shortcut. [#16169](https://github.com/JabRef/jabref/pull/16169)
 
 ### Changed
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -252,11 +252,7 @@ public class EntryEditor extends BorderPane implements PreviewControls {
                         event.consume();
                     }
                     case JUMP_TO_FIELD -> {
-                        if (getCurrentlyEditedEntry() != null) {
-                            JumpToFieldDialog dialog = new JumpToFieldDialog(this);
-                            dialog.initModality(Modality.NONE);
-                            dialog.show();
-                        }
+                        openJumpToFieldDialog();
                         event.consume();
                     }
                     case HELP -> {
@@ -292,6 +288,19 @@ public class EntryEditor extends BorderPane implements PreviewControls {
     @FXML
     private void generateCiteKeyButton() {
         viewModel.generateCiteKey();
+    }
+
+    @FXML
+    private void jumpToFieldButton() {
+        openJumpToFieldDialog();
+    }
+
+    private void openJumpToFieldDialog() {
+        if (getCurrentlyEditedEntry() != null) {
+            JumpToFieldDialog dialog = new JumpToFieldDialog(this);
+            dialog.initModality(Modality.NONE);
+            dialog.show();
+        }
     }
 
     @FXML

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -37,6 +37,7 @@ import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.undo.CountingUndoManager;
 import org.jabref.gui.undo.RedoAction;
 import org.jabref.gui.undo.UndoAction;
+import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.DirectoryMonitor;
 import org.jabref.gui.util.DragDrop;
 import org.jabref.logic.ai.AiService;
@@ -74,6 +75,8 @@ public class EntryEditor extends BorderPane implements PreviewControls {
 
     private final EntryEditorViewModel viewModel;
     private final EntryEditorFocusUtils focusUtils;
+
+    private @Nullable JumpToFieldDialog jumpToFieldDialog;
 
     @FXML private TabPane tabbed;
 
@@ -296,11 +299,17 @@ public class EntryEditor extends BorderPane implements PreviewControls {
     }
 
     private void openJumpToFieldDialog() {
-        if (getCurrentlyEditedEntry() != null) {
-            JumpToFieldDialog dialog = new JumpToFieldDialog(this);
-            dialog.initModality(Modality.NONE);
-            dialog.show();
+        if (jumpToFieldDialog != null && jumpToFieldDialog.isShowing()) {
+            BaseDialog.bringToFront(jumpToFieldDialog);
+            return;
         }
+
+        Optional.ofNullable(getCurrentlyEditedEntry()).ifPresent(_ -> {
+            jumpToFieldDialog = new JumpToFieldDialog(this);
+            jumpToFieldDialog.initModality(Modality.NONE);
+            jumpToFieldDialog.setOnHidden(_ -> jumpToFieldDialog = null);
+            jumpToFieldDialog.show();
+        });
     }
 
     @FXML

--- a/jabgui/src/main/resources/org/jabref/gui/entryeditor/EntryEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/entryeditor/EntryEditor.fxml
@@ -42,6 +42,14 @@
                     <Tooltip text="%Change entry type"/>
                 </tooltip>
             </Button>
+            <Button styleClass="icon-button,narrow" onAction="#jumpToFieldButton">
+                <graphic>
+                    <JabRefIconView glyph="SEARCH"/>
+                </graphic>
+                <tooltip>
+                    <Tooltip text="%Jump to field"/>
+                </tooltip>
+            </Button>
             <Button styleClass="icon-button,narrow" onAction="#generateCiteKeyButton">
                 <graphic>
                     <JabRefIconView glyph="MAKE_KEY"/>


### PR DESCRIPTION
The Ctrl+J jump-to-field dialog previously had no visible entry point in the new entry editor sidebar. Add a magnifying-glass button that triggers the same dialog.

Kudos to @ThiloteE for wanting this.

### Related issues and pull requests
Closes https://github.com/JabRef/jabref/issues/16170
Follow-up to https://github.com/JabRef/jabref/pull/14120 and #16166

### PR Description

<img width="1326" height="1244" alt="grafik" src="https://github.com/user-attachments/assets/95d37e80-8429-4a1a-898e-1367dba1710c" />

### Steps to test

Click the icon

### AI usage

Claude did the job.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
