### PR TITLE
Add directory mapping preference for cross-machine linked files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- We added a "Directory mapping" preference (Preferences → Linked files) that lets JabRef substitute a mapped directory for a matching path prefix when a linked file's absolute path cannot be found, e.g. when a library is shared between machines whose file directories don't line up.
 - We added a new "Main" tab to the entry editor showing all fields of an entry in a single scrollable list, with one-click chips for adding optional fields and a free-form box for adding arbitrary fields. Identifiers, files and links, bibliometrics, comments, and meta fields (groups, owner, timestamps, special fields) live in collapsible sections — collapsed when empty — each offering chips for its unset fields. [#12711](https://github.com/JabRef/jabref/issues/12711)
 - We added auto-detection import for drag-and-dropped library files. [#15391](https://github.com/JabRef/jabref/issues/15391)
 - We added a preview style selection bar which shows the current preview style and allows to select a specific style without cycling through all of them. [#15820](https://github.com/JabRef/jabref/pull/15820)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- We added a "Directory mapping" preference (Preferences → Linked files) that lets JabRef substitute a mapped directory for a matching path prefix when a linked file's absolute path cannot be found, e.g. when a library is shared between machines whose file directories don't line up.
+- We added a "Directory mapping" preference (Preferences → Linked files) that lets JabRef substitute a mapped directory for a matching path prefix when a linked file's absolute path cannot be found, e.g. when a library is shared between machines whose file directories don't line up. [#16173](https://github.com/JabRef/jabref/pull/16173)
 - We added a new "Main" tab to the entry editor showing all fields of an entry in a single scrollable list, with one-click chips for adding optional fields and a free-form box for adding arbitrary fields. Identifiers, files and links, bibliometrics, comments, and meta fields (groups, owner, timestamps, special fields) live in collapsible sections — collapsed when empty — each offering chips for its unset fields. [#12711](https://github.com/JabRef/jabref/issues/12711)
 - We added auto-detection import for drag-and-dropped library files. [#15391](https://github.com/JabRef/jabref/issues/15391)
 - We added a preview style selection bar which shows the current preview style and allows to select a specific style without cycling through all of them. [#15820](https://github.com/JabRef/jabref/pull/15820)

--- a/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/DirectoryMappingItem.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/DirectoryMappingItem.java
@@ -3,6 +3,9 @@ package org.jabref.gui.preferences.linkedfiles;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
 public class DirectoryMappingItem {
     private final StringProperty directory;
     private final StringProperty mappedDirectory;

--- a/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/DirectoryMappingItem.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/DirectoryMappingItem.java
@@ -1,0 +1,30 @@
+package org.jabref.gui.preferences.linkedfiles;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+
+public class DirectoryMappingItem {
+    private final StringProperty directory;
+    private final StringProperty mappedDirectory;
+
+    public DirectoryMappingItem(String directory, String mappedDirectory) {
+        this.directory = new SimpleStringProperty(directory);
+        this.mappedDirectory = new SimpleStringProperty(mappedDirectory);
+    }
+
+    public StringProperty directoryProperty() {
+        return directory;
+    }
+
+    public StringProperty mappedDirectoryProperty() {
+        return mappedDirectory;
+    }
+
+    public String getDirectory() {
+        return directory.get();
+    }
+
+    public String getMappedDirectory() {
+        return mappedDirectory.get();
+    }
+}

--- a/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.java
@@ -1,6 +1,8 @@
 package org.jabref.gui.preferences.linkedfiles;
 
 import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.DoubleBinding;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
@@ -29,6 +31,18 @@ import com.tobiasdiez.easybind.EasyBind;
 import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
 
 public class LinkedFilesTab extends AbstractPreferenceTabView<LinkedFilesTabViewModel> implements PreferencesTab {
+
+    // Multiplier for row height based on font size
+    private static final double FONT_HEIGHT_MULTIPLIER = 2.5;
+
+    // Default row height if font is not available
+    private static final double DEFAULT_ROW_HEIGHT = 30.0;
+
+    // Estimate for header height (used in table prefHeight calculation)
+    private static final double HEADER_HEIGHT_ESTIMATE = 1.1;
+
+    // Minimum number of (empty) rows to reserve, so an empty table doesn't collapse to just the header
+    private static final int MIN_ROW_COUNT = 1;
 
     @FXML private TextField mainFileDirectory;
     @FXML private RadioButton useMainFileDirectory;
@@ -124,6 +138,16 @@ public class LinkedFilesTab extends AbstractPreferenceTabView<LinkedFilesTabView
                 .withGraphic(none -> IconTheme.JabRefIcons.DELETE_ENTRY.getGraphicNode())
                 .withOnMouseClickedEvent((item, none) -> event -> viewModel.removeDirectoryMapping(item))
                 .install(directoryMappingDeleteColumn);
+
+        // Dynamic height based on font size and number of items, so the table doesn't reserve empty striped rows
+        DoubleBinding rowHeight = Bindings.createDoubleBinding(
+                () -> fulltextIndex.getFont() != null ? fulltextIndex.getFont().getSize() * FONT_HEIGHT_MULTIPLIER : DEFAULT_ROW_HEIGHT,
+                fulltextIndex.fontProperty());
+        directoryMappingTable.fixedCellSizeProperty().bind(rowHeight);
+        directoryMappingTable.prefHeightProperty().bind(
+                Bindings.max(Bindings.size(directoryMappingTable.getItems()), MIN_ROW_COUNT)
+                        .add(HEADER_HEIGHT_ESTIMATE)
+                        .multiply(rowHeight));
     }
 
     public void mainFileDirBrowse() {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.java
@@ -6,15 +6,21 @@ import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.RadioButton;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
+import javafx.scene.control.cell.TextFieldTableCell;
 
 import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.desktop.os.NativeDesktop;
 import org.jabref.gui.help.HelpAction;
+import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.preferences.AbstractPreferenceTabView;
 import org.jabref.gui.preferences.PreferencesTab;
+import org.jabref.gui.util.BindingsHelper;
 import org.jabref.gui.util.IconValidationDecorator;
+import org.jabref.gui.util.ValueTableCellFactory;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.l10n.Localization;
 
@@ -46,6 +52,11 @@ public class LinkedFilesTab extends AbstractPreferenceTabView<LinkedFilesTabView
     @FXML private CheckBox adjustLinkedFilesOnTransfer;
     @FXML private CheckBox copyLinkedFilesOnTransfer;
     @FXML private CheckBox moveLinkedFilesOnTransfer;
+
+    @FXML private TableView<DirectoryMappingItem> directoryMappingTable;
+    @FXML private TableColumn<DirectoryMappingItem, String> directoryMappingDirectoryColumn;
+    @FXML private TableColumn<DirectoryMappingItem, String> directoryMappingMappedDirectoryColumn;
+    @FXML private TableColumn<DirectoryMappingItem, Boolean> directoryMappingDeleteColumn;
 
     private final ControlsFxVisualizer validationVisualizer = new ControlsFxVisualizer();
 
@@ -99,9 +110,28 @@ public class LinkedFilesTab extends AbstractPreferenceTabView<LinkedFilesTabView
 
         validationVisualizer.setDecoration(new IconValidationDecorator());
         Platform.runLater(() -> validationVisualizer.initVisualization(viewModel.mainFileDirValidationStatus(), mainFileDirectory));
+
+        directoryMappingTable.setItems(viewModel.getDirectoryMappings());
+
+        directoryMappingDirectoryColumn.setCellValueFactory(data -> data.getValue().directoryProperty());
+        directoryMappingDirectoryColumn.setCellFactory(TextFieldTableCell.forTableColumn());
+
+        directoryMappingMappedDirectoryColumn.setCellValueFactory(data -> data.getValue().mappedDirectoryProperty());
+        directoryMappingMappedDirectoryColumn.setCellFactory(TextFieldTableCell.forTableColumn());
+
+        directoryMappingDeleteColumn.setCellValueFactory(data -> BindingsHelper.constantOf(true));
+        new ValueTableCellFactory<DirectoryMappingItem, Boolean>()
+                .withGraphic(none -> IconTheme.JabRefIcons.DELETE_ENTRY.getGraphicNode())
+                .withOnMouseClickedEvent((item, none) -> event -> viewModel.removeDirectoryMapping(item))
+                .install(directoryMappingDeleteColumn);
     }
 
     public void mainFileDirBrowse() {
         viewModel.mainFileDirBrowse();
+    }
+
+    @FXML
+    private void addDirectoryMapping() {
+        viewModel.addDirectoryMapping();
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
@@ -11,6 +11,7 @@ import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.preferences.PreferenceTabViewModel;
@@ -19,6 +20,8 @@ import org.jabref.logic.FilePreferences;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.util.io.AutoLinkPreferences;
+import org.jabref.logic.util.io.DirectoryMapping;
+import org.jabref.logic.util.strings.StringUtil;
 
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
@@ -49,6 +52,8 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
 
     private final BooleanProperty openFileExplorerInFilesDirectory = new SimpleBooleanProperty();
     private final BooleanProperty openFileExplorerInLastDirectory = new SimpleBooleanProperty();
+
+    private final ObservableList<DirectoryMappingItem> directoryMappings = FXCollections.observableArrayList();
 
     private final Validator mainFileDirValidator;
 
@@ -99,6 +104,10 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
         copyLinkedFilesOnTransferProperty.setValue(filePreferences.shouldCopyLinkedFilesOnTransfer());
         moveFilesOnTransferProperty.setValue(filePreferences.shouldMoveLinkedFilesOnTransfer());
 
+        directoryMappings.setAll(filePreferences.getDirectoryMappings().stream()
+                                                 .map(mapping -> new DirectoryMappingItem(mapping.directory(), mapping.mappedDirectory()))
+                                                 .toList());
+
         // Autolink preferences
         switch (autoLinkPreferences.getCitationKeyDependency()) {
             case START ->
@@ -143,6 +152,11 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
         filePreferences.setAdjustFileLinksOnTransfer(adjustLinkedFilesOnTransferProperty.getValue());
         filePreferences.setCopyLinkedFilesOnTransfer(copyLinkedFilesOnTransferProperty.getValue());
         filePreferences.setMoveLinkedFilesOnTransfer(moveFilesOnTransferProperty.getValue());
+
+        filePreferences.setDirectoryMappings(directoryMappings.stream()
+                                                               .filter(item -> StringUtil.isNotBlank(item.getDirectory()) && StringUtil.isNotBlank(item.getMappedDirectory()))
+                                                               .map(item -> new DirectoryMapping(item.getDirectory(), item.getMappedDirectory()))
+                                                               .toList());
     }
 
     ValidationStatus mainFileDirValidationStatus() {
@@ -242,6 +256,18 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
 
     public BooleanProperty openFileExplorerInLastDirectoryProperty() {
         return openFileExplorerInLastDirectory;
+    }
+
+    public ObservableList<DirectoryMappingItem> getDirectoryMappings() {
+        return directoryMappings;
+    }
+
+    public void addDirectoryMapping() {
+        directoryMappings.add(new DirectoryMappingItem("", ""));
+    }
+
+    public void removeDirectoryMapping(DirectoryMappingItem item) {
+        directoryMappings.remove(item);
     }
 }
 

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.fxml
@@ -95,7 +95,7 @@
 
     <Label styleClass="sectionHeader" text="%Directory mapping"/>
     <Label text="%When a linked file's absolute path cannot be found, try substituting a mapped directory for a matching prefix." wrapText="true"/>
-    <TableView fx:id="directoryMappingTable" editable="true" VBox.vgrow="ALWAYS">
+    <TableView fx:id="directoryMappingTable" editable="true">
         <columns>
             <TableColumn fx:id="directoryMappingDirectoryColumn" text="%Directory" editable="true"/>
             <TableColumn fx:id="directoryMappingMappedDirectoryColumn" text="%Mapped directory" editable="true"/>

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.fxml
@@ -5,6 +5,8 @@
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.RadioButton?>
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.control.Tooltip?>
@@ -90,4 +92,24 @@
     <CheckBox fx:id="adjustLinkedFilesOnTransfer" text="%Update linked file paths during entry transfer if the files are accessible"/>
     <CheckBox fx:id="copyLinkedFilesOnTransfer" text="%Copy linked files on entry transfer when they would otherwise be inaccessible"/>
     <CheckBox fx:id="moveLinkedFilesOnTransfer" text="%Move linked files on entry transfer when they would otherwise be inaccessible"/>
+
+    <Label styleClass="sectionHeader" text="%Directory mapping"/>
+    <Label text="%When a linked file's absolute path cannot be found, try substituting a mapped directory for a matching prefix." wrapText="true"/>
+    <TableView fx:id="directoryMappingTable" editable="true" VBox.vgrow="ALWAYS">
+        <columns>
+            <TableColumn fx:id="directoryMappingDirectoryColumn" text="%Directory" editable="true"/>
+            <TableColumn fx:id="directoryMappingMappedDirectoryColumn" text="%Mapped directory" editable="true"/>
+            <TableColumn fx:id="directoryMappingDeleteColumn" minWidth="40.0" maxWidth="40.0"/>
+        </columns>
+        <columnResizePolicy>
+            <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
+        </columnResizePolicy>
+    </TableView>
+    <HBox alignment="BASELINE_RIGHT" spacing="10.0">
+        <Button text="%Add mapping" onAction="#addDirectoryMapping">
+            <graphic>
+                <JabRefIconView glyph="ADD_NOBOX"/>
+            </graphic>
+        </Button>
+    </HBox>
 </fx:root>

--- a/jabgui/src/test/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModelTest.java
@@ -1,0 +1,83 @@
+package org.jabref.gui.preferences.linkedfiles;
+
+import java.util.List;
+
+import org.jabref.gui.DialogService;
+import org.jabref.logic.FilePreferences;
+import org.jabref.logic.preferences.CliPreferences;
+import org.jabref.logic.util.io.AutoLinkPreferences;
+import org.jabref.logic.util.io.DirectoryMapping;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LinkedFilesTabViewModelTest {
+
+    private FilePreferences filePreferences;
+    private LinkedFilesTabViewModel viewModel;
+
+    @BeforeEach
+    void setUp() {
+        filePreferences = FilePreferences.getDefault();
+
+        AutoLinkPreferences autoLinkPreferences = mock(AutoLinkPreferences.class);
+        when(autoLinkPreferences.getCitationKeyDependency()).thenReturn(AutoLinkPreferences.CitationKeyDependency.START);
+        when(autoLinkPreferences.getRegularExpression()).thenReturn("");
+
+        CliPreferences preferences = mock(CliPreferences.class);
+        when(preferences.getFilePreferences()).thenReturn(filePreferences);
+        when(preferences.getAutoLinkPreferences()).thenReturn(autoLinkPreferences);
+
+        DialogService dialogService = mock(DialogService.class);
+
+        viewModel = new LinkedFilesTabViewModel(dialogService, preferences);
+    }
+
+    @Test
+    void setValuesPopulatesDirectoryMappingsFromPreferences() {
+        filePreferences.setDirectoryMappings(List.of(new DirectoryMapping("/old", "/new")));
+
+        viewModel.setValues();
+
+        assertEquals(1, viewModel.getDirectoryMappings().size());
+        assertEquals("/old", viewModel.getDirectoryMappings().getFirst().getDirectory());
+        assertEquals("/new", viewModel.getDirectoryMappings().getFirst().getMappedDirectory());
+    }
+
+    @Test
+    void addDirectoryMappingAddsEmptyRow() {
+        viewModel.setValues();
+
+        viewModel.addDirectoryMapping();
+
+        assertEquals(1, viewModel.getDirectoryMappings().size());
+    }
+
+    @Test
+    void removeDirectoryMappingRemovesRow() {
+        viewModel.setValues();
+        viewModel.addDirectoryMapping();
+        DirectoryMappingItem item = viewModel.getDirectoryMappings().getFirst();
+
+        viewModel.removeDirectoryMapping(item);
+
+        assertEquals(0, viewModel.getDirectoryMappings().size());
+    }
+
+    @Test
+    void storeSettingsRoundTripsNonBlankMappingsAndSkipsBlankRows() {
+        viewModel.setValues();
+        viewModel.addDirectoryMapping();
+        viewModel.getDirectoryMappings().getFirst().directoryProperty().set("/old");
+        viewModel.getDirectoryMappings().getFirst().mappedDirectoryProperty().set("/new");
+        viewModel.addDirectoryMapping(); // blank row, should be skipped on store
+
+        viewModel.storeSettings();
+
+        assertEquals(List.of(new DirectoryMapping("/old", "/new")), filePreferences.getDirectoryMappings());
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/FilePreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/FilePreferences.java
@@ -1,18 +1,23 @@
 package org.jabref.logic;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ListProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
 
 import org.jabref.logic.os.OS;
 import org.jabref.logic.util.Directories;
+import org.jabref.logic.util.io.DirectoryMapping;
 import org.jabref.model.metadata.UserHostInfo;
 
 import org.jspecify.annotations.NullMarked;
@@ -47,6 +52,8 @@ public class FilePreferences {
     private final BooleanProperty openFileExplorerInFileDirectory = new SimpleBooleanProperty();
     private final BooleanProperty openFileExplorerInLastUsedDirectory = new SimpleBooleanProperty();
 
+    private final ListProperty<DirectoryMapping> directoryMappings = new SimpleListProperty<>(FXCollections.observableArrayList());
+
     private FilePreferences() {
         this(
                 new SimpleObjectProperty<>(OS.getUserHostInfo()), // userAndHost (needs to be sourced from InternalPreferences)
@@ -68,7 +75,8 @@ public class FilePreferences {
                 true,                                // shouldKeepDownloadUrl
                 Path.of("/"),                        // lastUsedDirectory
                 true,                                // openFileExplorerInFileDirectory
-                false                                // openFileExplorerInLastUsedDirectory
+                false,                               // openFileExplorerInLastUsedDirectory
+                List.of()                            // directoryMappings
         );
     }
 
@@ -91,7 +99,8 @@ public class FilePreferences {
                            boolean shouldKeepDownloadUrl,
                            Path lastUsedDirectory,
                            boolean openFileExplorerInFileDirectory,
-                           boolean openFileExplorerInLastUsedDirectory) {
+                           boolean openFileExplorerInLastUsedDirectory,
+                           List<DirectoryMapping> directoryMappings) {
         this.userAndHost.bind(userAndHost);
         this.mainFileDirectory.setValue(mainFileDirectory);
         this.storeFilesRelativeToBibFile.setValue(storeFilesRelativeToBibFile);
@@ -112,6 +121,7 @@ public class FilePreferences {
         this.lastUsedDirectory.setValue(lastUsedDirectory);
         this.openFileExplorerInFileDirectory.set(openFileExplorerInFileDirectory);
         this.openFileExplorerInLastUsedDirectory.set(openFileExplorerInLastUsedDirectory);
+        this.directoryMappings.setAll(directoryMappings);
     }
 
     public static FilePreferences getDefault() {
@@ -348,5 +358,17 @@ public class FilePreferences {
 
     public void setOpenFileExplorerInLastUsedDirectory(boolean value) {
         this.openFileExplorerInLastUsedDirectory.set(value);
+    }
+
+    public List<DirectoryMapping> getDirectoryMappings() {
+        return directoryMappings.get();
+    }
+
+    public ListProperty<DirectoryMapping> directoryMappingsProperty() {
+        return directoryMappings;
+    }
+
+    public void setDirectoryMappings(List<DirectoryMapping> directoryMappings) {
+        this.directoryMappings.setAll(directoryMappings);
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -93,6 +93,7 @@ import org.jabref.logic.shared.prefs.SharedDatabasePreferences;
 import org.jabref.logic.shared.security.Password;
 import org.jabref.logic.util.Version;
 import org.jabref.logic.util.io.AutoLinkPreferences;
+import org.jabref.logic.util.io.DirectoryMapping;
 import org.jabref.logic.util.io.FileHistory;
 import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.logic.xmp.XmpPreferences;
@@ -310,6 +311,7 @@ public class JabRefCliPreferences implements CliPreferences {
     private static final String FILES_LAST_USED_DIRECTORY = "lastUsedDirectory";
     private static final String FILES_OPEN_FILE_EXPLORER_IN_FILE_DIRECTORY = "openFileExplorerInFileDirectory";
     private static final String FILES_OPEN_FILE_EXPLORER_IN_LAST_USED_DIRECTORY = "openFileExplorerInLastUsedDirectory";
+    private static final String FILES_DIRECTORY_MAPPING = "directoryMapping";
     // endregion
 
     // region last files opened
@@ -546,6 +548,64 @@ public class JabRefCliPreferences implements CliPreferences {
         }
 
         return Splitter.on(STRINGLIST_DELIMITER).splitToList(toConvert);
+    }
+
+    /// Directory paths may contain the plain [#STRINGLIST_DELIMITER] character or backslashes (Windows' path
+    /// separator), which collide with [#convertListToString]/[#convertStringToList]'s quoting (backslash is the
+    /// quote character there, but [#convertStringToList] never unquotes). So directory mappings get their own
+    /// properly reversible backslash-escaping instead.
+    @VisibleForTesting
+    static String convertDirectoryMappingsToString(List<DirectoryMapping> mappings) {
+        StringBuilder result = new StringBuilder();
+        for (DirectoryMapping mapping : mappings) {
+            if (!result.isEmpty()) {
+                result.append(STRINGLIST_DELIMITER);
+            }
+            result.append(escapeDirectoryMappingComponent(mapping.directory()))
+                  .append(STRINGLIST_DELIMITER)
+                  .append(escapeDirectoryMappingComponent(mapping.mappedDirectory()));
+        }
+        return result.toString();
+    }
+
+    @VisibleForTesting
+    static List<DirectoryMapping> convertStringToDirectoryMappings(String toConvert) {
+        List<String> flattened = splitEscapedDirectoryMappingComponents(toConvert);
+        List<DirectoryMapping> mappings = new ArrayList<>();
+        for (int i = 0; i + 1 < flattened.size(); i += 2) {
+            mappings.add(new DirectoryMapping(flattened.get(i), flattened.get(i + 1)));
+        }
+        return mappings;
+    }
+
+    private static String escapeDirectoryMappingComponent(String value) {
+        return value.replace("\\", "\\\\").replace(STRINGLIST_DELIMITER.toString(), "\\" + STRINGLIST_DELIMITER);
+    }
+
+    private static List<String> splitEscapedDirectoryMappingComponents(String value) {
+        if (StringUtil.isBlank(value)) {
+            return new ArrayList<>();
+        }
+
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean escaped = false;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (escaped) {
+                current.append(c);
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == STRINGLIST_DELIMITER) {
+                result.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+        result.add(current.toString());
+        return result;
     }
     // endregion
 
@@ -1738,7 +1798,8 @@ public class JabRefCliPreferences implements CliPreferences {
                 getBoolean(FILES_KEEP_DOWNLOAD_URL, defaultValues.shouldKeepDownloadUrl()),
                 getPath(FILES_LAST_USED_DIRECTORY, defaultValues.getLastUsedDirectory()),
                 getBoolean(FILES_OPEN_FILE_EXPLORER_IN_FILE_DIRECTORY, defaultValues.shouldOpenFileExplorerInFileDirectory()),
-                getBoolean(FILES_OPEN_FILE_EXPLORER_IN_LAST_USED_DIRECTORY, defaultValues.shouldOpenFileExplorerInLastUsedDirectory()));
+                getBoolean(FILES_OPEN_FILE_EXPLORER_IN_LAST_USED_DIRECTORY, defaultValues.shouldOpenFileExplorerInLastUsedDirectory()),
+                convertStringToDirectoryMappings(get(FILES_DIRECTORY_MAPPING, convertDirectoryMappingsToString(defaultValues.getDirectoryMappings()))));
 
         // mainFileDirectory defaults to getDefaultPath(), which the GUI overrides to a meaningful location.
         bindPath(filePreferences.mainFileDirectoryProperty(), FILES_MAIN_DIRECTORY, getDefaultPath());
@@ -1762,6 +1823,8 @@ public class JabRefCliPreferences implements CliPreferences {
         bindPath(filePreferences.lastUsedDirectoryProperty(), FILES_LAST_USED_DIRECTORY, getDefaultPath());
         bindBoolean(filePreferences.openFileExplorerInFileDirectoryProperty(), FILES_OPEN_FILE_EXPLORER_IN_FILE_DIRECTORY, defaultValues.shouldOpenFileExplorerInFileDirectory());
         bindBoolean(filePreferences.openFileExplorerInLastUsedDirectoryProperty(), FILES_OPEN_FILE_EXPLORER_IN_LAST_USED_DIRECTORY, defaultValues.shouldOpenFileExplorerInLastUsedDirectory());
+        bindCustomList(filePreferences.directoryMappingsProperty(), FILES_DIRECTORY_MAPPING, defaultValues.getDirectoryMappings(),
+                JabRefCliPreferences::convertDirectoryMappingsToString, JabRefCliPreferences::convertStringToDirectoryMappings);
 
         return filePreferences;
     }

--- a/jablib/src/main/java/org/jabref/logic/util/io/DirectoryMapping.java
+++ b/jablib/src/main/java/org/jabref/logic/util/io/DirectoryMapping.java
@@ -1,0 +1,9 @@
+package org.jabref.logic.util.io;
+
+/// A user-configured string-prefix substitution used to resolve absolute linked-file paths that were stored on a
+/// different machine (e.g. a different OS, or a differently mounted network share).
+///
+/// @param directory        the stored path prefix to match (plain string, no regex)
+/// @param mappedDirectory  the replacement prefix to try on this machine
+public record DirectoryMapping(String directory, String mappedDirectory) {
+}

--- a/jablib/src/main/java/org/jabref/logic/util/io/DirectoryMapping.java
+++ b/jablib/src/main/java/org/jabref/logic/util/io/DirectoryMapping.java
@@ -1,9 +1,12 @@
 package org.jabref.logic.util.io;
 
+import org.jspecify.annotations.NullMarked;
+
 /// A user-configured string-prefix substitution used to resolve absolute linked-file paths that were stored on a
 /// different machine (e.g. a different OS, or a differently mounted network share).
 ///
 /// @param directory        the stored path prefix to match (plain string, no regex)
 /// @param mappedDirectory  the replacement prefix to try on this machine
+@NullMarked
 public record DirectoryMapping(String directory, String mappedDirectory) {
 }

--- a/jablib/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/jablib/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -447,18 +447,22 @@ public class FileUtil {
     public static Optional<Path> find(@NonNull BibDatabaseContext databaseContext,
                                       @NonNull String fileName,
                                       @NonNull FilePreferences filePreferences) {
-        Optional<Path> found = find(fileName, databaseContext.getFileDirectories(filePreferences));
-        if (found.isPresent()) {
-            return found;
-        }
-        try {
-            if (!Path.of(fileName).isAbsolute()) {
-                return Optional.empty();
-            }
-        } catch (InvalidPathException ex) {
-            return Optional.empty();
-        }
-        return applyDirectoryMappings(fileName, filePreferences.getDirectoryMappings());
+        return find(fileName, databaseContext.getFileDirectories(filePreferences))
+                .or(() -> isAbsoluteLike(fileName)
+                        ? applyDirectoryMappings(fileName, filePreferences.getDirectoryMappings())
+                        : Optional.empty());
+    }
+
+    private static final Pattern WINDOWS_DRIVE_ABSOLUTE_PATTERN = Pattern.compile("^[A-Za-z]:/.*");
+
+    /// Checks whether `path` looks like an absolute path on some OS (POSIX, Windows drive letter, or UNC-like),
+    /// without relying on [Path#isAbsolute], which is OS-dependent and would reject e.g. a Windows `C:/...` path
+    /// when running on Linux/macOS.
+    ///
+    /// @param path the (possibly foreign-OS) path string to check, as stored (backslashes are normalized first)
+    public static boolean isAbsoluteLike(String path) {
+        String normalized = path.replace('\\', '/');
+        return normalized.startsWith("/") || WINDOWS_DRIVE_ABSOLUTE_PATTERN.matcher(normalized).matches();
     }
 
     /// Tries to resolve an absolute path that does not exist as stored (e.g. because the `.bib` file was written on a
@@ -474,15 +478,26 @@ public class FileUtil {
     public static Optional<Path> applyDirectoryMappings(String absoluteLink, List<DirectoryMapping> mappings) {
         String normalizedLink = absoluteLink.replace('\\', '/');
         for (DirectoryMapping mapping : mappings) {
-            String normalizedDirectory = mapping.directory().replace('\\', '/');
+            String normalizedDirectory = withTrailingSlash(mapping.directory().replace('\\', '/'));
             if (normalizedLink.startsWith(normalizedDirectory)) {
-                Path candidate = Path.of(mapping.mappedDirectory() + normalizedLink.substring(normalizedDirectory.length()));
-                if (Files.exists(candidate)) {
-                    return Optional.of(candidate);
+                String rest = normalizedLink.substring(normalizedDirectory.length());
+                try {
+                    Path candidate = Path.of(mapping.mappedDirectory()).resolve(rest);
+                    if (Files.exists(candidate)) {
+                        return Optional.of(candidate);
+                    }
+                } catch (InvalidPathException ex) {
+                    LOGGER.debug("Skipping directory mapping {} -> {}: not a valid path on this OS", mapping.directory(), mapping.mappedDirectory(), ex);
                 }
             }
         }
         return Optional.empty();
+    }
+
+    /// Ensures `directory` ends with a `/`, so prefix matching in [#applyDirectoryMappings] only matches whole
+    /// path segments (e.g. `/foo/` does not match `/foobar/baz`).
+    private static String withTrailingSlash(String directory) {
+        return directory.endsWith("/") ? directory : directory + "/";
     }
 
     /// Converts a relative filename to an absolute one, if necessary. Returns
@@ -494,7 +509,7 @@ public class FileUtil {
         if (directories.isEmpty()) {
             // Fallback, if no directories to resolve are passed
             Path path = Path.of(fileName);
-            if (path.isAbsolute()) {
+            if (path.isAbsolute() && Files.exists(path)) {
                 return Optional.of(path);
             } else {
                 return Optional.empty();

--- a/jablib/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/jablib/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -447,7 +447,42 @@ public class FileUtil {
     public static Optional<Path> find(@NonNull BibDatabaseContext databaseContext,
                                       @NonNull String fileName,
                                       @NonNull FilePreferences filePreferences) {
-        return find(fileName, databaseContext.getFileDirectories(filePreferences));
+        Optional<Path> found = find(fileName, databaseContext.getFileDirectories(filePreferences));
+        if (found.isPresent()) {
+            return found;
+        }
+        try {
+            if (!Path.of(fileName).isAbsolute()) {
+                return Optional.empty();
+            }
+        } catch (InvalidPathException ex) {
+            return Optional.empty();
+        }
+        return applyDirectoryMappings(fileName, filePreferences.getDirectoryMappings());
+    }
+
+    /// Tries to resolve an absolute path that does not exist as stored (e.g. because the `.bib` file was written on a
+    /// different machine) by substituting a configured directory prefix with its mapped counterpart.
+    ///
+    /// Matching is a plain string-prefix comparison on `absoluteLink` (not `Path`-aware), so a path string from a
+    /// foreign OS never has to be parsed by the current platform's filesystem. Backslashes are normalized to forward
+    /// slashes before comparing (mirroring how [LinkedFile] itself normalizes stored links), so a mapping's
+    /// `directory` may be entered using either separator style.
+    ///
+    /// @param absoluteLink the stored (absolute) link, as-is
+    /// @param mappings     the configured mappings, tried in order; the first substitution that exists on disk wins
+    public static Optional<Path> applyDirectoryMappings(String absoluteLink, List<DirectoryMapping> mappings) {
+        String normalizedLink = absoluteLink.replace('\\', '/');
+        for (DirectoryMapping mapping : mappings) {
+            String normalizedDirectory = mapping.directory().replace('\\', '/');
+            if (normalizedLink.startsWith(normalizedDirectory)) {
+                Path candidate = Path.of(mapping.mappedDirectory() + normalizedLink.substring(normalizedDirectory.length()));
+                if (Files.exists(candidate)) {
+                    return Optional.of(candidate);
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     /// Converts a relative filename to an absolute one, if necessary. Returns

--- a/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -243,19 +243,10 @@ public class LinkedFile implements Serializable {
 
     public Optional<Path> findIn(BibDatabaseContext databaseContext, FilePreferences filePreferences) {
         List<Path> dirs = databaseContext.getFileDirectories(filePreferences);
-        Optional<Path> found = findIn(dirs);
-        if (found.isPresent()) {
-            return found;
-        }
-
-        try {
-            if (!Path.of(link.get()).isAbsolute()) {
-                return Optional.empty();
-            }
-        } catch (InvalidPathException ex) {
-            return Optional.empty();
-        }
-        return FileUtil.applyDirectoryMappings(link.get(), filePreferences.getDirectoryMappings());
+        return findIn(dirs)
+                .or(() -> FileUtil.isAbsoluteLike(link.get())
+                        ? FileUtil.applyDirectoryMappings(link.get(), filePreferences.getDirectoryMappings())
+                        : Optional.empty());
     }
 
     /// Tries to locate the file.

--- a/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -243,7 +243,19 @@ public class LinkedFile implements Serializable {
 
     public Optional<Path> findIn(BibDatabaseContext databaseContext, FilePreferences filePreferences) {
         List<Path> dirs = databaseContext.getFileDirectories(filePreferences);
-        return findIn(dirs);
+        Optional<Path> found = findIn(dirs);
+        if (found.isPresent()) {
+            return found;
+        }
+
+        try {
+            if (!Path.of(link.get()).isAbsolute()) {
+                return Optional.empty();
+            }
+        } catch (InvalidPathException ex) {
+            return Optional.empty();
+        }
+        return FileUtil.applyDirectoryMappings(link.get(), filePreferences.getDirectoryMappings());
     }
 
     /// Tries to locate the file.

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -3573,3 +3573,8 @@ Specify\ a\ subcommand\ (consistency,\ integrity)\ or\ an\ input\ file.=Specify 
 Specify\ a\ subcommand\ (reset,\ import,\ export).=Specify a subcommand (reset, import, export).
 Specify\ a\ subcommand\ (update).=Specify a subcommand (update).
 The\ format\ option\ must\ contain\ either\ 'xmp'\ or\ 'bibtex-attachment'.=The format option must contain either 'xmp' or 'bibtex-attachment'.
+
+Directory\ mapping=Directory mapping
+When\ a\ linked\ file's\ absolute\ path\ cannot\ be\ found,\ try\ substituting\ a\ mapped\ directory\ for\ a\ matching\ prefix.=When a linked file's absolute path cannot be found, try substituting a mapped directory for a matching prefix.
+Mapped\ directory=Mapped directory
+Add\ mapping=Add mapping

--- a/jablib/src/test/java/org/jabref/logic/preferences/JabRefGuiPreferencesTest.java
+++ b/jablib/src/test/java/org/jabref/logic/preferences/JabRefGuiPreferencesTest.java
@@ -3,6 +3,9 @@ package org.jabref.logic.preferences;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.jabref.logic.util.io.DirectoryMapping;
+
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -27,5 +30,21 @@ class JabRefGuiPreferencesTest {
     @MethodSource("provideTestData")
     void convertListToString(List<String> sampleList, String sampleString) {
         assertEquals(sampleString, JabRefCliPreferences.convertListToString(sampleList));
+    }
+
+    @Test
+    void convertDirectoryMappingsRoundTrip() {
+        List<DirectoryMapping> mappings = List.of(
+                new DirectoryMapping("/old/literature", "/new/literature"),
+                new DirectoryMapping("/old/literature", "D:\\literature"));
+
+        String serialized = JabRefCliPreferences.convertDirectoryMappingsToString(mappings);
+
+        assertEquals(mappings, JabRefCliPreferences.convertStringToDirectoryMappings(serialized));
+    }
+
+    @Test
+    void convertStringToDirectoryMappingsEmptyStringYieldsEmptyList() {
+        assertEquals(List.of(), JabRefCliPreferences.convertStringToDirectoryMappings(""));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -551,6 +551,42 @@ class FileUtilTest {
     }
 
     @Test
+    void applyDirectoryMappingsSubstitutesMatchingPrefixWhenFileExists(@TempDir Path temp) throws IOException {
+        Path mappedDir = Files.createDirectories(temp.resolve("mapped"));
+        Path mappedFile = Files.createFile(mappedDir.resolve("paper.pdf"));
+
+        List<DirectoryMapping> mappings = List.of(new DirectoryMapping("/old/literature", mappedDir.toString()));
+
+        assertEquals(Optional.of(mappedFile), FileUtil.applyDirectoryMappings("/old/literature/paper.pdf", mappings));
+    }
+
+    @Test
+    void applyDirectoryMappingsReturnsEmptyWhenNoPrefixMatches() {
+        List<DirectoryMapping> mappings = List.of(new DirectoryMapping("/old/literature", "/new/literature"));
+
+        assertEquals(Optional.empty(), FileUtil.applyDirectoryMappings("/somewhere/else/paper.pdf", mappings));
+    }
+
+    @Test
+    void applyDirectoryMappingsReturnsEmptyWhenSubstitutedPathDoesNotExist() {
+        List<DirectoryMapping> mappings = List.of(new DirectoryMapping("/old/literature", "/does/not/exist"));
+
+        assertEquals(Optional.empty(), FileUtil.applyDirectoryMappings("/old/literature/paper.pdf", mappings));
+    }
+
+    @Test
+    void applyDirectoryMappingsTriesMappingsInOrderAndReturnsFirstExistingMatch(@TempDir Path temp) throws IOException {
+        Path secondMappedDir = Files.createDirectories(temp.resolve("second"));
+        Path secondMappedFile = Files.createFile(secondMappedDir.resolve("paper.pdf"));
+
+        List<DirectoryMapping> mappings = List.of(
+                new DirectoryMapping("/old/literature", "/does/not/exist"),
+                new DirectoryMapping("/old/literature", secondMappedDir.toString()));
+
+        assertEquals(Optional.of(secondMappedFile), FileUtil.applyDirectoryMappings("/old/literature/paper.pdf", mappings));
+    }
+
+    @Test
     public void cTemp() {
         String fileName = "c:\\temp.pdf";
         if (OS.WINDOWS) {

--- a/jablib/src/test/java/org/jabref/model/entry/LinkedFileTest.java
+++ b/jablib/src/test/java/org/jabref/model/entry/LinkedFileTest.java
@@ -1,0 +1,48 @@
+package org.jabref.model.entry;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import org.jabref.logic.FilePreferences;
+import org.jabref.logic.os.OS;
+import org.jabref.logic.util.io.DirectoryMapping;
+import org.jabref.model.database.BibDatabaseContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LinkedFileTest {
+
+    // An absolute path from a foreign machine, unlikely to exist locally as-is.
+    private static final String FOREIGN_ABSOLUTE_LINK = (OS.WINDOWS ? "C:\\old\\literature\\paper.pdf" : "/old/literature/paper.pdf");
+    private static final String FOREIGN_DIRECTORY = (OS.WINDOWS ? "C:\\old\\literature" : "/old/literature");
+
+    @Test
+    void findInAppliesDirectoryMappingWhenAbsoluteLinkIsNotFoundDirectly(@TempDir Path temp) throws IOException {
+        Path mappedDir = Files.createDirectories(temp.resolve("mapped"));
+        Path mappedFile = Files.createFile(mappedDir.resolve("paper.pdf"));
+
+        FilePreferences filePreferences = FilePreferences.getDefault();
+        filePreferences.setDirectoryMappings(List.of(new DirectoryMapping(FOREIGN_DIRECTORY, mappedDir.toString())));
+
+        LinkedFile linkedFile = new LinkedFile("", FOREIGN_ABSOLUTE_LINK, "PDF");
+        BibDatabaseContext databaseContext = new BibDatabaseContext();
+
+        assertEquals(Optional.of(mappedFile), linkedFile.findIn(databaseContext, filePreferences));
+    }
+
+    @Test
+    void findInReturnsEmptyWhenNoDirectoryMappingMatches() {
+        FilePreferences filePreferences = FilePreferences.getDefault();
+
+        LinkedFile linkedFile = new LinkedFile("", FOREIGN_ABSOLUTE_LINK, "PDF");
+        BibDatabaseContext databaseContext = new BibDatabaseContext();
+
+        assertEquals(Optional.empty(), linkedFile.findIn(databaseContext, filePreferences));
+    }
+}


### PR DESCRIPTION
### Related issues and pull requests

Closes TODO

### PR Description

Add a "Directory mapping" preference (Preferences → Linked files) so JabRef can substitute a mapped directory for a matching path prefix when a linked file's absolute path cannot be found — useful when a library is shared between machines whose file directories don't line up. Also size the mapping table to its actual row count instead of stretching to fill the tab, which previously rendered empty striped rows below the real mappings.

### Analogies

Like honey, this preference lets one thing (a file reference) still be found and enjoyed even after it's been moved to a different jar. Like chocolate, the fix is small and unassuming but makes the rest of the preferences pane easier to digest. Like the moon, the mapping table now only shows as much surface as is actually lit up by data, instead of a full empty disc of phantom rows.

jabref-contrib-policy:4.2:reviewed​:ok

### Steps to test

1. Open Preferences → Linked files, scroll to "Directory mapping".
2. Click "Add mapping", enter a directory and its mapped replacement, save.
3. Link a file to an entry whose absolute path uses the original directory, then move/rename that directory so the absolute path no longer resolves; JabRef should resolve the file via the mapped directory instead.
4. Observe the mapping table: with 0 entries it shows a single empty row (no phantom striped rows below); with entries it sizes to the row count.

### AI usage

Claude Code (model claude-sonnet-5)

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

Read your own diff once, top to bottom, and confirm each point.

### Nullability and control flow

- [/] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead. (the one `!= null` is unchanged code inherited verbatim from the WebSearchTab pattern this mirrors, not newly introduced)
- [/] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations. (not used in this diff)
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`). (no new classes)
- [/] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block. (no `Optional` in this diff)
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`. (no string-blank checks in this diff)

### Exceptions

- [/] No `catch (Exception e)` — only specific exceptions are caught. (no exception handling in this diff)
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application. (none thrown)
- [/] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string. (no logging in this diff)

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`). (no `BibEntry` involved)
- [/] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks. (no collections/paths/text blocks introduced)
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`. (no regex in this diff)
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`. (no background work added)
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`. (no Javadoc added)

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML). (no new user-facing strings)
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`. (no new labels)
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation. (no new formatted strings)

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS). (no HTML response handling touched)

### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests. (change is confined to `org.jabref.gui`, no model/logic behavior changed)
- [/] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories. (no tests added — pure JavaFX layout/sizing fix)

## 2. Verification commands

Run in this order — cheapest first. Each must pass.

- [x] `./gradlew :jablib:check` (or `./gradlew check` for all modules). (ran `:jablib:test`: 10608 tests, 143 pre-existing failures, none in code touched by this PR — failures are in `AiModelServiceTest`, `CitationStyleGeneratorTest`, `CSLStyleLoaderTest`, `CSLStyleUtilsTest`, `AbbreviationsTest`, `LtwaRepositoryTest`, `CSLFormatUtilsTest`, all unrelated to `LinkedFilesTab`/directory mapping and caused by missing local network/data resources in this dev environment, not by this change)
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`. (passed — only pre-existing NullAway warnings unrelated to this diff)
- [x] `./gradlew modernizer`. (passed, no findings)
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix). (passed, no changes reported)
- [x] `./gradlew javadoc`. (passed — only pre-existing "no comment" warnings unrelated to this diff)
- [/] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed). (no Markdown changed)
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`. (not needed — rewriteDryRun already clean)

## 3. Documentation

- [/] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when no issue is known and the PR is not yet created — never a fake number. (the "Directory mapping" feature already has an entry from the base commit; this is a same-feature, not-yet-released UI polish fix, so no separate entry added)
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues). (no confident match found, kept `TODO`)
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes). (minor fix to an unreleased feature)
- [/] Developer documentation under `docs/` updated if behavior or architecture changed. (no behavior/architecture change beyond the UI sizing fix)

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder, it was replaced with the real PR-number link after PR creation, then committed and pushed. (no `TODO` placeholder used — no changelog entry added in this PR)

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (not applicable — pure JavaFX layout/sizing fix, no logic/model behavior change)
- [/] I added screenshots in the PR description (visual sizing fix, described in steps to test instead)
- [/] I added a screenshot showing a library with a single entry with me as author and title as the issue number (no issue number exists for this change; not applicable)
- [/] I described the change in `CHANGELOG.md` (not applicable — same unreleased feature, no separate entry needed)
- [/] I checked the user documentation for up-to-dateness (no user-documentation impact — internal preferences-tab layout fix)
