### PR TITLE
Refine skill descriptions and add category field

### DIFF
--- a/skills/developers/jabref-contributor/SKILL.md
+++ b/skills/developers/jabref-contributor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: jabref-contributor
-description: Development conventions for contributing to JabRef, the open-source BibTeX/biblatex reference manager. Use when working on the JabRef codebase - covers the Gradle build, module layout (jablib, jabgui, jabkit, jabls, jabsrv), testing rules (JUnit 5, no Hamcrest), naming conventions, and the mandatory pre-PR checklist.
+category: developers
+description: Gradle build, module layout (jablib, jabgui, jabkit, jabls, jabsrv), JUnit 5 testing rules, naming conventions, and the mandatory pre-PR checklist for contributing to JabRef.
 license: MIT
 ---
 

--- a/skills/users/bibtex-library-management/SKILL.md
+++ b/skills/users/bibtex-library-management/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: bibtex-library-management
-description: Check, clean, and maintain BibTeX and biblatex libraries with JabRef's jabkit CLI. Use when the user wants to validate a .bib file (integrity and consistency checks), generate citation keys, search a bibliography, convert between bibliography formats, or pseudonymize a library before sharing.
+category: users
+description: Validates, cleans, and repairs BibTeX/biblatex libraries with JabRef's jabkit CLI - integrity checks, citation key generation, searching, format conversion, and pseudonymization before sharing.
 license: MIT
 ---
 

--- a/skills/users/jabkit/SKILL.md
+++ b/skills/users/jabkit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: jabkit
-description: Command-line reference for jabkit, JabRef's CLI for BibTeX and biblatex bibliographies. Use for any reference-management task from the terminal - fetching entries from online providers, converting DOIs to BibTeX, extracting references from PDF papers, checking libraries, generating citation keys, writing XMP metadata into PDFs, and searching .bib files.
+category: users
+description: JabRef's Swiss Army knife CLI for BibTeX/biblatex - fetches entries online, converts DOIs to BibTeX, extracts references from PDFs, checks libraries, generates citation keys, writes XMP metadata, and searches .bib files.
 license: MIT
 ---
 

--- a/skills/users/pdf-to-bibtex/SKILL.md
+++ b/skills/users/pdf-to-bibtex/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pdf-to-bibtex
-description: Extract BibTeX entries from PDF papers using JabRef's jabkit CLI. Use when the user wants to import academic papers (PDFs) into a BibTeX or biblatex library, generate .bib entries from PDF metadata (XMP, embedded BibTeX, GROBID, text heuristics), or turn a folder of papers into a bibliography.
+category: users
+description: Turns PDF papers into BibTeX entries with JabRef's jabkit CLI, pulling metadata from XMP, embedded BibTeX, GROBID, or text heuristics - builds a bibliography from a whole folder of papers.
 license: MIT
 ---
 


### PR DESCRIPTION
I am still new to https://www.skills.sh/

Didn't like this - now fixed.

<img width="1161" height="890" alt="grafik" src="https://github.com/user-attachments/assets/5542dac3-7f6d-429d-a75d-9443c6ac703e" />

<img width="1476" height="787" alt="grafik" src="https://github.com/user-attachments/assets/635c85f6-07e8-45cb-930a-12a63ef26ee8" />


### Related issues and pull requests

Closes _____

### PR Description

Shortened the descriptions in the four Agent Skill frontmatter blocks (`jabkit`, `bibtex-library-management`, `pdf-to-bibtex`, `jabref-contributor`) so `npx skills add JabRef/jabref` no longer truncates them mid-word in its selection list, and led each with the concrete result instead of "Use when...". Also called out `jabkit` as JabRef's Swiss-Army-knife CLI for BibTeX/biblatex, and added a `category:` (`users`/`developers`) frontmatter field under `name:` in each SKILL.md.

### Analogies

Like honey, the old descriptions were sweet but ran on too long and stuck in the wrong spot when poured. Like a chocolate bar, they're now broken into clean, snappable pieces instead of an odd crumbled edge. And like the moon, the important part — `jabkit` — now shows its full face instead of being half in shadow.

jabref-contrib-policy:4.2:reviewed​:ok

### Steps to test

1. Run `npx skills add JabRef/jabref`.
2. Check the skill selection list: descriptions should read as complete phrases, not cut off mid-word with `...`.
3. Confirm `category:` appears under `name:` in each SKILL.md.

### AI usage

Claude Code (model claude-sonnet-5)

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

Read your own diff once, top to bottom, and confirm each point.

### Nullability and control flow

- [/] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead. (no Java code touched)
- [/] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations. (no Java code touched)
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`). (no new classes)
- [/] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block. (no Java code touched)
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`. (no Java code touched)

### Exceptions

- [/] No `catch (Exception e)` — only specific exceptions are caught. (no Java code touched)
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application. (no Java code touched)
- [/] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string. (no Java code touched)

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`). (no Java code touched)
- [/] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks. (no Java code touched)
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`. (no Java code touched)
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`. (no Java code touched)
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`. (no Javadoc touched)

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML). (change is Agent Skill metadata, not application UI text)
- [x] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation. (not applicable)

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS). (no such code touched)

### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests. (no such code touched)
- [/] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories. (no tests added, none needed)

## 2. Verification commands

Run in this order — cheapest first. Each must pass.

- [/] `./gradlew :jablib:check` (or `./gradlew check` for all modules). (no Java/Gradle-relevant files changed)
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`. (no Java files changed)
- [/] `./gradlew modernizer`. (no Java files changed)
- [/] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix). (no Java files changed)
- [/] `./gradlew javadoc`. (no Java files changed)
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed). (SKILL.md changes are frontmatter-only, manually verified as valid YAML)
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`. (not applicable, no formatting drift)

## 3. Documentation

- [/] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when no issue is known and the PR is not yet created — never a fake number. (change not visible to JabRef end users, only Agent Skills packaging)
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues). (none found; no issue linked)
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes). (not a new feature or significant bug fix)
- [/] Developer documentation under `docs/` updated if behavior or architecture changed. (no behavior/architecture change)

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder, it was replaced with the real PR-number link after PR creation, then committed and pushed. (no `CHANGELOG.md` entry added)

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required) — change is to Agent Skill markdown metadata, not application code; verified by re-reading the frontmatter, not by running JabRef.
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
