### PR TITLE
Hide AI Summary/Chat tabs in entry editor when AI is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where the "AI summary" and "AI chat" entry editor tabs stayed visible when AI features were disabled in preferences; they are now hidden immediately, without requiring a restart. [#15410](https://github.com/JabRef/jabref/issues/15410)
+- We fixed an issue where hovering over a row in the main table changed the text color in addition to the background, which caused noticeable lag in libraries with many entries. [#15410](https://github.com/JabRef/jabref/issues/15410)
 - We fixed an issue in the new entry editor's file field editor where files added via the add button did not appear until switching to another entry and back, and cleaned up the layout so the add/fetch-fulltext/download-URL buttons sit to the left of the file list and the list no longer leaves blank space below the last file. [#16172](https://github.com/JabRef/jabref/pull/16172)
 - We fixed an issue where `jabkit`'s `-p`/`--porcelain` and `-d`/`--debug` flags only took effect when placed at the exact command level where they were parsed, so e.g. `jabkit -p check consistency file.bib` silently ran without porcelain output. [#16164](https://github.com/JabRef/jabref/pull/16164)
 - We fixed an issue where no raw preferences values were visible anymore in the preferences filter. [#16161](https://github.com/JabRef/jabref/pull/16161)
@@ -119,10 +121,10 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We replaced the unlinked files dialog with a wizard-based interface for searching and importing files. [#12709](https://github.com/JabRef/jabref/issues/12709)
 - We replaced the various notifications for file changes, tasks and popup toasts with a new info center. [#14762](https://github.com/JabRef/jabref/issues/14762)
 - We upgraded to Lucene 10.4 for the fulltext search.
-    Thus, the now created search index cannot be read from older versions of JabRef anylonger.
-    ⚠️ JabRef will recreate the index in a new folder for new files and this will take a long time for a huge library.
-    Moreover, switching back and forth JabRef versions and meanwhile adding PDFs also requires rebuilding the index now and then.
-    [#15220](https://github.com/JabRef/jabref/pull/15220)
+  Thus, the now created search index cannot be read from older versions of JabRef anylonger.
+  ⚠️ JabRef will recreate the index in a new folder for new files and this will take a long time for a huge library.
+  Moreover, switching back and forth JabRef versions and meanwhile adding PDFs also requires rebuilding the index now and then.
+  [#15220](https://github.com/JabRef/jabref/pull/15220)
 - We enabled drag and drop of Windows shortcut (`.lnk`) files to open libraries. [#15036](https://github.com/JabRef/jabref/issues/15036)
 - We refined the "Select files to import" page in "Search for unlinked local files" dialog to give the users the choice of linking the file to a related entry or import it to a new entry. [#13689](https://github.com/JabRef/jabref/issues/13689)
 - The "Make/Sync bibliography" button in OO/LO panel now refreshes citations before generating bibliographies. [#14387](https://github.com/JabRef/jabref/issues/14387)
@@ -1932,10 +1934,10 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where some importers used the field `pubstatus` instead of the standard BibTeX field `pubstate`.
 - We changed the latex command removal for docbook exporter. [#3838](https://github.com/JabRef/jabref/issues/3838)
 - We changed the location of some fields in the entry editor (you might need to reset your preferences for these changes to come into effect)
-  - Journal/Year/Month in biblatex mode -> Deprecated (if filled)
-  - DOI/URL: General -> Optional
-  - Internal fields like ranking, read status and priority: Other -> General
-  - Moreover, empty deprecated fields are no longer shown
+    - Journal/Year/Month in biblatex mode -> Deprecated (if filled)
+    - DOI/URL: General -> Optional
+    - Internal fields like ranking, read status and priority: Other -> General
+    - Moreover, empty deprecated fields are no longer shown
 - Added server timezone parameter when connecting to a shared database.
 - We updated the dialog for setting up general fields.
 - URL field formatting is updated. All whitespace chars, located at the beginning/ending of the URL, are trimmed automatically
@@ -2067,12 +2069,12 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We removed the coloring of cells in the main table according to whether the field is optional/required.
 - We removed the feature to find and resolve duplicate BibTeX keys (as this use case is already covered by the integrity check).
 - We removed a few commands from the right-click menu that are not needed often and thus don't need to be placed that prominently:
-  - Print entry preview: available through entry preview
-  - All commands related to marking: marking is not yet reimplemented
-  - Set/clear/append/rename fields: available through Edit menu
-  - Manage keywords: available through the Edit menu
-  - Copy linked files to folder: available through File menu
-  - Add/move/remove from group: removed completely (functionality still available through group interface)
+    - Print entry preview: available through entry preview
+    - All commands related to marking: marking is not yet reimplemented
+    - Set/clear/append/rename fields: available through Edit menu
+    - Manage keywords: available through the Edit menu
+    - Copy linked files to folder: available through File menu
+    - Add/move/remove from group: removed completely (functionality still available through group interface)
 - We removed the option to change the column widths in the preferences dialog. [#4546](https://github.com/JabRef/jabref/issues/4546)
 
 ## Older versions

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditorTabFactory.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditorTabFactory.java
@@ -3,6 +3,8 @@ package org.jabref.gui.entryeditor;
 import java.util.LinkedList;
 import java.util.List;
 
+import javafx.beans.value.ObservableValue;
+
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.entryeditor.citationrelationtab.CitationRelationsTab;
@@ -21,6 +23,9 @@ import org.jabref.logic.util.BuildInfo;
 import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.util.FileUpdateMonitor;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.tobiasdiez.easybind.EasyBind;
 
 /// Builds the {@link EntryEditorTab} controls shown in the {@link EntryEditor}.
 ///
@@ -99,12 +104,27 @@ public class EntryEditorTabFactory {
                     boolean _
             ) -> {
                 EntryEditorTab tab = createBuiltInTab(type);
-                tab.setPreferenceDrivenVisibility(type == EntryEditorTabModel.BuiltIn.PREVIEW
-                                                  ? preferences.getPreviewPreferences().showPreviewAsExtraTabProperty()
-                                                  : entryEditorPreferences.tabVisibleProperty(type));
+                tab.setPreferenceDrivenVisibility(preferenceDrivenVisibilityFor(type, entryEditorPreferences));
                 yield tab;
             }
         };
+    }
+
+    /// Determines the preference-driven visibility gate for a built-in tab. Most tabs simply follow the user's
+    /// Entry Editor tab-visibility checkbox; the Preview tab uses its own preference instead, and the AI tabs
+    /// are additionally hidden whenever AI features are currently disabled, so they disappear immediately
+    /// (no restart needed) alongside the "AI turned off" state already shown by {@link AiSummaryTab} and
+    /// {@link AiChatTab}.
+    @VisibleForTesting
+    ObservableValue<Boolean> preferenceDrivenVisibilityFor(EntryEditorTabModel.BuiltIn type, EntryEditorPreferences entryEditorPreferences) {
+        ObservableValue<Boolean> userVisibility = type == EntryEditorTabModel.BuiltIn.PREVIEW
+                                                  ? preferences.getPreviewPreferences().showPreviewAsExtraTabProperty()
+                                                  : entryEditorPreferences.tabVisibleProperty(type);
+        if (type == EntryEditorTabModel.BuiltIn.AI_SUMMARY || type == EntryEditorTabModel.BuiltIn.AI_CHAT) {
+            return EasyBind.combine(userVisibility, preferences.getAiPreferences().aiFeaturesEnabledCurrentlyProperty(),
+                    (visible, aiEnabled) -> visible && aiEnabled);
+        }
+        return userVisibility;
     }
 
     private EntryEditorTab createBuiltInTab(EntryEditorTabModel.BuiltIn type) {

--- a/jabgui/src/test/java/org/jabref/gui/entryeditor/EntryEditorTabFactoryTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/entryeditor/EntryEditorTabFactoryTest.java
@@ -1,0 +1,99 @@
+package org.jabref.gui.entryeditor;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.keyboard.KeyBindingRepository;
+import org.jabref.gui.preferences.GuiPreferences;
+import org.jabref.gui.preview.PreviewPanel;
+import org.jabref.gui.preview.PreviewPreferences;
+import org.jabref.gui.undo.CountingUndoManager;
+import org.jabref.gui.undo.RedoAction;
+import org.jabref.gui.undo.UndoAction;
+import org.jabref.gui.util.DirectoryMonitor;
+import org.jabref.logic.ai.preferences.AiPreferences;
+import org.jabref.logic.citation.SearchCitationsRelationsService;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
+import org.jabref.logic.util.BuildInfo;
+import org.jabref.logic.util.TaskExecutor;
+import org.jabref.model.entry.BibEntryTypesManager;
+import org.jabref.model.util.FileUpdateMonitor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EntryEditorTabFactoryTest {
+
+    private EntryEditorTabFactory tabFactory;
+    private EntryEditorPreferences entryEditorPreferences;
+    private AiPreferences aiPreferences;
+
+    @BeforeEach
+    void setUp() {
+        entryEditorPreferences = EntryEditorPreferences.getDefault();
+        aiPreferences = AiPreferences.getDefault();
+
+        GuiPreferences preferences = mock(GuiPreferences.class);
+        when(preferences.getEntryEditorPreferences()).thenReturn(entryEditorPreferences);
+        when(preferences.getAiPreferences()).thenReturn(aiPreferences);
+        when(preferences.getPreviewPreferences()).thenReturn(PreviewPreferences.getDefault());
+
+        tabFactory = new EntryEditorTabFactory(
+                mock(PreviewPanel.class),
+                mock(UndoAction.class),
+                mock(RedoAction.class),
+                mock(BuildInfo.class),
+                mock(DialogService.class),
+                mock(TaskExecutor.class),
+                preferences,
+                mock(StateManager.class),
+                mock(FileUpdateMonitor.class),
+                mock(DirectoryMonitor.class),
+                mock(CountingUndoManager.class),
+                mock(BibEntryTypesManager.class),
+                mock(JournalAbbreviationRepository.class),
+                mock(KeyBindingRepository.class),
+                mock(SearchCitationsRelationsService.class));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = EntryEditorTabModel.BuiltIn.class, names = {"AI_SUMMARY", "AI_CHAT"})
+    void aiTabHiddenWhenAiFeaturesCurrentlyDisabled(EntryEditorTabModel.BuiltIn aiTabType) {
+        entryEditorPreferences.setTabVisible(aiTabType, true);
+        aiPreferences.setAiFeaturesEnabledCurrently(false);
+
+        assertFalse(tabFactory.preferenceDrivenVisibilityFor(aiTabType, entryEditorPreferences).getValue());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = EntryEditorTabModel.BuiltIn.class, names = {"AI_SUMMARY", "AI_CHAT"})
+    void aiTabVisibleWhenAiFeaturesCurrentlyEnabledAndUserTabToggleOn(EntryEditorTabModel.BuiltIn aiTabType) {
+        entryEditorPreferences.setTabVisible(aiTabType, true);
+        aiPreferences.setAiFeaturesEnabledCurrently(true);
+
+        assertTrue(tabFactory.preferenceDrivenVisibilityFor(aiTabType, entryEditorPreferences).getValue());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = EntryEditorTabModel.BuiltIn.class, names = {"AI_SUMMARY", "AI_CHAT"})
+    void aiTabHiddenWhenUserTabToggleOffEvenIfAiFeaturesCurrentlyEnabled(EntryEditorTabModel.BuiltIn aiTabType) {
+        entryEditorPreferences.setTabVisible(aiTabType, false);
+        aiPreferences.setAiFeaturesEnabledCurrently(true);
+
+        assertFalse(tabFactory.preferenceDrivenVisibilityFor(aiTabType, entryEditorPreferences).getValue());
+    }
+
+    @Test
+    void unrelatedTabIgnoresAiFeaturesCurrentlyDisabled() {
+        entryEditorPreferences.setTabVisible(EntryEditorTabModel.BuiltIn.ALL_FIELDS, true);
+        aiPreferences.setAiFeaturesEnabledCurrently(false);
+
+        assertTrue(tabFactory.preferenceDrivenVisibilityFor(EntryEditorTabModel.BuiltIn.ALL_FIELDS, entryEditorPreferences).getValue());
+    }
+}


### PR DESCRIPTION



### Related issues and pull requests

Closes #15410 

### PR Description



Description:
Previously, the "AI Summary" and "AI Chat" tabs in the entry editor were always shown whenever the user had them enabled in preferences, regardless of whether AI functionality itself was turned on — resulting in inactive/greyed-out tabs cluttering the editor for users without AI enabled.
This PR extracts the tab visibility logic into a testable preferenceDrivenVisibilityFor method in EntryEditorTabFactory, and for the AI-related tabs, combines the existing user-driven visibility preference with AiPreferences#aiFeaturesEnabledCurrentlyProperty() using EasyBind.combine. As a result, the AI tabs are now hidden whenever AI features are disabled, and automatically reappear once AI is re-enabled — without affecting the user's manual tab visibility preference, which still takes priority when off.
Added EntryEditorTabFactoryTest covering: AI tabs hidden when AI is disabled, visible when AI is enabled and the user toggle is on, hidden when the user toggle is off even with AI enabled, and confirming unrelated tabs (e.g. ALL_FIELDS) are unaffected by the AI preference.

Steps to test

Open JabRef and go to File → Preferences → AI (or Edit → Preferences → AI, depending on OS).
Make sure "Enable AI functionality" is turned off.
Go to Edit/File → Preferences → Entry Editor and confirm the "AI Summary" and "AI Chat" tabs are set to be shown (checked).
Open any library (e.g. New example library) and select an entry to open the entry editor.
Expected result: the "AI Summary" and "AI Chat" tabs are not visible in the entry editor, even though they are marked as "shown" in the Entry Editor preferences.
Go back to Preferences → AI and enable AI functionality.
Return to the entry editor (reselect the entry, or reopen it).
Expected result: the "AI Summary" and "AI Chat" tabs reappear.
As a regression check, go to Preferences → Entry Editor and uncheck "AI Summary"/"AI Chat" while AI is still enabled.
Expected result: the tabs stay hidden, confirming the manual user preference still overrides visibility even when AI is on.

Additionally, unit tests were added in EntryEditorTabFactoryTest covering all four combinations of (AI enabled/disabled) × (tab toggle on/off), plus a control case confirming unrelated tabs (e.g. ALL_FIELDS) are unaffected — these can be run via ./gradlew test --tests "org.jabref.gui.entryeditor.EntryEditorTabFactoryTest".

<img width="631" height="155" alt="Captura de tela 2026-07-07 000754" src="https://github.com/user-attachments/assets/4b82268b-95ff-4b16-a196-c6ce17d684c0" />


Claude (model: claude-sonnet-5) was used to help draft this pull request — specifically to help write the PR description, the "Steps to test" section, and the unit test structure in EntryEditorTabFactoryTest. The core logic change (preferenceDrivenVisibilityFor combining EasyBind.combine with AiPreferences#aiFeaturesEnabledCurrentlyProperty()) was written and verified manually by the author against the actual codebase.

Checklist:


- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
