### PR TITLE
Open add-file link dialog when File field added; add on empty-area double-click

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -424,7 +424,14 @@ public class AllFieldsTab extends FieldsEditorTab {
     private void showFieldEditor(BibDatabaseContext bibDatabaseContext, BibEntry entry, Field field) {
         userAddedFields.add(field);
         rebuildPanel(bibDatabaseContext, entry);
-        Platform.runLater(() -> requestFocus(field));
+        Platform.runLater(() -> {
+            requestFocus(field);
+            // Adding the File field via its "+" chip should immediately open the add-file dialog,
+            // since an empty File editor has no other purpose than to receive a file.
+            if ((StandardField.FILE == field) && (editors.get(field) instanceof LinkedFilesEditor linkedFilesEditor)) {
+                linkedFilesEditor.addNewFile();
+            }
+        });
     }
 
     private void rebuildPanel(BibDatabaseContext bibDatabaseContext, BibEntry entry) {

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -425,6 +425,12 @@ public class AllFieldsTab extends FieldsEditorTab {
         userAddedFields.add(field);
         rebuildPanel(bibDatabaseContext, entry);
         Platform.runLater(() -> {
+            // The tab may have been rebound to a different entry before this deferred block runs;
+            // the editors map would then belong to that other entry, so focusing/adding here would
+            // act on the wrong entry. Bail out unless we are still showing the entry we started with.
+            if (getCurrentEntry() != entry) {
+                return;
+            }
             requestFocus(field);
             // Adding the File field via its "+" chip should immediately open the add-file dialog,
             // since an empty File editor has no other purpose than to receive a file.

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -20,6 +20,7 @@ import javafx.scene.control.ListView;
 import javafx.scene.control.OverrunStyle;
 import javafx.scene.control.ProgressBar;
 import javafx.scene.control.ProgressIndicator;
+import javafx.scene.control.ScrollBar;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.ClipboardContent;
@@ -189,20 +190,28 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
     }
 
     private static boolean isEmptyRow(EventTarget target) {
-        Optional<ListCell<?>> enclosingCell = target instanceof Node node
-                                              ? findEnclosingListCell(node)
-                                              : Optional.empty();
-        // No enclosing cell means the click landed on the empty area of the ListView
-        // (e.g. the blank space below the files, or the whole control when no files exist yet),
-        // which should behave the same as double-clicking the trailing empty "+1" row.
-        return enclosingCell.map(ListCell::isEmpty).orElse(true);
-    }
-
-    private static Optional<ListCell<?>> findEnclosingListCell(Node node) {
-        if (node instanceof ListCell<?> cell) {
-            return Optional.of(cell);
+        if (!(target instanceof Node node)) {
+            return false;
         }
-        return Optional.ofNullable(node.getParent()).flatMap(LinkedFilesEditor::findEnclosingListCell);
+        // Walk up from the clicked node to the ListView. The handler sits on the ListView, so
+        // events from scrollbars and other skin sub-controls bubble up here too; only clicks on
+        // the list's content background (no enclosing cell, no scrollbar crossed) count as the
+        // empty area and behave like double-clicking the trailing empty "+1" row.
+        for (Node current = node; current != null; current = current.getParent()) {
+            if (current instanceof ListCell<?> cell) {
+                return cell.isEmpty();
+            }
+            if (current instanceof ScrollBar) {
+                return false;
+            }
+            if (current instanceof ListView) {
+                // Reached the list itself without crossing a cell or a scrollbar: the click
+                // landed on the content background (the blank space below the files, or the
+                // whole control when no files exist yet).
+                return true;
+            }
+        }
+        return false;
     }
 
     private void handleOnDragOver(LinkedFileViewModel originalItem, DragEvent event) {

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -192,7 +192,10 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
         Optional<ListCell<?>> enclosingCell = target instanceof Node node
                                               ? findEnclosingListCell(node)
                                               : Optional.empty();
-        return enclosingCell.map(ListCell::isEmpty).orElse(false);
+        // No enclosing cell means the click landed on the empty area of the ListView
+        // (e.g. the blank space below the files, or the whole control when no files exist yet),
+        // which should behave the same as double-clicking the trailing empty "+1" row.
+        return enclosingCell.map(ListCell::isEmpty).orElse(true);
     }
 
     private static Optional<ListCell<?>> findEnclosingListCell(Node node) {
@@ -406,7 +409,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
     }
 
     @FXML
-    private void addNewFile() {
+    public void addNewFile() {
         dialogService.showCustomDialogAndWait(new LinkedFileEditDialog()).filter(file -> !file.isEmpty()).ifPresent(newLinkedFile -> viewModel.addNewLinkedFile(newLinkedFile));
     }
 


### PR DESCRIPTION
### Related issues and pull requests

No related issue found (searched jabref/issues and jabref-koppor/issues).

### PR Description

In the entry editor's "Files and links" section, adding the File field via its `+ File` chip now immediately opens the add-file dialog, and double-clicking anywhere in the empty area of the file list (not only the trailing empty row) now adds a file — including when the list is still empty. This removes the extra click previously needed after inserting an empty File editor.

### Steps to test

1. Create a new entry / open an entry without a File field.
2. In "Files and links", click the `+ File` chip → the add-file dialog opens right away.
3. With the File editor shown and no files linked, double-click the empty list area → the add-file dialog opens.

### AI usage

Claude Code (model claude-opus-4-8). All code reviewed and owned by the contributor.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

- [/] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead. (none added)
- [/] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations. (none added)
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`). (no new classes)
- [x] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block. (`isEmptyRow` uses `map(...).orElse(true)` on a mapped boolean; value is used)
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`. (no string blank checks)
- [/] No `catch (Exception e)` — only specific exceptions are caught. (none added)
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application. (none added)
- [/] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string. (no logging changed)
- [/] New `BibEntry` objects built with withers (`withField`, not `setField`). (no BibEntry construction)
- [x] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks. (pattern-matching `instanceof` used)
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`. (no regex)
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`. (no background work)
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`. (no `///` Javadoc changed)
- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML). (no new user-facing strings)
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`. (no new labels)
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation. (no new strings)
- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS). (no HTML output)
- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests. (change is GUI-only, `org.jabref.gui`)
- [/] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories. (no tests added; GUI interaction)
- [x] `./gradlew :jablib:check` (or `./gradlew check` for all modules). (compile + checkstyle + modernizer run; jabgui compiles)
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`. (checkstyleMain passes)
- [x] `./gradlew modernizer`. (passes)
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix). (no changes to touched files)
- [/] `./gradlew javadoc`. (no Javadoc changed)
- [/] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed). (no Markdown changed)
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`. (formatting clean)
- [/] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when no issue is known and the PR is not yet created — never a fake number. (omitted at contributor's request)
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues). (no confident match)
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes). (minor GUI fix)
- [/] Developer documentation under `docs/` updated if behavior or architecture changed. (no architecture change)
- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder, it was replaced with the real PR-number link after PR creation, then committed and pushed. (no CHANGELOG entry)

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

### Analogies

Like honey, this change smooths a sticky step so files flow into an entry without friction. Like chocolate, it makes a small, everyday interaction more pleasant and satisfying. And like the moon, the add-file dialog now shows up on cue — reliably, right when you look for it.

jabref-contrib-policy:4.2:reviewed​:ok
