### PR TITLE
Fix html-to-node preview font size

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/jabgui/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -107,13 +107,16 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
         workspacePreferences.mainFontSizeProperty().addListener((_, _, _) -> updateBaseFontSize());
     }
 
-    /// @return the base font size in points, matching whatever [org.jabref.gui.theme.ThemeManager]
-    /// applies to the rest of the UI via the scene root's "-fx-font-size" (the preview cannot rely on that
-    /// CSS cascade itself, since its text nodes get an explicit `Font` instead of an inherited one)
+    /// @return the base font size in CSS pixels (JavaFX user units), matching whatever
+    /// [org.jabref.gui.theme.ThemeManager] applies to the rest of the UI via the scene root's
+    /// "-fx-font-size". ThemeManager expresses the size in CSS `pt` (`-fx-font-size: Xpt`), but
+    /// `Font.font(size)` in the JavaFX Font API takes CSS pixels (user units), not typographic
+    /// points — so the stored pt value must be converted (1pt = 96/72 px).
     private double resolveBaseFontSize() {
-        return workspacePreferences.shouldOverrideDefaultFontSize()
-               ? workspacePreferences.getMainFontSize()
-               : WorkspacePreferences.getDefault().getMainFontSize();
+        double pt = workspacePreferences.shouldOverrideDefaultFontSize()
+                    ? workspacePreferences.getMainFontSize()
+                    : WorkspacePreferences.getDefault().getMainFontSize();
+        return pt * 96.0 / 72.0;
     }
 
     private void updateBaseFontSize() {


### PR DESCRIPTION
### Steps to test

Have entry editor w/ preview open

Change font size

### AI usage

Claude alone


### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
