### PR TITLE
Render TeX math in the entry preview

### DIFF
--- a/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
@@ -313,6 +313,16 @@ extraJavaModuleInfo {
     module("org.javassist:javassist", "org.javassist")
     module("org.jbibtex:jbibtex", "jbibtex")
     module("org.scala-lang:scala-library", "scala.library")
+    // JLaTeXMath renders TeX math in the entry preview (via org.jabref:html-to-node). It ships no
+    // module descriptor and splits its optional fonts into resource-only companion jars, so merge
+    // them into one module; jdeps reports it uses java.desktop (Java2D) and java.xml.
+    module("org.scilab.forge:jlatexmath", "jlatexmath") {
+        exportAllPackages()
+        requires("java.desktop")
+        requires("java.xml")
+        mergeJar("org.scilab.forge:jlatexmath-font-greek")
+        mergeJar("org.scilab.forge:jlatexmath-font-cyrillic")
+    }
     module("pt.davidafsilva.apple:jkeychain", "jkeychain")
 
     module("org.testfx:testfx-core", "org.testfx") {

--- a/jabgui/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/jabgui/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -95,7 +95,10 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
         previewView.getStyleClass().add("preview-viewer-content");
         previewView.setOptions(HtmlRenderOptions.defaults()
                                                 .withLinkHandler(this::openLink)
-                                                .withBaseFontSize(resolveBaseFontSize()));
+                                                .withBaseFontSize(resolveBaseFontSize())
+                                                // TeX math ($…$, $$…$$) in fields such as the abstract is preserved
+                                                // through the layout (HTMLChars(preserveMath)) and typeset here
+                                                .withRenderMath(true));
         // The outer ScrollPane scrolls (scroll sync, tooltips); the area sizes to its content
         previewView.setUseContentHeight(true);
         setContent(previewView);

--- a/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -298,6 +298,8 @@ public class PreferencesMigrations {
         String migratedStyle = currentPreviewStyle.replace("\\begin{review}<BR><BR><b>Review: </b> \\format[HTMLChars]{\\review} \\end{review}", "\\begin{comment}<BR><BR><b>Comment: </b> \\format[Markdown,HTMLChars]{\\comment} \\end{comment}")
                                                   .replace("\\format[HTMLChars]{\\comment}", "\\format[Markdown,HTMLChars]{\\comment}")
                                                   .replace("\\format[Markdown,HTMLChars]{\\comment}", "\\format[Markdown,HTMLChars(keepCurlyBraces)]{\\comment}")
+                                                  .replace("\\format[Markdown,HTMLChars(keepCurlyBraces)]{\\comment}", "\\format[Markdown,HTMLChars(keepCurlyBraces,preserveMath)]{\\comment}")
+                                                  .replace("\\format[HTMLChars]{\\abstract}", "\\format[HTMLChars(preserveMath)]{\\abstract}")
                                                   .replace("<b><i>\\bibtextype</i><a name=\"\\bibtexkey\">\\begin{bibtexkey} (\\bibtexkey)</a>", "<b><i>\\bibtextype</i><a name=\"\\citationkey\">\\begin{citationkey} (\\citationkey)</a>")
                                                   .replace("\\end{bibtexkey}</b><br>__NEWLINE__", "\\end{citationkey}</b><br>__NEWLINE__")
                                                   .replace("\\end{pages}__NEWLINE__\\begin{abstract}", """

--- a/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
+++ b/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
@@ -86,13 +86,13 @@ class GuiPreferencesMigrationsTest {
         String newPreviewStyle = """
                 <font face="sans-serif">__NEWLINE__\
                 Customized preview style using reviews and comments:__NEWLINE__\
-                \\begin{comment}<BR><BR><b>Comment: </b> \\format[Markdown,HTMLChars(keepCurlyBraces)]{\\comment} \\end{comment}__NEWLINE__\
-                \\begin{comment} Something: \\format[Markdown,HTMLChars(keepCurlyBraces)]{\\comment} special \\end{comment}__NEWLINE__\
+                \\begin{comment}<BR><BR><b>Comment: </b> \\format[Markdown,HTMLChars(keepCurlyBraces,preserveMath)]{\\comment} \\end{comment}__NEWLINE__\
+                \\begin{comment} Something: \\format[Markdown,HTMLChars(keepCurlyBraces,preserveMath)]{\\comment} special \\end{comment}__NEWLINE__\
                 </font>__NEWLINE__\
                 \\begin{pages}<BR> p. \\format[FormatPagesForHTML]{\\pages}\\end{pages}__NEWLINE__\
                 \\begin{doi}<BR>doi <a href="https://doi.org/\\format[DOIStrip]{\\doi}">\\format[DOIStrip]{\\doi}</a>\\end{doi}__NEWLINE__\
                 \\begin{url}<BR>URL <a href="\\url">\\url</a>\\end{url}__NEWLINE__\
-                \\begin{abstract}<BR><BR><b>Abstract: </b>\\format[HTMLChars]{\\abstract} \\end{abstract}__NEWLINE__""";
+                \\begin{abstract}<BR><BR><b>Abstract: </b>\\format[HTMLChars(preserveMath)]{\\abstract} \\end{abstract}__NEWLINE__""";
 
         when(preferences.get(eq(JabRefGuiPreferences.PREVIEW_STYLE), anyString())).thenReturn(oldPreviewStyle);
 
@@ -109,7 +109,6 @@ class GuiPreferencesMigrationsTest {
                 \\begin{title}<BR><b>\\format[HTMLChars]{\\title}</b>\\end{title}__NEWLINE__\
                 \\begin{pages}<BR> p. \\format[FormatPagesForHTML]{\\pages}\\end{pages}__NEWLINE__\
                 \\begin{note}<BR>\\format[HTMLChars]{\\note}\\end{note}__NEWLINE__\
-                \\begin{abstract}<BR><BR><b>Abstract: </b>\\format[HTMLChars]{\\abstract} \\end{abstract}__NEWLINE__\
                 </font>__NEWLINE__""";
 
         when(preferences.get(eq(JabRefGuiPreferences.PREVIEW_STYLE), anyString())).thenReturn(unchangedPreviewStyle);

--- a/jablib/src/main/java/org/jabref/logic/layout/format/HTMLChars.java
+++ b/jablib/src/main/java/org/jabref/logic/layout/format/HTMLChars.java
@@ -1,7 +1,10 @@
 package org.jabref.logic.layout.format;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.jabref.logic.layout.ParamLayoutFormatter;
@@ -20,17 +23,47 @@ public class HTMLChars implements ParamLayoutFormatter {
     /// - `&Hey` **Matched**
     private static final Pattern HTML_ENTITY_PATTERN = Pattern.compile("&(?!(?:[a-z0-9]+|#[0-9]{1,6}|#x[0-9a-fA-F]{1,6});)");
 
+    /// Delimited TeX math spans, longer delimiters first so `$$…$$` wins over `$…$`. Used only in
+    /// `preserveMath` mode to lift math out before the LaTeX→HTML conversion (which would otherwise
+    /// consume the `\commands` inside) and splice it back verbatim for a downstream math renderer.
+    private static final Pattern MATH_SPAN = Pattern.compile(
+            "(?<!\\\\)\\$\\$.+?\\$\\$"           // $$ … $$
+                    + "|\\\\\\[.+?\\\\\\]"       // \[ … \]
+                    + "|\\\\\\(.+?\\\\\\)"       // \( … \)
+                    + "|(?<!\\\\)\\$[^$]+?\\$",  // $ … $ (opening not an escaped \$)
+            Pattern.DOTALL);
+
+    /// Private-use sentinel bounding a span placeholder: neither a LaTeX command, brace, nor an
+    /// HTML-special character, so it passes through the conversion untouched.
+    private static final char MATH_SENTINEL = '\uE000';
+
     private boolean keepCurlyBraces = false;
+    private boolean preserveMath = false;
 
     @Override
     public void setArgument(String arg) {
-        if ("keepCurlyBraces".equalsIgnoreCase(arg)) {
-            this.keepCurlyBraces = true;
+        // The layout engine passes the whole parenthesised argument as one string, so several flags
+        // can be combined, e.g. HTMLChars(keepCurlyBraces,preserveMath).
+        for (String flag : arg.split(",")) {
+            String trimmed = flag.trim();
+            if ("keepCurlyBraces".equalsIgnoreCase(trimmed)) {
+                this.keepCurlyBraces = true;
+            } else if ("preserveMath".equalsIgnoreCase(trimmed)) {
+                this.preserveMath = true;
+            }
         }
     }
 
     @Override
     public String format(String inField) {
+        if (preserveMath) {
+            return formatPreservingMath(inField);
+        }
+        return convertToHtml(inField);
+    }
+
+    /// Escapes HTML and converts LaTeX character commands to their HTML/Unicode equivalents.
+    private String convertToHtml(String inField) {
         String field = normalizedField(inField);
 
         StringBuilder sb = new StringBuilder();
@@ -183,6 +216,38 @@ public class HTMLChars implements ParamLayoutFormatter {
                                   .replace("\n", "<br>") // Replace single line breaks with <br>
                                   .replace("\\$", "&dollar;") // Replace \$ with &dollar;
                                   .replaceAll("\\$([^$]*)\\$", this.keepCurlyBraces ? "\\\\{$1\\\\}" : "$1}");
+    }
+
+    /// Converts to HTML while keeping TeX math spans intact for a downstream math renderer.
+    ///
+    /// The spans are lifted out (replaced by sentinel placeholders that pass through
+    /// [#convertToHtml] unchanged), the surrounding text is converted normally, then the spans are
+    /// spliced back verbatim — only `<`, `>` and `&` escaped so the HTML parser keeps them as text.
+    /// Delimiters and TeX bodies are left untouched; whether a span is really math (versus, say, a
+    /// currency amount) is left to the renderer's own heuristics.
+    private String formatPreservingMath(String inField) {
+        List<String> spans = new ArrayList<>();
+        Matcher matcher = MATH_SPAN.matcher(inField);
+        StringBuilder protectedField = new StringBuilder();
+        while (matcher.find()) {
+            matcher.appendReplacement(protectedField, Matcher.quoteReplacement(placeholder(spans.size())));
+            spans.add(matcher.group());
+        }
+        matcher.appendTail(protectedField);
+
+        String converted = convertToHtml(protectedField.toString());
+        for (int i = 0; i < spans.size(); i++) {
+            converted = converted.replace(placeholder(i), escapeHtmlSpecials(spans.get(i)));
+        }
+        return converted;
+    }
+
+    private static String placeholder(int index) {
+        return MATH_SENTINEL + Integer.toString(index) + MATH_SENTINEL;
+    }
+
+    private static String escapeHtmlSpecials(String span) {
+        return span.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 
     private String getHTMLTag(String latexCommand) {

--- a/jablib/src/main/java/org/jabref/logic/preview/TextBasedPreviewLayout.java
+++ b/jablib/src/main/java/org/jabref/logic/preview/TextBasedPreviewLayout.java
@@ -35,9 +35,9 @@ public final class TextBasedPreviewLayout implements PreviewLayout {
             "\\begin{pages}<BR> p. \\format[FormatPagesForHTML]{\\pages}\\end{pages}__NEWLINE__" +
             "\\begin{doi}<BR>doi <a href=\"https://doi.org/\\format[DOIStrip]{\\doi}\">\\format[DOIStrip]{\\doi}</a>\\end{doi}__NEWLINE__" +
             "\\begin{url}<BR>URL <a href=\"\\url\">\\url</a>\\end{url}__NEWLINE__" +
-            "\\begin{abstract}<BR><BR><b>Abstract: </b>\\format[HTMLChars]{\\abstract} \\end{abstract}__NEWLINE__" +
+            "\\begin{abstract}<BR><BR><b>Abstract: </b>\\format[HTMLChars(preserveMath)]{\\abstract} \\end{abstract}__NEWLINE__" +
             "\\begin{owncitation}<BR><BR><b>Own citation: </b>\\format[HTMLChars]{\\owncitation} \\end{owncitation}__NEWLINE__" +
-            "\\begin{comment}<BR><BR><b>Comment: </b>\\format[Markdown,HTMLChars(keepCurlyBraces)]{\\comment}\\end{comment}__NEWLINE__" +
+            "\\begin{comment}<BR><BR><b>Comment: </b>\\format[Markdown,HTMLChars(keepCurlyBraces,preserveMath)]{\\comment}\\end{comment}__NEWLINE__" +
             "</font>__NEWLINE__";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TextBasedPreviewLayout.class);

--- a/jablib/src/test/java/org/jabref/logic/layout/format/HTMLCharsTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/HTMLCharsTest.java
@@ -96,6 +96,41 @@ class HTMLCharsTest {
         assertEquals(expected, layout.format(input));
     }
 
+    private static Stream<Arguments> providePreserveMathData() {
+        return Stream.of(
+                // TeX spans (including their \commands) survive verbatim for a downstream renderer,
+                // instead of being stripped/mangled as in the default equations() cases above
+                Arguments.of("$E=mc^2$", "$E=mc^2$"),
+                Arguments.of("$\\sigma$", "$\\sigma$"),
+                Arguments.of("$\\frac{a}{b}$", "$\\frac{a}{b}$"),
+                Arguments.of("$$\\int_0^1 x\\,dx$$", "$$\\int_0^1 x\\,dx$$"),
+                Arguments.of("\\(a+b\\)", "\\(a+b\\)"),
+                // only HTML-special characters inside the span are escaped
+                Arguments.of("$a&lt;b$", "$a<b$"),
+                // text around the span is still converted (LaTeX accent -> HTML entity)
+                Arguments.of("M&ouml;nch $x$", "M\\\"onch $x$"),
+                // an escaped \$ is a literal dollar (not a delimiter) and does not corrupt real math
+                Arguments.of("cost &dollar;5 and $x=5$", "cost \\$5 and $x=5$"),
+                Arguments.of("no math here", "no math here")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("providePreserveMathData")
+    void preserveMath(String expected, String input) {
+        ParamLayoutFormatter preserving = new HTMLChars();
+        preserving.setArgument("preserveMath");
+        assertEquals(expected, preserving.format(input));
+    }
+
+    @Test
+    void combinedArgumentEnablesBothFlags() {
+        // The layout engine passes "keepCurlyBraces,preserveMath" as a single argument
+        ParamLayoutFormatter combined = new HTMLChars();
+        combined.setArgument("keepCurlyBraces,preserveMath");
+        assertEquals("{x} $\\sigma$", combined.format("{x} $\\sigma$"));
+    }
+
     private static Stream<Arguments> provideNewLineTestData() {
         return Stream.of(
                 Arguments.of("a<br>b", "a\nb"),


### PR DESCRIPTION
### Related issues and pull requests

Depends on JabRef/html-to-node#7 (adds the `renderMath` support this PR turns on). Originates from the math-in-preview request in #16145.

### PR Description

🤖 Enables TeX math rendering in the entry preview. `PreviewViewer` turns on html-to-node's `renderMath`, and the default preview layout runs the abstract and comment through a new opt-in `HTMLChars(preserveMath)` argument. That argument lifts `$…$` / `$$…$$` / `\(…\)` / `\[…\]` spans out before the formatter's LaTeX-command handling (which otherwise strips or mangles them, e.g. `$\sigma$` → `$$`) and splices them back verbatim — only `<`, `>`, `&` escaped — so the renderer receives intact TeX. The shared `HTMLChars` behaviour used by exports is unchanged. A preferences migration applies the same switch to existing custom preview styles, and JLaTeXMath (pulled in transitively via html-to-node) is registered as a proper JPMS module with its font companion jars merged.

This is a **draft**: it depends on JabRef/html-to-node#7 being merged and its `0.1.0-SNAPSHOT` republished before CI can resolve `withRenderMath`; until then the build only succeeds locally with `-PuseMavenLocal`. Remaining steps once #7 lands: add a `CHANGELOG.md` entry and requirements doc, attach the required screenshots, and run the full `check` / `checkstyle` / `modernizer` / `javadoc` suite.

**Analogies**

Like honey, this change is sweet in small amounts — a crisp equation where raw `$…$` used to sit. Like chocolate, it melts the delimiters away cleanly, but only if handled with care, or it smears (hence the deliberate span-protection instead of letting the formatter chew the TeX). And like the moon, the math was always there in the field text, orbiting unseen; this PR just turns the preview to face it so it finally shows.

jabref-contrib-policy:4.2:reviewed​:ok

### Steps to test

1. Add or edit an entry whose `abstract` (or `comment`) contains TeX math, for example:
   `The relation $E=mc^2$ and the integral $$\int_{-\infty}^{\infty} e^{-x^2}\,dx = \sqrt{\pi}$$, with a fraction $\frac{a}{b}$. Prices like \$5 stay literal.`
2. Open the entry preview (default preview style).
3. Expect: the `$…$` and `$$…$$` spans render as typeset equations, `\$5` shows as a literal `$` (not math), and non-math LaTeX such as accents still converts as before.

_Screenshot of the rendered preview to be attached (the layout → html-to-node pipeline renders `$E=mc^2$`, the Gaussian integral, `$\frac{a}{b}$`, and a literal `$5`)._

### AI usage

Claude Code (model claude-opus-4-8).

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [/] No `== null` / `!= null` checks — none added in this diff.
- [/] No `Objects.requireNonNull(...)` — none added.
- [/] New classes annotated with `@NullMarked` — no new classes added (only methods/fields on existing `HTMLChars`).
- [/] `Optional` consumed with `ifPresent`/… — no `Optional` in the diff.
- [/] `StringUtil.isBlank(...)` — no blank checks in the diff.

### Exceptions

- [/] No `catch (Exception e)` — no catches added.
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — none added.
- [/] Logged exceptions passed as last logger argument — no logging added.

### Style and idioms

- [/] New `BibEntry` objects built with withers — no `BibEntry` construction.
- [x] Modern Java used — precompiled `Pattern` constant; no legacy idioms introduced.
- [x] Regexes use a precompiled `Pattern.compile(...)` constant — `MATH_SPAN` is a `static final Pattern`.
- [/] Background work uses `BackgroundTask` — no background work.
- [x] No commented-out code, no trivial comments, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax (`` `code` ``, `[Type]`), not `{@code}`/`{@link}`.

### User-facing text

- [/] All user-facing text localized — no user-facing strings added (layout format directives + an internal formatter flag).
- [/] Sentence case / no trailing `!` / no trailing `:` — n/a.
- [/] Variance expressed with placeholders — n/a.

### Security

- [x] User-controlled data HTML-escaped — reinserted math spans (field content) are escaped for `<`, `>`, `&` via `escapeHtmlSpecials` before entering the HTML preview.

### Tests

- [x] Behavior changes in `logic` have added/updated tests — `HTMLCharsTest` (`preserveMath`, combined argument) and `GuiPreferencesMigrationsTest`.
- [x] Tests assert contents with plain JUnit `assertEquals`, no `@DisplayName`, do not catch exceptions, no manual temp dirs.

## 2. Verification commands

- [ ] `./gradlew :jablib:check` — not yet run (draft); ran targeted `HTMLCharsTest` + `GuiPreferencesMigrationsTest` + `:jabgui:compileJava`, all green (with `-PuseMavenLocal`).
- [ ] `./gradlew checkstyleMain checkstyleTest checkstyleJmh` — not yet run (draft).
- [ ] `./gradlew modernizer` — not yet run (draft).
- [x] `./gradlew rewriteRun` reports no changes — ran, clean.
- [ ] `./gradlew javadoc` — not yet run (draft).
- [/] `markdownlint` — no Markdown changed.
- [/] IntelliJ format docker image — `idea format` applied locally against `.idea/codeStyles/Project.xml`.

## 3. Documentation

- [ ] `CHANGELOG.md` entry — TODO (draft; user-visible change).
- [/] Searched issues for a related one — no confident JabRef issue match; kept as a reference to #16145, no `closes`.
- [ ] Requirement added to `docs/requirements/` — TODO (draft; new feature).
- [/] Developer documentation — no architecture change beyond the documented formatter flag.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file`.
- [ ] `CHANGELOG.md` `TODO` placeholder replaced with the PR number — no CHANGELOG entry yet (draft).

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [ ] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [ ] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
