### PR TITLE
Impprove latex2unicode preview rendering for super and subscript

### DIFF
--- a/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -298,6 +298,7 @@ public class PreferencesMigrations {
         String migratedStyle = currentPreviewStyle.replace("\\begin{review}<BR><BR><b>Review: </b> \\format[HTMLChars]{\\review} \\end{review}", "\\begin{comment}<BR><BR><b>Comment: </b> \\format[Markdown,HTMLChars]{\\comment} \\end{comment}")
                                                   .replace("\\format[HTMLChars]{\\comment}", "\\format[Markdown,HTMLChars]{\\comment}")
                                                   .replace("\\format[Markdown,HTMLChars]{\\comment}", "\\format[Markdown,HTMLChars(keepCurlyBraces)]{\\comment}")
+                                                  .replace("\\format[HTMLChars]{\\abstract}", "\\format[LatexToUnicode,HTMLChars]{\\abstract}")
                                                   .replace("<b><i>\\bibtextype</i><a name=\"\\bibtexkey\">\\begin{bibtexkey} (\\bibtexkey)</a>", "<b><i>\\bibtextype</i><a name=\"\\citationkey\">\\begin{citationkey} (\\citationkey)</a>")
                                                   .replace("\\end{bibtexkey}</b><br>__NEWLINE__", "\\end{citationkey}</b><br>__NEWLINE__")
                                                   .replace("\\end{pages}__NEWLINE__\\begin{abstract}", """

--- a/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
+++ b/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
@@ -92,7 +92,7 @@ class GuiPreferencesMigrationsTest {
                 \\begin{pages}<BR> p. \\format[FormatPagesForHTML]{\\pages}\\end{pages}__NEWLINE__\
                 \\begin{doi}<BR>doi <a href="https://doi.org/\\format[DOIStrip]{\\doi}">\\format[DOIStrip]{\\doi}</a>\\end{doi}__NEWLINE__\
                 \\begin{url}<BR>URL <a href="\\url">\\url</a>\\end{url}__NEWLINE__\
-                \\begin{abstract}<BR><BR><b>Abstract: </b>\\format[HTMLChars]{\\abstract} \\end{abstract}__NEWLINE__""";
+                \\begin{abstract}<BR><BR><b>Abstract: </b>\\format[LatexToUnicode,HTMLChars]{\\abstract} \\end{abstract}__NEWLINE__""";
 
         when(preferences.get(eq(JabRefGuiPreferences.PREVIEW_STYLE), anyString())).thenReturn(oldPreviewStyle);
 
@@ -102,8 +102,8 @@ class GuiPreferencesMigrationsTest {
     }
 
     @Test
-    void previewStyleUnchangedWhenMigrationPatternIsMissing() {
-        String unchangedPreviewStyle = """
+    void previewStyleAbstractFormatterMigratesWhenOtherPatternsAreMissing() {
+        String oldPreviewStyle = """
                 <font face="sans-serif">__NEWLINE__\
                 Custom preview style with no migration patterns.__NEWLINE__\
                 \\begin{title}<BR><b>\\format[HTMLChars]{\\title}</b>\\end{title}__NEWLINE__\
@@ -112,11 +112,20 @@ class GuiPreferencesMigrationsTest {
                 \\begin{abstract}<BR><BR><b>Abstract: </b>\\format[HTMLChars]{\\abstract} \\end{abstract}__NEWLINE__\
                 </font>__NEWLINE__""";
 
-        when(preferences.get(eq(JabRefGuiPreferences.PREVIEW_STYLE), anyString())).thenReturn(unchangedPreviewStyle);
+        String migratedPreviewStyle = """
+                <font face="sans-serif">__NEWLINE__\
+                Custom preview style with no migration patterns.__NEWLINE__\
+                \\begin{title}<BR><b>\\format[HTMLChars]{\\title}</b>\\end{title}__NEWLINE__\
+                \\begin{pages}<BR> p. \\format[FormatPagesForHTML]{\\pages}\\end{pages}__NEWLINE__\
+                \\begin{note}<BR>\\format[HTMLChars]{\\note}\\end{note}__NEWLINE__\
+                \\begin{abstract}<BR><BR><b>Abstract: </b>\\format[LatexToUnicode,HTMLChars]{\\abstract} \\end{abstract}__NEWLINE__\
+                </font>__NEWLINE__""";
+
+        when(preferences.get(eq(JabRefGuiPreferences.PREVIEW_STYLE), anyString())).thenReturn(oldPreviewStyle);
 
         PreferencesMigrations.upgradePreviewStyle(preferences);
 
-        verify(preferences).put(JabRefGuiPreferences.PREVIEW_STYLE, unchangedPreviewStyle);
+        verify(preferences).put(JabRefGuiPreferences.PREVIEW_STYLE, migratedPreviewStyle);
     }
 
     @Test

--- a/jablib/src/main/java/org/jabref/logic/preview/TextBasedPreviewLayout.java
+++ b/jablib/src/main/java/org/jabref/logic/preview/TextBasedPreviewLayout.java
@@ -35,7 +35,7 @@ public final class TextBasedPreviewLayout implements PreviewLayout {
             "\\begin{pages}<BR> p. \\format[FormatPagesForHTML]{\\pages}\\end{pages}__NEWLINE__" +
             "\\begin{doi}<BR>doi <a href=\"https://doi.org/\\format[DOIStrip]{\\doi}\">\\format[DOIStrip]{\\doi}</a>\\end{doi}__NEWLINE__" +
             "\\begin{url}<BR>URL <a href=\"\\url\">\\url</a>\\end{url}__NEWLINE__" +
-            "\\begin{abstract}<BR><BR><b>Abstract: </b>\\format[HTMLChars]{\\abstract} \\end{abstract}__NEWLINE__" +
+            "\\begin{abstract}<BR><BR><b>Abstract: </b>\\format[LatexToUnicode,HTMLChars]{\\abstract} \\end{abstract}__NEWLINE__" +
             "\\begin{owncitation}<BR><BR><b>Own citation: </b>\\format[HTMLChars]{\\owncitation} \\end{owncitation}__NEWLINE__" +
             "\\begin{comment}<BR><BR><b>Comment: </b>\\format[Markdown,HTMLChars(keepCurlyBraces)]{\\comment}\\end{comment}__NEWLINE__" +
             "</font>__NEWLINE__";

--- a/jablib/src/main/java/org/jabref/model/strings/LatexToUnicodeAdapter.java
+++ b/jablib/src/main/java/org/jabref/model/strings/LatexToUnicodeAdapter.java
@@ -1,9 +1,13 @@
 package org.jabref.model.strings;
 
 import java.text.Normalizer;
+import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.tomtung.latex2unicode.LaTeX2Unicode;
@@ -15,6 +19,8 @@ public class LatexToUnicodeAdapter {
     private static final int CACHE_SIZE = 50_000;
 
     private static final Pattern UNDERSCORE_MATCHER = Pattern.compile("_(?!\\{)");
+    private static final Pattern TEXT_LIKE_COMMAND_MATCHER = Pattern.compile("\\\\(?:text|mathrm|operatorname|mathsf)\\{([^{}]*)}");
+    private static final Pattern MATHSF_SINGLE_TOKEN_MATCHER = Pattern.compile("\\\\mathsf\\s+([\\p{L}\\p{N}])");
 
     private static final Pattern TILDE_MATCHER = Pattern.compile("(?<!\\\\)~");
 
@@ -23,6 +29,27 @@ public class LatexToUnicodeAdapter {
     private static final String REPLACEMENT_CHAR = "\uFFFD";
 
     private static final Pattern UNDERSCORE_PLACEHOLDER_MATCHER = Pattern.compile(REPLACEMENT_CHAR);
+    private static final Pattern SCRIPT_FALLBACK_MATCHER = Pattern.compile("([\\^_])\\(([^()]*)\\)");
+    private static final BiMap<Character, Character> ASCII_TO_SUBSCRIPT = createAsciiToSubscriptMap();
+    private static final BiMap<Character, Character> ASCII_TO_SUPERSCRIPT = createAsciiToSuperscriptMap();
+    private static final Map<Character, String> SPECIAL_SUBSCRIPT_TO_ASCII = Map.ofEntries(
+            Map.entry('ₔ', "schwa"),
+            Map.entry('ᵦ', "beta"),
+            Map.entry('ᵧ', "gamma"),
+            Map.entry('ᵨ', "rho"),
+            Map.entry('ᵩ', "phi"),
+            Map.entry('ᵪ', "chi"));
+    private static final Map<Character, String> SPECIAL_SUPERSCRIPT_TO_ASCII = Map.ofEntries(
+            Map.entry('ᵅ', "alpha"),
+            Map.entry('ᵝ', "beta"),
+            Map.entry('ᵞ', "gamma"),
+            Map.entry('ᵟ', "delta"),
+            Map.entry('ᶿ', "theta"),
+            Map.entry('ᶥ', "iota"),
+            Map.entry('ᵠ', "phi"),
+            Map.entry('ᵡ', "chi"),
+            Map.entry('ᵋ', "epsilon"),
+            Map.entry('ᶲ', "Phi"));
     private static final Cache<String, String> FORMAT_CACHE = Caffeine.newBuilder()
                                                                       .maximumSize(CACHE_SIZE)
                                                                       .build();
@@ -44,14 +71,228 @@ public class LatexToUnicodeAdapter {
     /// @param inField a String containing LaTeX
     /// @return an `Optional<String>` with LaTeX resolved into Unicode or `empty` on failure.
     public static Optional<String> parse(@NonNull String inField) {
-        String toFormat = TILDE_MATCHER.matcher(inField).replaceAll(NO_BREAK_SPACE);
+        String toFormat = stripSimpleTextCommands(inField);
+        toFormat = TILDE_MATCHER.matcher(toFormat).replaceAll(NO_BREAK_SPACE);
         toFormat = UNDERSCORE_MATCHER.matcher(toFormat).replaceAll(REPLACEMENT_CHAR);
         Parsed<String> parsingResult = LaTeX2Unicode.parse(toFormat);
         if (parsingResult instanceof Parsed.Success) {
             String text = parsingResult.get().value();
             toFormat = Normalizer.normalize(text, Normalizer.Form.NFC);
-            return Optional.of(UNDERSCORE_PLACEHOLDER_MATCHER.matcher(toFormat).replaceAll("_"));
+            toFormat = UNDERSCORE_PLACEHOLDER_MATCHER.matcher(toFormat).replaceAll("_");
+            return Optional.of(makeFallbackScriptsReadable(toFormat));
         }
         return Optional.empty();
+    }
+
+    private static String stripSimpleTextCommands(String input) {
+        String result = input;
+        String updated = replaceUntilStable(result, TEXT_LIKE_COMMAND_MATCHER, "$1");
+        result = updated;
+        updated = replaceUntilStable(result, MATHSF_SINGLE_TOKEN_MATCHER, "$1");
+        result = updated;
+        return result;
+    }
+
+    private static String replaceUntilStable(String input, Pattern pattern, String replacement) {
+        String result = input;
+        String updated = pattern.matcher(result).replaceAll(replacement);
+        while (!updated.equals(result)) {
+            result = updated;
+            updated = pattern.matcher(result).replaceAll(replacement);
+        }
+        return result;
+    }
+
+    private static String makeFallbackScriptsReadable(String input) {
+        Matcher matcher = SCRIPT_FALLBACK_MATCHER.matcher(input);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String scriptMarker = matcher.group(1);
+            String scriptContent = matcher.group(2);
+            String readableScriptContent = makeScriptContentReadable(scriptContent);
+            String replacement = tryMakeCompactScript(scriptMarker, scriptContent)
+                    .orElseGet(() -> formatNonCompactScript(scriptMarker, readableScriptContent));
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
+    private static String formatNonCompactScript(String scriptMarker, String readableScriptContent) {
+        if (readableScriptContent.codePointCount(0, readableScriptContent.length()) == 1) {
+            return scriptMarker + readableScriptContent;
+        }
+
+        return scriptMarker + "(" + readableScriptContent + ")";
+    }
+
+    private static Optional<String> tryMakeCompactScript(String scriptMarker, String scriptContent) {
+        if ("^".equals(scriptMarker)) {
+            return tryMapScriptContent(scriptContent, ASCII_TO_SUPERSCRIPT, ASCII_TO_SUBSCRIPT.inverse().keySet());
+        }
+
+        if ("_".equals(scriptMarker)) {
+            return tryMapScriptContent(scriptContent, ASCII_TO_SUBSCRIPT, ASCII_TO_SUPERSCRIPT.inverse().keySet());
+        }
+
+        return Optional.empty();
+    }
+
+    private static Optional<String> tryMapScriptContent(String scriptContent, Map<Character, Character> directMappings, java.util.Set<Character> passthroughCharacters) {
+        StringBuilder result = new StringBuilder();
+        for (int index = 0; index < scriptContent.length(); index++) {
+            char currentCharacter = scriptContent.charAt(index);
+            Character mappedCharacter = directMappings.get(currentCharacter);
+            if (mappedCharacter != null) {
+                result.append(mappedCharacter);
+            } else if (passthroughCharacters.contains(currentCharacter)) {
+                result.append(currentCharacter);
+            } else {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(result.toString());
+    }
+
+    private static String makeScriptContentReadable(String scriptContent) {
+        StringBuilder result = new StringBuilder();
+        for (int index = 0; index < scriptContent.length(); index++) {
+            char currentCharacter = scriptContent.charAt(index);
+            Character asciiSubscript = ASCII_TO_SUBSCRIPT.inverse().get(currentCharacter);
+            if (asciiSubscript != null) {
+                result.append('_').append(asciiSubscript);
+                continue;
+            }
+
+            String specialSubscript = SPECIAL_SUBSCRIPT_TO_ASCII.get(currentCharacter);
+            if (specialSubscript != null) {
+                result.append('_').append(specialSubscript);
+                continue;
+            }
+
+            Character asciiSuperscript = ASCII_TO_SUPERSCRIPT.inverse().get(currentCharacter);
+            if (asciiSuperscript != null) {
+                result.append('^').append(asciiSuperscript);
+                continue;
+            }
+
+            String specialSuperscript = SPECIAL_SUPERSCRIPT_TO_ASCII.get(currentCharacter);
+            if (specialSuperscript != null) {
+                result.append('^').append(specialSuperscript);
+                continue;
+            }
+
+            result.append(currentCharacter);
+        }
+        return result.toString();
+    }
+
+    private static BiMap<Character, Character> createAsciiToSubscriptMap() {
+        BiMap<Character, Character> map = HashBiMap.create();
+        map.put('0', '₀');
+        map.put('1', '₁');
+        map.put('2', '₂');
+        map.put('3', '₃');
+        map.put('4', '₄');
+        map.put('5', '₅');
+        map.put('6', '₆');
+        map.put('7', '₇');
+        map.put('8', '₈');
+        map.put('9', '₉');
+        map.put('+', '₊');
+        map.put('-', '₋');
+        map.put('=', '₌');
+        map.put('(', '₍');
+        map.put(')', '₎');
+        map.put('a', 'ₐ');
+        map.put('e', 'ₑ');
+        map.put('o', 'ₒ');
+        map.put('x', 'ₓ');
+        map.put('i', 'ᵢ');
+        map.put('j', 'ⱼ');
+        map.put('r', 'ᵣ');
+        map.put('u', 'ᵤ');
+        map.put('v', 'ᵥ');
+        map.put('β', 'ᵦ');
+        map.put('γ', 'ᵧ');
+        map.put('ρ', 'ᵨ');
+        map.put('φ', 'ᵩ');
+        map.put('χ', 'ᵪ');
+        return map;
+    }
+
+    private static BiMap<Character, Character> createAsciiToSuperscriptMap() {
+        BiMap<Character, Character> map = HashBiMap.create();
+        map.put('0', '⁰');
+        map.put('1', '¹');
+        map.put('2', '²');
+        map.put('3', '³');
+        map.put('4', '⁴');
+        map.put('5', '⁵');
+        map.put('6', '⁶');
+        map.put('7', '⁷');
+        map.put('8', '⁸');
+        map.put('9', '⁹');
+        map.put('+', '⁺');
+        map.put('-', '⁻');
+        map.put('=', '⁼');
+        map.put('(', '⁽');
+        map.put(')', '⁾');
+        map.put('A', 'ᴬ');
+        map.put('B', 'ᴮ');
+        map.put('D', 'ᴰ');
+        map.put('E', 'ᴱ');
+        map.put('G', 'ᴳ');
+        map.put('H', 'ᴴ');
+        map.put('I', 'ᴵ');
+        map.put('J', 'ᴶ');
+        map.put('K', 'ᴷ');
+        map.put('L', 'ᴸ');
+        map.put('M', 'ᴹ');
+        map.put('N', 'ᴺ');
+        map.put('O', 'ᴼ');
+        map.put('P', 'ᴾ');
+        map.put('R', 'ᴿ');
+        map.put('T', 'ᵀ');
+        map.put('U', 'ᵁ');
+        map.put('V', 'ⱽ');
+        map.put('W', 'ᵂ');
+        map.put('a', 'ᵃ');
+        map.put('b', 'ᵇ');
+        map.put('c', 'ᶜ');
+        map.put('d', 'ᵈ');
+        map.put('e', 'ᵉ');
+        map.put('f', 'ᶠ');
+        map.put('g', 'ᵍ');
+        map.put('h', 'ʰ');
+        map.put('i', 'ⁱ');
+        map.put('j', 'ʲ');
+        map.put('k', 'ᵏ');
+        map.put('l', 'ˡ');
+        map.put('m', 'ᵐ');
+        map.put('n', 'ⁿ');
+        map.put('o', 'ᵒ');
+        map.put('p', 'ᵖ');
+        map.put('r', 'ʳ');
+        map.put('s', 'ˢ');
+        map.put('t', 'ᵗ');
+        map.put('u', 'ᵘ');
+        map.put('v', 'ᵛ');
+        map.put('w', 'ʷ');
+        map.put('x', 'ˣ');
+        map.put('y', 'ʸ');
+        map.put('z', 'ᶻ');
+        map.put('α', 'ᵅ');
+        map.put('β', 'ᵝ');
+        map.put('γ', 'ᵞ');
+        map.put('δ', 'ᵟ');
+        map.put('θ', 'ᶿ');
+        map.put('ι', 'ᶥ');
+        map.put('φ', 'ᵠ');
+        map.put('χ', 'ᵡ');
+        map.put('∊', 'ᵋ');
+        map.put('Φ', 'ᶲ');
+        map.put('∘', '°');
+        return map;
     }
 }

--- a/jablib/src/main/java/org/jabref/model/strings/LatexToUnicodeAdapter.java
+++ b/jablib/src/main/java/org/jabref/model/strings/LatexToUnicodeAdapter.java
@@ -6,11 +6,11 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.tomtung.latex2unicode.LaTeX2Unicode;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import fastparse.Parsed;
 import org.jspecify.annotations.NonNull;
 
@@ -78,8 +78,9 @@ public class LatexToUnicodeAdapter {
         if (parsingResult instanceof Parsed.Success) {
             String text = parsingResult.get().value();
             toFormat = Normalizer.normalize(text, Normalizer.Form.NFC);
+            toFormat = makeFallbackScriptsReadable(toFormat);
             toFormat = UNDERSCORE_PLACEHOLDER_MATCHER.matcher(toFormat).replaceAll("_");
-            return Optional.of(makeFallbackScriptsReadable(toFormat));
+            return Optional.of(toFormat);
         }
         return Optional.empty();
     }

--- a/jablib/src/test/java/org/jabref/logic/layout/LayoutTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/LayoutTest.java
@@ -109,6 +109,20 @@ class LayoutTest {
                 layoutText);
     }
 
+    @Test
+    void previewAbstractCanRenderLatexMathAsUnicodeBeforeHtmlEscaping() throws IOException {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.ABSTRACT, "Much progress has been made in classifying when the weak Lefschetz property holds for $A=\\mathbb{F}[x,y,z]/I$ where $\\text{char}(\\mathbb{F})=0$ and $I=(x^{d_{1}},y^{d_{2}},z^{d_{3}},x^{a_{1}}y^{a_{2}}z^{a_{3}})$.");
+
+        String layoutText = layout(
+                "<font face=\"arial\">\\begin{abstract}<BR><BR><b>Abstract: </b>\\format[LatexToUnicode,HTMLChars]{\\abstract}\\end{abstract}</font>",
+                entry);
+
+        assertEquals(
+                "<font face=\"arial\"><BR><BR><b>Abstract: </b>Much progress has been made in classifying when the weak Lefschetz property holds for A=𝔽[x,y,z]/I where char(𝔽)=0 and I=(xᵈ₁,yᵈ₂,zᵈ₃,xᵃ₁yᵃ₂zᵃ₃).</font>",
+                layoutText);
+    }
+
     @ParameterizedTest
     @CsvSource(
             delimiterString = "->",

--- a/jablib/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -58,6 +58,18 @@ class LatexToUnicodeFormatterTest {
     }
 
     @Test
+    void equationsWithNestedScriptsRemainReadable() {
+        assertEquals("Much progress has been made in classifying when the weak Lefschetz property holds for A=𝔽[x,y,z]/I where char(𝔽)=0 and I=(xᵈ₁,yᵈ₂,zᵈ₃,xᵃ₁yᵃ₂zᵃ₃)",
+                formatter.format("Much progress has been made in classifying when the weak Lefschetz property holds for $A=\\mathbb{F}[x,y,z]/I$ where $\\text{char}(\\mathbb{F})=0$ and $I=(x^{d_{1}},y^{d_{2}},z^{d_{3}},x^{a_{1}}y^{a_{2}}z^{a_{3}})$"));
+    }
+
+    @Test
+    void equationsWithTextLikeMathCommandsRemainReadable() {
+        assertEquals("Let R be a standard graded algebra over an infinite field k, and let 𝔹_ℚ(R) and 𝔹_ℚᵖᵘʳᵉ(R) denote the rational cones spanned by the Betti tables of all finitely generated R-modules and of those with pure resolutions, respectively. We establish several necessary conditions for the equality 𝔹_ℚ(R) = 𝔹_ℚᵖᵘʳᵉ(R). When edim(R)≥ 2, we prove that k has a pure resolution if and only if it has a linear resolution, and consequently, if the extremal rays of 𝔹_ℚ(R) are pure, then R is Koszul and good (in the sense of Roos). We show that if R has depth zero, it must be Artinian for the equality of the two cones to hold. For rings with linear pairs of exact zerodivisors, we show that the equality of the cones implies that the h-polynomial has degree at most 2, and use it to characterize generic Gorenstein Artin algebras satisfying 𝔹_ℚ(R) = 𝔹_ℚᵖᵘʳᵉ(R). We also characterize algebras whose extremal rays are exactly the Betti tables of shifts of R/𝔪ʲ and of pure modules M with codim(M)=pdim(M): apart from polynomial rings, these are precisely Cohen–Macaulay algebras of dimension at most one with minimal multiplicity. In addition, we obtain a characterization of Cohen–Macaulay algebras of minimal multiplicity in terms of the extremal rays of the Betti cone of maximal Cohen–Macaulay modules.",
+                formatter.format("Let $R$ be a standard graded algebra over an infinite field $\\mathsf k$, and let $\\mathbb{B}_{\\mathbb{Q}}(R)$ and $\\mathbb{B}_{\\mathbb{Q}}^{\\mathrm{pure}}(R)$ denote the rational cones spanned by the Betti tables of all finitely generated $R$-modules and of those with pure resolutions, respectively. We establish several necessary conditions for the equality $\\mathbb{B}_{\\mathbb{Q}}(R) = \\mathbb{B}_{\\mathbb{Q}}^{\\mathrm{pure}}(R)$. When $\\operatorname{edim}(R)\\ge 2$, we prove that $\\mathsf k$ has a pure resolution if and only if it has a linear resolution, and consequently, if the extremal rays of $\\mathbb{B}_{\\mathbb{Q}}(R)$ are pure, then $R$ is Koszul and good (in the sense of Roos). We show that if $R$ has depth zero, it must be Artinian for the equality of the two cones to hold. For rings with linear pairs of exact zerodivisors, we show that the equality of the cones implies that the $h$-polynomial has degree at most $2$, and use it to characterize generic Gorenstein Artin algebras satisfying $\\mathbb{B}_{\\mathbb{Q}}(R) = \\mathbb{B}_{\\mathbb{Q}}^{\\mathrm{pure}}(R)$. We also characterize algebras whose extremal rays are exactly the Betti tables of shifts of $R/\\mathfrak m^j$ and of pure modules $M$ with $\\operatorname{codim}(M)=\\operatorname{pdim}(M)$: apart from polynomial rings, these are precisely Cohen--Macaulay algebras of dimension at most one with minimal multiplicity. In addition, we obtain a characterization of Cohen--Macaulay algebras of minimal multiplicity in terms of the extremal rays of the Betti cone of maximal Cohen--Macaulay modules."));
+    }
+
+    @Test
     void formatExample() {
         assertEquals("Mönch", formatter.format(formatter.getExampleInput()));
     }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -70,6 +70,11 @@ class LatexToUnicodeFormatterTest {
     }
 
     @Test
+    void literalUnderscoreParenthesesRemainLiteral() {
+        assertEquals("name_(a) and x_(1)", formatter.format("name_(a) and x_(1)"));
+    }
+
+    @Test
     void formatExample() {
         assertEquals("Mönch", formatter.format(formatter.getExampleInput()));
     }

--- a/jablib/src/test/java/org/jabref/model/entry/BibEntryTest.java
+++ b/jablib/src/test/java/org/jabref/model/entry/BibEntryTest.java
@@ -244,6 +244,28 @@ class BibEntryTest {
     }
 
     @Test
+    void getFieldOrAliasLatexFreeAbstractWithNestedMathScriptsRemainsReadable() {
+        entry.setField(StandardField.ABSTRACT, """
+                Much progress has been made in classifying when the weak Lefschetz property holds for $A=\\mathbb{F}[x,y,z]/I$ where $\\text{char}(\\mathbb{F})=0$ and $I=(x^{d_{1}},y^{d_{2}},z^{d_{3}},x^{a_{1}}y^{a_{2}}z^{a_{3}})$ is a monomial almost complete intersection. We connect this problem to the setting of two variables through a certain relation. In so doing, we are led to determine explicit formulas for the generators of the colon ideal $(x^{d_{1}},y^{d_{2}}):(x+y)^{a_{3}}$. With these generators in hand, we construct a matrix and show that failure of WLP for $A$ is dictated by the vanishing of a certain polynomial (namely the determinant of our matrix) when $A$ is level. We further show in the level case that a conjecture first posed by Migliore, Miró-Roig, and Nagel is true in a few new cases.
+                """);
+
+        assertEquals(Optional.of("""
+                Much progress has been made in classifying when the weak Lefschetz property holds for A=𝔽[x,y,z]/I where char(𝔽)=0 and I=(xᵈ₁,yᵈ₂,zᵈ₃,xᵃ₁yᵃ₂zᵃ₃) is a monomial almost complete intersection. We connect this problem to the setting of two variables through a certain relation. In so doing, we are led to determine explicit formulas for the generators of the colon ideal (xᵈ₁,yᵈ₂):(x+y)ᵃ₃. With these generators in hand, we construct a matrix and show that failure of WLP for A is dictated by the vanishing of a certain polynomial (namely the determinant of our matrix) when A is level. We further show in the level case that a conjecture first posed by Migliore, Miró-Roig, and Nagel is true in a few new cases.
+                """.stripTrailing()), entry.getFieldOrAliasLatexFree(StandardField.ABSTRACT).map(String::stripTrailing));
+    }
+
+    @Test
+    void getFieldOrAliasLatexFreeAbstractWithTextLikeMathCommandsRemainsReadable() {
+        entry.setField(StandardField.ABSTRACT, """
+                Let $R$ be a standard graded algebra over an infinite field $\\mathsf k$, and let $\\mathbb{B}_{\\mathbb{Q}}(R)$ and $\\mathbb{B}_{\\mathbb{Q}}^{\\mathrm{pure}}(R)$ denote the rational cones spanned by the Betti tables of all finitely generated $R$-modules and of those with pure resolutions, respectively. We establish several necessary conditions for the equality $\\mathbb{B}_{\\mathbb{Q}}(R) = \\mathbb{B}_{\\mathbb{Q}}^{\\mathrm{pure}}(R)$. When $\\operatorname{edim}(R)\\ge 2$, we prove that $\\mathsf k$ has a pure resolution if and only if it has a linear resolution, and consequently, if the extremal rays of $\\mathbb{B}_{\\mathbb{Q}}(R)$ are pure, then $R$ is Koszul and good (in the sense of Roos). We show that if $R$ has depth zero, it must be Artinian for the equality of the two cones to hold. For rings with linear pairs of exact zerodivisors, we show that the equality of the cones implies that the $h$-polynomial has degree at most $2$, and use it to characterize generic Gorenstein Artin algebras satisfying $\\mathbb{B}_{\\mathbb{Q}}(R) = \\mathbb{B}_{\\mathbb{Q}}^{\\mathrm{pure}}(R)$. We also characterize algebras whose extremal rays are exactly the Betti tables of shifts of $R/\\mathfrak m^j$ and of pure modules $M$ with $\\operatorname{codim}(M)=\\operatorname{pdim}(M)$: apart from polynomial rings, these are precisely Cohen--Macaulay algebras of dimension at most one with minimal multiplicity. In addition, we obtain a characterization of Cohen--Macaulay algebras of minimal multiplicity in terms of the extremal rays of the Betti cone of maximal Cohen--Macaulay modules.
+                """);
+
+        assertEquals(Optional.of("""
+                Let R be a standard graded algebra over an infinite field k, and let 𝔹_ℚ(R) and 𝔹_ℚᵖᵘʳᵉ(R) denote the rational cones spanned by the Betti tables of all finitely generated R-modules and of those with pure resolutions, respectively. We establish several necessary conditions for the equality 𝔹_ℚ(R) = 𝔹_ℚᵖᵘʳᵉ(R). When edim(R)≥ 2, we prove that k has a pure resolution if and only if it has a linear resolution, and consequently, if the extremal rays of 𝔹_ℚ(R) are pure, then R is Koszul and good (in the sense of Roos). We show that if R has depth zero, it must be Artinian for the equality of the two cones to hold. For rings with linear pairs of exact zerodivisors, we show that the equality of the cones implies that the h-polynomial has degree at most 2, and use it to characterize generic Gorenstein Artin algebras satisfying 𝔹_ℚ(R) = 𝔹_ℚᵖᵘʳᵉ(R). We also characterize algebras whose extremal rays are exactly the Betti tables of shifts of R/𝔪ʲ and of pure modules M with codim(M)=pdim(M): apart from polynomial rings, these are precisely Cohen–Macaulay algebras of dimension at most one with minimal multiplicity. In addition, we obtain a characterization of Cohen–Macaulay algebras of minimal multiplicity in terms of the extremal rays of the Betti cone of maximal Cohen–Macaulay modules.
+                """.stripTrailing()), entry.getFieldOrAliasLatexFree(StandardField.ABSTRACT).map(String::stripTrailing));
+    }
+
+    @Test
     void getAndAddToLinkedFileList() {
         List<LinkedFile> files = entry.getFiles();
         files.add(new LinkedFile("", Path.of(""), ""));


### PR DESCRIPTION
…ide math stuff

### Related issues and pull requests

Refs https://github.com/JabRef/jabref/issues/3644

### PR Description

> Tip: re-read your description before opening the pull request, then delete this line.

### Steps to test

Paste https://arxiv.org/abs/2603.11491 on the entry table
Use customized preview style and see that superscripts, etc., are rendered


### AI usage

GPT 5.4 
<img width="2362" height="932" alt="grafik" src="https://github.com/user-attachments/assets/db7af384-c97b-454c-bbd2-428674a0be2b" />




_____

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

<!-- AI: paste the full CHECKLIST.md here, every item marked. -->

</details>

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
