### PR TITLE
JabRef-Zotero Compatibility - C (Insert jabref-entrytype into meta.xml)

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -15,6 +15,7 @@ import org.jabref.gui.StateManager;
 import org.jabref.logic.JabRefException;
 import org.jabref.logic.citationstyle.CitationStyle;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.openoffice.CitationEntryTypeMetadata;
 import org.jabref.logic.openoffice.OpenOfficePreferences;
 import org.jabref.logic.openoffice.action.EditInsert;
 import org.jabref.logic.openoffice.action.EditMerge;
@@ -47,6 +48,8 @@ import org.jabref.model.openoffice.util.OOResult;
 import org.jabref.model.openoffice.util.OOVoidResult;
 
 import com.airhacks.afterburner.injection.Injector;
+import com.sun.star.beans.IllegalTypeException;
+import com.sun.star.beans.PropertyVetoException;
 import com.sun.star.comp.helper.BootstrapException;
 import com.sun.star.container.NoSuchElementException;
 import com.sun.star.lang.WrappedTargetException;
@@ -92,9 +95,19 @@ public class OOBibBase {
         testDialog(connection.selectDocument(autoSelectForSingle));
 
         if (isConnectedToDocument()) {
-            initializeCitationAdapter(this.getXTextDocument().get());
+            XTextDocument doc = this.getXTextDocument().get();
+            initializeCitationAdapter(doc);
+            storeZoteroEntryTypes(doc);
             dialogService.notify(Localization.lang("Connected to document") + ": "
                     + this.getCurrentDocumentTitle().orElse(""));
+        }
+    }
+
+    private void storeZoteroEntryTypes(XTextDocument doc) {
+        try {
+            CitationEntryTypeMetadata.storeZoteroEntryTypes(doc);
+        } catch (IllegalTypeException | NoDocumentException | PropertyVetoException | WrappedTargetException e) {
+            LOGGER.warn("Could not store Zotero citation entry type metadata", e);
         }
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -15,7 +15,7 @@ import org.jabref.gui.StateManager;
 import org.jabref.logic.JabRefException;
 import org.jabref.logic.citationstyle.CitationStyle;
 import org.jabref.logic.l10n.Localization;
-import org.jabref.logic.openoffice.CitationEntryTypeMetadata;
+import org.jabref.logic.openoffice.CitationEntryTypeMetadataManager;
 import org.jabref.logic.openoffice.OpenOfficePreferences;
 import org.jabref.logic.openoffice.action.EditInsert;
 import org.jabref.logic.openoffice.action.EditMerge;
@@ -105,7 +105,7 @@ public class OOBibBase {
 
     private void storeZoteroEntryTypes(XTextDocument doc) {
         try {
-            CitationEntryTypeMetadata.storeZoteroEntryTypes(doc);
+            CitationEntryTypeMetadataManager.storeZoteroEntryTypes(doc);
         } catch (IllegalTypeException | NoDocumentException | PropertyVetoException | WrappedTargetException e) {
             LOGGER.warn("Could not store Zotero citation entry type metadata", e);
         }

--- a/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
@@ -1,152 +1,32 @@
 package org.jabref.logic.openoffice;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.jabref.logic.util.strings.StringUtil;
-import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.types.EntryTypeFactory;
-import org.jabref.model.openoffice.uno.NoDocumentException;
-import org.jabref.model.openoffice.uno.UnoReferenceMark;
-import org.jabref.model.openoffice.uno.UnoUserDefinedProperty;
-
-import com.google.gson.Gson;
-import com.google.gson.JsonParseException;
-import com.sun.star.beans.IllegalTypeException;
-import com.sun.star.beans.PropertyVetoException;
-import com.sun.star.lang.WrappedTargetException;
-import com.sun.star.text.XTextDocument;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @NullMarked
-public class CitationEntryTypeMetadata {
+class CitationEntryTypeMetadata {
 
-    static final String PROPERTY_NAME = "jabref-entrytype";
+    static final int SCHEMA_VERSION = 1;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CitationEntryTypeMetadata.class);
-    private static final Gson GSON = new Gson();
-    private static final int SCHEMA_VERSION = 1;
+    int schemaVersion = SCHEMA_VERSION;
+    @Nullable Map<String, @Nullable CitationEntryType> citationTypeMap = new LinkedHashMap<>();
 
-    private CitationEntryTypeMetadata() {
-    }
-
-    public static void storeZoteroEntryTypes(XTextDocument document)
-            throws
-            IllegalTypeException,
-            NoDocumentException,
-            PropertyVetoException,
-            WrappedTargetException {
-        Map<String, String> entryTypesInMetaData = UnoUserDefinedProperty.getStringValue(document, PROPERTY_NAME)
-                                                                         .map(CitationEntryTypeMetadata::readEntryTypes)
-                                                                         .orElseGet(Map::of);
-        List<BibEntry> entries = parseZoteroEntries(UnoReferenceMark.getListOfNames(document), entryTypesInMetaData);
-        storeEntryTypes(document, entries);
-    }
-
-    public static void storeEntryTypes(XTextDocument document, List<BibEntry> entries)
-            throws
-            IllegalTypeException,
-            PropertyVetoException,
-            WrappedTargetException {
-        if (entries.isEmpty()) {
-            return;
-        }
-
-        Optional<String> existingMetadata = UnoUserDefinedProperty.getStringValue(document, PROPERTY_NAME);
-        String metadata = mergeEntryTypes(existingMetadata, entries);
-        UnoUserDefinedProperty.setStringProperty(document, PROPERTY_NAME, metadata);
-    }
-
-    static String mergeEntryTypes(Optional<String> existingMetadata, List<BibEntry> entries) {
-        EntryTypeMetadata metadata = existingMetadata
-                .flatMap(CitationEntryTypeMetadata::parseMetadata)
-                .orElseGet(EntryTypeMetadata::new);
-
-        Map<String, @Nullable CitationEntryType> citationTypeMap = getCitationTypeMap(metadata);
-        metadata.schemaVersion = SCHEMA_VERSION;
-
-        for (BibEntry entry : entries) {
-            entry.getCitationKey()
-                 .ifPresent(citationKey -> citationTypeMap.put(
-                         citationKey,
-                         new CitationEntryType(entry.getType().getName())));
-        }
-
-        return GSON.toJson(metadata);
-    }
-
-    static Map<String, String> readEntryTypes(String metadata) {
-        Optional<EntryTypeMetadata> parsedMetadata = parseMetadata(metadata);
-        if (parsedMetadata.isEmpty()) {
-            return Map.of();
-        }
-
-        EntryTypeMetadata entryTypeMetadata = parsedMetadata.get();
-        Map<String, @Nullable CitationEntryType> citationTypeMap = getCitationTypeMap(entryTypeMetadata);
-        Map<String, String> result = new LinkedHashMap<>(citationTypeMap.size());
-        for (Map.Entry<String, @Nullable CitationEntryType> entry : citationTypeMap.entrySet()) {
-            Optional.ofNullable(entry.getValue())
-                    .map(citationEntryType -> citationEntryType.jabrefEntryType)
-                    .filter(value -> !StringUtil.isBlank(value))
-                    .ifPresent(value -> result.put(entry.getKey(), value));
-        }
-        return result;
-    }
-
-    static List<BibEntry> parseZoteroEntries(List<String> referenceMarkNames, Map<String, String> entryTypesInMetaData) {
-        List<BibEntry> entries = new ArrayList<>();
-        for (String referenceMarkName : referenceMarkNames) {
-            if (ReferenceMark.isZoteroReferenceMarkName(referenceMarkName)) {
-                // If citation key is in metadata, then use the entry type in metadata
-                for (BibEntry entry : ZoteroCitationMarkParser.parse(referenceMarkName)) {
-                    entry.getCitationKey()
-                         .map(entryTypesInMetaData::get)
-                         .filter(value -> !StringUtil.isBlank(value))
-                         .map(EntryTypeFactory::parse)
-                         .ifPresent(entry::setType);
-                    entries.add(entry);
-                }
-            }
-        }
-        return entries;
-    }
-
-    private static Optional<EntryTypeMetadata> parseMetadata(String metadata) {
-        if (StringUtil.isBlank(metadata)) {
-            return Optional.empty();
-        }
-
-        try {
-            return Optional.of(GSON.fromJson(metadata, EntryTypeMetadata.class));
-        } catch (JsonParseException e) {
-            LOGGER.debug("Could not parse citation entry type metadata", e);
-            return Optional.empty();
-        }
-    }
-
-    private static Map<String, @Nullable CitationEntryType> getCitationTypeMap(EntryTypeMetadata metadata) {
-        Map<String, @Nullable CitationEntryType> citationTypeMap = Optional.ofNullable(metadata.citationTypeMap)
-                                                                           .orElseGet(LinkedHashMap::new);
-        metadata.citationTypeMap = citationTypeMap;
-        return citationTypeMap;
-    }
-
-    private static class EntryTypeMetadata {
-        int schemaVersion = SCHEMA_VERSION;
-        @Nullable Map<String, @Nullable CitationEntryType> citationTypeMap = new LinkedHashMap<>();
-    }
-
-    private static class CitationEntryType {
+    static class CitationEntryType {
         @Nullable String jabrefEntryType;
 
         CitationEntryType(String jabrefEntryType) {
             this.jabrefEntryType = jabrefEntryType;
         }
+    }
+
+    public static Map<String, @Nullable CitationEntryType> getCitationTypeMap(CitationEntryTypeMetadata metadata) {
+        Map<String, @Nullable CitationEntryType> citationTypeMap = Optional.ofNullable(metadata.citationTypeMap)
+                                                                           .orElseGet(LinkedHashMap::new);
+        metadata.citationTypeMap = citationTypeMap;
+        return citationTypeMap;
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
@@ -88,8 +88,9 @@ public class CitationEntryTypeMetadata {
         }
 
         EntryTypeMetadata entryTypeMetadata = parsedMetadata.get();
-        Map<String, String> result = new LinkedHashMap<>();
-        for (Map.Entry<String, @Nullable CitationEntryType> entry : getCitationTypeMap(entryTypeMetadata).entrySet()) {
+        Map<String, @Nullable CitationEntryType> citationTypeMap = getCitationTypeMap(entryTypeMetadata);
+        Map<String, String> result = new LinkedHashMap<>(citationTypeMap.size());
+        for (Map.Entry<String, @Nullable CitationEntryType> entry : citationTypeMap.entrySet()) {
             Optional.ofNullable(entry.getValue())
                     .map(citationEntryType -> citationEntryType.jabrefEntryType)
                     .filter(value -> !StringUtil.isBlank(value))

--- a/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
@@ -1,0 +1,207 @@
+package org.jabref.logic.openoffice;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.jabref.logic.util.strings.StringUtil;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.types.EntryTypeFactory;
+import org.jabref.model.openoffice.uno.NoDocumentException;
+import org.jabref.model.openoffice.uno.UnoReferenceMark;
+import org.jabref.model.openoffice.uno.UnoUserDefinedProperty;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import com.sun.star.beans.IllegalTypeException;
+import com.sun.star.beans.PropertyVetoException;
+import com.sun.star.lang.WrappedTargetException;
+import com.sun.star.text.XTextDocument;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@NullMarked
+public class CitationEntryTypeMetadata {
+
+    static final String PROPERTY_NAME = "jabref-entrytype";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CitationEntryTypeMetadata.class);
+    private static final Gson GSON = new Gson();
+    private static final int SCHEMA_VERSION = 1;
+
+    private CitationEntryTypeMetadata() {
+    }
+
+    public static void storeZoteroEntryTypes(XTextDocument document)
+            throws
+            IllegalTypeException,
+            NoDocumentException,
+            PropertyVetoException,
+            WrappedTargetException {
+        Map<String, String> entryTypesInMetaData = UnoUserDefinedProperty.getStringValue(document, PROPERTY_NAME)
+                                                                         .map(CitationEntryTypeMetadata::readEntryTypes)
+                                                                         .orElseGet(Map::of);
+        List<BibEntry> entries = parseZoteroEntries(UnoReferenceMark.getListOfNames(document), entryTypesInMetaData);
+        storeEntryTypes(document, entries);
+    }
+
+    public static void storeEntryTypes(XTextDocument document, List<BibEntry> entries)
+            throws
+            IllegalTypeException,
+            PropertyVetoException,
+            WrappedTargetException {
+        if (entries.isEmpty()) {
+            return;
+        }
+
+        Optional<String> existingMetadata = UnoUserDefinedProperty.getStringValue(document, PROPERTY_NAME);
+        String metadata = mergeEntryTypes(existingMetadata, entries);
+        UnoUserDefinedProperty.setStringProperty(document, PROPERTY_NAME, metadata);
+    }
+
+    static String mergeEntryTypes(Optional<String> existingMetadata, List<BibEntry> entries) {
+        EntryTypeMetadata metadata = existingMetadata
+                .flatMap(CitationEntryTypeMetadata::parseMetadata)
+                .orElseGet(EntryTypeMetadata::new);
+
+        Map<String, CitationEntryType> citationTypeMap = getCitationTypeMap(metadata);
+        metadata.schemaVersion = SCHEMA_VERSION;
+
+        for (BibEntry entry : entries) {
+            entry.getCitationKey()
+                 .ifPresent(citationKey -> citationTypeMap.put(
+                         citationKey,
+                         new CitationEntryType(entry.getType().getName())));
+        }
+
+        return GSON.toJson(metadata);
+    }
+
+    static Map<String, String> readEntryTypes(String metadata) {
+        Optional<EntryTypeMetadata> parsedMetadata = parseMetadata(metadata);
+        if (parsedMetadata.isEmpty()) {
+            return Map.of();
+        }
+
+        EntryTypeMetadata entryTypeMetadata = parsedMetadata.get();
+        Map<String, String> result = new LinkedHashMap<>();
+        for (Map.Entry<String, CitationEntryType> entry : getCitationTypeMap(entryTypeMetadata).entrySet()) {
+            Optional.of(entry.getValue())
+                    .map(citationEntryType -> citationEntryType.jabrefEntryType)
+                    .filter(value -> !StringUtil.isBlank(value))
+                    .ifPresent(value -> result.put(entry.getKey(), value));
+        }
+        return result;
+    }
+
+    static List<BibEntry> parseZoteroEntries(List<String> referenceMarkNames, Map<String, String> entryTypesInMetaData) {
+        List<BibEntry> entries = new ArrayList<>();
+        for (String referenceMarkName : referenceMarkNames) {
+            if (ReferenceMark.isZoteroReferenceMarkName(referenceMarkName)) {
+                entries.addAll(parseZoteroEntries(referenceMarkName, entryTypesInMetaData));
+            }
+        }
+        return entries;
+    }
+
+    private static List<BibEntry> parseZoteroEntries(String referenceMarkName, Map<String, String> entryTypesInMetaData) {
+        Optional<List<String>> citationKeys = readZoteroCitationKeys(referenceMarkName);
+        if (citationKeys.isEmpty()) {
+            return ZoteroCitationMarkParser.parse(referenceMarkName);
+        }
+
+        List<BibEntry> entries = new ArrayList<>();
+        List<String> missingCitationKeys = new ArrayList<>();
+        for (String citationKey : citationKeys.get()) {
+            Optional<String> entryType = Optional.ofNullable(entryTypesInMetaData.get(citationKey))
+                                                 .filter(value -> !StringUtil.isBlank(value));
+            entryType.ifPresentOrElse(
+                    value -> entries.add(new BibEntry(EntryTypeFactory.parse(value)).withCitationKey(citationKey)),
+                    () -> missingCitationKeys.add(citationKey));
+        }
+
+        // All citation keys are in metadata
+        if (missingCitationKeys.isEmpty()) {
+            return entries;
+        }
+
+        // None of the citation keys are in metadata
+        if (entries.isEmpty()) {
+            return ZoteroCitationMarkParser.parse(referenceMarkName);
+        }
+
+        // Part of the citation keys are in metadata
+        for (BibEntry entry : ZoteroCitationMarkParser.parse(referenceMarkName)) {
+            entry.getCitationKey()
+                 .filter(missingCitationKeys::contains)
+                 .ifPresent(_ -> entries.add(entry));
+        }
+
+        return entries;
+    }
+
+    private static Optional<List<String>> readZoteroCitationKeys(String referenceMarkName) {
+        Optional<String> cslJson = extractCSLJSON(referenceMarkName);
+        if (cslJson.isEmpty()) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(GSON.fromJson(cslJson.orElseThrow(), ZoteroCitationData.class))
+                           .map(citationData -> Optional.ofNullable(citationData.citationItems)
+                                                        .orElseGet(List::of)
+                                                        .stream()
+                                                        .map(citationItem -> "Zotero-" + citationItem.id)
+                                                        .toList());
+        } catch (JsonParseException e) {
+            LOGGER.debug("Could not parse Zotero citation entry type metadata", e);
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<String> extractCSLJSON(String referenceMarkName) {
+        int jsonStart = referenceMarkName.indexOf('{');
+        int jsonEnd = referenceMarkName.lastIndexOf('}');
+        if ((jsonStart < 0) || (jsonEnd < jsonStart)) {
+            return Optional.empty();
+        }
+        return Optional.of(referenceMarkName.substring(jsonStart, jsonEnd + 1));
+    }
+
+    private static Optional<EntryTypeMetadata> parseMetadata(String metadata) {
+        if (StringUtil.isBlank(metadata)) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(GSON.fromJson(metadata, EntryTypeMetadata.class));
+        } catch (JsonParseException e) {
+            LOGGER.debug("Could not parse citation entry type metadata", e);
+            return Optional.empty();
+        }
+    }
+
+    private static Map<String, CitationEntryType> getCitationTypeMap(EntryTypeMetadata metadata) {
+        Map<String, CitationEntryType> citationTypeMap = Optional.ofNullable(metadata.citationTypeMap)
+                                                                 .orElseGet(LinkedHashMap::new);
+        metadata.citationTypeMap = citationTypeMap;
+        return citationTypeMap;
+    }
+
+    private static class EntryTypeMetadata {
+        int schemaVersion = SCHEMA_VERSION;
+        @Nullable Map<String, CitationEntryType> citationTypeMap = new LinkedHashMap<>();
+    }
+
+    private static class CitationEntryType {
+        @Nullable String jabrefEntryType;
+
+        CitationEntryType(String jabrefEntryType) {
+            this.jabrefEntryType = jabrefEntryType;
+        }
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
@@ -123,7 +123,7 @@ public class CitationEntryTypeMetadata {
         }
 
         try {
-            return Optional.ofNullable(GSON.fromJson(metadata, EntryTypeMetadata.class));
+            return Optional.of(GSON.fromJson(metadata, EntryTypeMetadata.class));
         } catch (JsonParseException e) {
             LOGGER.debug("Could not parse citation entry type metadata", e);
             return Optional.empty();

--- a/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
@@ -102,74 +102,18 @@ public class CitationEntryTypeMetadata {
         List<BibEntry> entries = new ArrayList<>();
         for (String referenceMarkName : referenceMarkNames) {
             if (ReferenceMark.isZoteroReferenceMarkName(referenceMarkName)) {
-                entries.addAll(parseZoteroEntries(referenceMarkName, entryTypesInMetaData));
+                // If citation key is in metadata, then use the entry type in metadata
+                for (BibEntry entry : ZoteroCitationMarkParser.parse(referenceMarkName)) {
+                    entry.getCitationKey()
+                         .map(entryTypesInMetaData::get)
+                         .filter(value -> !StringUtil.isBlank(value))
+                         .map(EntryTypeFactory::parse)
+                         .ifPresent(entry::setType);
+                    entries.add(entry);
+                }
             }
         }
         return entries;
-    }
-
-    private static List<BibEntry> parseZoteroEntries(String referenceMarkName, Map<String, String> entryTypesInMetaData) {
-        Optional<List<String>> citationKeys = readZoteroCitationKeys(referenceMarkName);
-        if (citationKeys.isEmpty()) {
-            return ZoteroCitationMarkParser.parse(referenceMarkName);
-        }
-
-        List<BibEntry> entries = new ArrayList<>();
-        List<String> missingCitationKeys = new ArrayList<>();
-        for (String citationKey : citationKeys.get()) {
-            Optional<String> entryType = Optional.ofNullable(entryTypesInMetaData.get(citationKey))
-                                                 .filter(value -> !StringUtil.isBlank(value));
-            entryType.ifPresentOrElse(
-                    value -> entries.add(new BibEntry(EntryTypeFactory.parse(value)).withCitationKey(citationKey)),
-                    () -> missingCitationKeys.add(citationKey));
-        }
-
-        // All citation keys are in metadata
-        if (missingCitationKeys.isEmpty()) {
-            return entries;
-        }
-
-        // None of the citation keys are in metadata
-        if (entries.isEmpty()) {
-            return ZoteroCitationMarkParser.parse(referenceMarkName);
-        }
-
-        // Part of the citation keys are in metadata
-        for (BibEntry entry : ZoteroCitationMarkParser.parse(referenceMarkName)) {
-            entry.getCitationKey()
-                 .filter(missingCitationKeys::contains)
-                 .ifPresent(_ -> entries.add(entry));
-        }
-
-        return entries;
-    }
-
-    private static Optional<List<String>> readZoteroCitationKeys(String referenceMarkName) {
-        Optional<String> cslJson = extractCSLJSON(referenceMarkName);
-        if (cslJson.isEmpty()) {
-            return Optional.empty();
-        }
-
-        try {
-            return Optional.of(GSON.fromJson(cslJson.orElseThrow(), ZoteroCitationData.class))
-                           .map(citationData -> Optional.ofNullable(citationData.citationItems)
-                                                        .orElseGet(List::of)
-                                                        .stream()
-                                                        .map(citationItem -> "Zotero-" + citationItem.id)
-                                                        .toList());
-        } catch (JsonParseException e) {
-            LOGGER.debug("Could not parse Zotero citation entry type metadata", e);
-            return Optional.empty();
-        }
-    }
-
-    private static Optional<String> extractCSLJSON(String referenceMarkName) {
-        int jsonStart = referenceMarkName.indexOf('{');
-        int jsonEnd = referenceMarkName.lastIndexOf('}');
-        if ((jsonStart < 0) || (jsonEnd < jsonStart)) {
-            return Optional.empty();
-        }
-        return Optional.of(referenceMarkName.substring(jsonStart, jsonEnd + 1));
     }
 
     private static Optional<EntryTypeMetadata> parseMetadata(String metadata) {

--- a/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
@@ -68,7 +68,7 @@ public class CitationEntryTypeMetadata {
                 .flatMap(CitationEntryTypeMetadata::parseMetadata)
                 .orElseGet(EntryTypeMetadata::new);
 
-        Map<String, CitationEntryType> citationTypeMap = getCitationTypeMap(metadata);
+        Map<String, @Nullable CitationEntryType> citationTypeMap = getCitationTypeMap(metadata);
         metadata.schemaVersion = SCHEMA_VERSION;
 
         for (BibEntry entry : entries) {
@@ -89,8 +89,8 @@ public class CitationEntryTypeMetadata {
 
         EntryTypeMetadata entryTypeMetadata = parsedMetadata.get();
         Map<String, String> result = new LinkedHashMap<>();
-        for (Map.Entry<String, CitationEntryType> entry : getCitationTypeMap(entryTypeMetadata).entrySet()) {
-            Optional.of(entry.getValue())
+        for (Map.Entry<String, @Nullable CitationEntryType> entry : getCitationTypeMap(entryTypeMetadata).entrySet()) {
+            Optional.ofNullable(entry.getValue())
                     .map(citationEntryType -> citationEntryType.jabrefEntryType)
                     .filter(value -> !StringUtil.isBlank(value))
                     .ifPresent(value -> result.put(entry.getKey(), value));
@@ -122,23 +122,23 @@ public class CitationEntryTypeMetadata {
         }
 
         try {
-            return Optional.of(GSON.fromJson(metadata, EntryTypeMetadata.class));
+            return Optional.ofNullable(GSON.fromJson(metadata, EntryTypeMetadata.class));
         } catch (JsonParseException e) {
             LOGGER.debug("Could not parse citation entry type metadata", e);
             return Optional.empty();
         }
     }
 
-    private static Map<String, CitationEntryType> getCitationTypeMap(EntryTypeMetadata metadata) {
-        Map<String, CitationEntryType> citationTypeMap = Optional.ofNullable(metadata.citationTypeMap)
-                                                                 .orElseGet(LinkedHashMap::new);
+    private static Map<String, @Nullable CitationEntryType> getCitationTypeMap(EntryTypeMetadata metadata) {
+        Map<String, @Nullable CitationEntryType> citationTypeMap = Optional.ofNullable(metadata.citationTypeMap)
+                                                                           .orElseGet(LinkedHashMap::new);
         metadata.citationTypeMap = citationTypeMap;
         return citationTypeMap;
     }
 
     private static class EntryTypeMetadata {
         int schemaVersion = SCHEMA_VERSION;
-        @Nullable Map<String, CitationEntryType> citationTypeMap = new LinkedHashMap<>();
+        @Nullable Map<String, @Nullable CitationEntryType> citationTypeMap = new LinkedHashMap<>();
     }
 
     private static class CitationEntryType {

--- a/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadataManager.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadataManager.java
@@ -1,0 +1,137 @@
+package org.jabref.logic.openoffice;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.jabref.logic.openoffice.CitationEntryTypeMetadata.CitationEntryType;
+import org.jabref.logic.util.strings.StringUtil;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.types.EntryTypeFactory;
+import org.jabref.model.openoffice.uno.NoDocumentException;
+import org.jabref.model.openoffice.uno.UnoReferenceMark;
+import org.jabref.model.openoffice.uno.UnoUserDefinedProperty;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import com.sun.star.beans.IllegalTypeException;
+import com.sun.star.beans.PropertyVetoException;
+import com.sun.star.lang.WrappedTargetException;
+import com.sun.star.text.XTextDocument;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.jabref.logic.openoffice.CitationEntryTypeMetadata.getCitationTypeMap;
+
+@NullMarked
+public class CitationEntryTypeMetadataManager {
+
+    static final String PROPERTY_NAME = "jabref-entrytype";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CitationEntryTypeMetadataManager.class);
+    private static final Gson GSON = new Gson();
+
+    private CitationEntryTypeMetadataManager() {
+    }
+
+    public static void storeZoteroEntryTypes(XTextDocument document)
+            throws
+            IllegalTypeException,
+            NoDocumentException,
+            PropertyVetoException,
+            WrappedTargetException {
+        Map<String, String> entryTypesInMetaData = UnoUserDefinedProperty.getStringValue(document, PROPERTY_NAME)
+                                                                         .map(CitationEntryTypeMetadataManager::readEntryTypes)
+                                                                         .orElseGet(Map::of);
+        List<BibEntry> entries = parseZoteroEntries(UnoReferenceMark.getListOfNames(document), entryTypesInMetaData);
+        storeEntryTypes(document, entries);
+    }
+
+    public static void storeEntryTypes(XTextDocument document, List<BibEntry> entries)
+            throws
+            IllegalTypeException,
+            PropertyVetoException,
+            WrappedTargetException {
+        if (entries.isEmpty()) {
+            return;
+        }
+
+        Optional<String> existingMetadata = UnoUserDefinedProperty.getStringValue(document, PROPERTY_NAME);
+        String metadata = mergeEntryTypes(existingMetadata, entries);
+        UnoUserDefinedProperty.setStringProperty(document, PROPERTY_NAME, metadata);
+    }
+
+    static String mergeEntryTypes(Optional<String> existingMetadata, List<BibEntry> entries) {
+        CitationEntryTypeMetadata metadata = existingMetadata
+                .flatMap(CitationEntryTypeMetadataManager::parseMetadata)
+                .orElseGet(CitationEntryTypeMetadata::new);
+
+        Map<String, @Nullable CitationEntryType> citationTypeMap = getCitationTypeMap(metadata);
+        metadata.schemaVersion = CitationEntryTypeMetadata.SCHEMA_VERSION;
+
+        for (BibEntry entry : entries) {
+            entry.getCitationKey()
+                 .ifPresent(citationKey -> citationTypeMap.put(
+                         citationKey,
+                         new CitationEntryType(entry.getType().getName())));
+        }
+
+        return GSON.toJson(metadata);
+    }
+
+    static Map<String, String> readEntryTypes(String metadata) {
+        Optional<CitationEntryTypeMetadata> parsedMetadata = parseMetadata(metadata);
+        if (parsedMetadata.isEmpty()) {
+            return Map.of();
+        }
+
+        CitationEntryTypeMetadata entryTypeMetadata = parsedMetadata.get();
+        Map<String, @Nullable CitationEntryType> citationTypeMap = getCitationTypeMap(entryTypeMetadata);
+        Map<String, String> result = new LinkedHashMap<>(citationTypeMap.size());
+        for (Map.Entry<String, @Nullable CitationEntryType> entry : citationTypeMap.entrySet()) {
+            Optional.ofNullable(entry.getValue())
+                    .map(citationEntryType -> citationEntryType.jabrefEntryType)
+                    .filter(value -> !StringUtil.isBlank(value))
+                    .ifPresent(value -> result.put(entry.getKey(), value));
+        }
+        return result;
+    }
+
+    static List<BibEntry> parseZoteroEntries(List<String> referenceMarkNames, Map<String, String> entryTypesInMetaData) {
+        List<BibEntry> entries = new ArrayList<>();
+        for (String referenceMarkName : referenceMarkNames) {
+            if (ReferenceMark.isZoteroReferenceMarkName(referenceMarkName)) {
+                for (BibEntry entry : ZoteroCitationMarkParser.parse(referenceMarkName)) {
+                    applyStoredEntryType(entry, entryTypesInMetaData);
+                    entries.add(entry);
+                }
+            }
+        }
+        return entries;
+    }
+
+    private static void applyStoredEntryType(BibEntry entry, Map<String, String> entryTypesByCitationKey) {
+        entry.getCitationKey()
+             .map(entryTypesByCitationKey::get)
+             .filter(entryType -> !StringUtil.isBlank(entryType))
+             .map(EntryTypeFactory::parse)
+             .ifPresent(entry::setType);
+    }
+
+    private static Optional<CitationEntryTypeMetadata> parseMetadata(String metadata) {
+        if (StringUtil.isBlank(metadata)) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(GSON.fromJson(metadata, CitationEntryTypeMetadata.class));
+        } catch (JsonParseException e) {
+            LOGGER.debug("Could not parse citation entry type metadata", e);
+            return Optional.empty();
+        }
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 import org.jabref.logic.citationstyle.CitationStyle;
 import org.jabref.logic.citationstyle.CitationStyleGenerator;
 import org.jabref.logic.citationstyle.CitationStyleOutputFormat;
+import org.jabref.logic.openoffice.CitationEntryTypeMetadata;
 import org.jabref.logic.openoffice.OpenOfficePreferences;
 import org.jabref.logic.openoffice.style.OOStyle;
 import org.jabref.model.database.BibDatabase;
@@ -220,6 +221,7 @@ public class CSLCitationOOAdapter {
             }
         }
         markManager.insertReferenceIntoOO(entries, document, cursor, ooText, !preceedingSpaceExists, openOfficePreferences.getAddSpaceAfter(), citationType);
+        CitationEntryTypeMetadata.storeEntryTypes(document, entries);
         markManager.setRealTimeNumberUpdateRequired(isNumericStyle);
         markManager.readAndUpdateExistingMarks();
         this.citationType = markManager.getCitationType();
@@ -269,6 +271,7 @@ public class CSLCitationOOAdapter {
                                                .flatMap(db -> db.getEntries().stream())
                                                .filter(this::isCitedEntry)
                                                .toList();
+        CitationEntryTypeMetadata.storeEntryTypes(document, citedEntries);
 
         BibDatabase unifiedDatabase = new BibDatabase(citedEntries);
         BibDatabaseContext unifiedBibDatabaseContext = new BibDatabaseContext(unifiedDatabase);

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
 import org.jabref.logic.citationstyle.CitationStyle;
 import org.jabref.logic.citationstyle.CitationStyleGenerator;
 import org.jabref.logic.citationstyle.CitationStyleOutputFormat;
-import org.jabref.logic.openoffice.CitationEntryTypeMetadata;
+import org.jabref.logic.openoffice.CitationEntryTypeMetadataManager;
 import org.jabref.logic.openoffice.OpenOfficePreferences;
 import org.jabref.logic.openoffice.style.OOStyle;
 import org.jabref.model.database.BibDatabase;
@@ -221,7 +221,7 @@ public class CSLCitationOOAdapter {
             }
         }
         markManager.insertReferenceIntoOO(entries, document, cursor, ooText, !preceedingSpaceExists, openOfficePreferences.getAddSpaceAfter(), citationType);
-        CitationEntryTypeMetadata.storeEntryTypes(document, entries);
+        CitationEntryTypeMetadataManager.storeEntryTypes(document, entries);
         markManager.setRealTimeNumberUpdateRequired(isNumericStyle);
         markManager.readAndUpdateExistingMarks();
         this.citationType = markManager.getCitationType();
@@ -271,7 +271,7 @@ public class CSLCitationOOAdapter {
                                                .flatMap(db -> db.getEntries().stream())
                                                .filter(this::isCitedEntry)
                                                .toList();
-        CitationEntryTypeMetadata.storeEntryTypes(document, citedEntries);
+        CitationEntryTypeMetadataManager.storeEntryTypes(document, citedEntries);
 
         BibDatabase unifiedDatabase = new BibDatabase(citedEntries);
         BibDatabaseContext unifiedBibDatabaseContext = new BibDatabaseContext(unifiedDatabase);

--- a/jablib/src/test/java/org/jabref/logic/openoffice/CitationEntryTypeMetadataTest.java
+++ b/jablib/src/test/java/org/jabref/logic/openoffice/CitationEntryTypeMetadataTest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 
 import org.jspecify.annotations.NullMarked;
@@ -22,7 +23,8 @@ class CitationEntryTypeMetadataTest {
                   "id": 587,
                   "itemData": {
                     "type": "article-journal",
-                    "title": "Test article"
+                    "title": "Test article",
+                    "container-title": "Journal of Test"
                   }
                 }
               ]
@@ -88,8 +90,9 @@ class CitationEntryTypeMetadataTest {
 
     @Test
     void parseZoteroEntriesUsesCslToJabRefMapping() {
-        // [utest->req~openoffice.citation-entrytype-metadata~1]
-        List<BibEntry> entries = CitationEntryTypeMetadata.parseZoteroEntries(List.of("JR_cite_1_Keen2020", ZOTERO_JOURNAL_ARTICLE));
+        List<BibEntry> entries = CitationEntryTypeMetadata.parseZoteroEntries(
+                List.of("JR_cite_1_Keen2020", ZOTERO_JOURNAL_ARTICLE),
+                Map.of());
 
         assertEquals(1, entries.size());
         BibEntry entry = entries.getFirst();
@@ -107,5 +110,7 @@ class CitationEntryTypeMetadataTest {
         BibEntry entry = entries.getFirst();
         assertEquals(StandardEntryType.Book, entry.getType());
         assertEquals(Optional.of("Zotero-587"), entry.getCitationKey());
+        assertEquals(Optional.of("Test article"), entry.getField(StandardField.TITLE));
+        assertEquals(Optional.of("Journal of Test"), entry.getField(StandardField.JOURNALTITLE));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/openoffice/CitationEntryTypeMetadataTest.java
+++ b/jablib/src/test/java/org/jabref/logic/openoffice/CitationEntryTypeMetadataTest.java
@@ -36,9 +36,9 @@ class CitationEntryTypeMetadataTest {
         BibEntry entry = new BibEntry(StandardEntryType.Article)
                 .withCitationKey("Keen2020");
 
-        String metadata = CitationEntryTypeMetadata.mergeEntryTypes(Optional.empty(), List.of(entry));
+        String metadata = CitationEntryTypeMetadataManager.mergeEntryTypes(Optional.empty(), List.of(entry));
 
-        assertEquals(Map.of("Keen2020", "article"), CitationEntryTypeMetadata.readEntryTypes(metadata));
+        assertEquals(Map.of("Keen2020", "article"), CitationEntryTypeMetadataManager.readEntryTypes(metadata));
     }
 
     @Test
@@ -56,11 +56,11 @@ class CitationEntryTypeMetadataTest {
                 }
                 """;
 
-        String metadata = CitationEntryTypeMetadata.mergeEntryTypes(Optional.of(existingMetadata), List.of(entry));
+        String metadata = CitationEntryTypeMetadataManager.mergeEntryTypes(Optional.of(existingMetadata), List.of(entry));
 
         assertEquals(Map.of(
                 "Keen2020", "article",
-                "Smith2021", "inproceedings"), CitationEntryTypeMetadata.readEntryTypes(metadata));
+                "Smith2021", "inproceedings"), CitationEntryTypeMetadataManager.readEntryTypes(metadata));
     }
 
     @Test
@@ -78,19 +78,19 @@ class CitationEntryTypeMetadataTest {
                 }
                 """;
 
-        String metadata = CitationEntryTypeMetadata.mergeEntryTypes(Optional.of(existingMetadata), List.of(entry));
+        String metadata = CitationEntryTypeMetadataManager.mergeEntryTypes(Optional.of(existingMetadata), List.of(entry));
 
-        assertEquals(Map.of("Keen2020", "book"), CitationEntryTypeMetadata.readEntryTypes(metadata));
+        assertEquals(Map.of("Keen2020", "book"), CitationEntryTypeMetadataManager.readEntryTypes(metadata));
     }
 
     @Test
     void readEntryTypesReturnsEmptyMapForInvalidMetadata() {
-        assertEquals(Map.of(), CitationEntryTypeMetadata.readEntryTypes("not json"));
+        assertEquals(Map.of(), CitationEntryTypeMetadataManager.readEntryTypes("not json"));
     }
 
     @Test
     void parseZoteroEntriesUsesCslToJabRefMapping() {
-        List<BibEntry> entries = CitationEntryTypeMetadata.parseZoteroEntries(
+        List<BibEntry> entries = CitationEntryTypeMetadataManager.parseZoteroEntries(
                 List.of("JR_cite_1_Keen2020", ZOTERO_JOURNAL_ARTICLE),
                 Map.of());
         BibEntry expectedEntry = new BibEntry(StandardEntryType.Article)
@@ -103,7 +103,7 @@ class CitationEntryTypeMetadataTest {
 
     @Test
     void parseZoteroEntriesUsesStoredEntryTypeMetadata() {
-        List<BibEntry> entries = CitationEntryTypeMetadata.parseZoteroEntries(
+        List<BibEntry> entries = CitationEntryTypeMetadataManager.parseZoteroEntries(
                 List.of(ZOTERO_JOURNAL_ARTICLE),
                 Map.of("Zotero-587", "book"));
         BibEntry expectedEntry = new BibEntry(StandardEntryType.Book)

--- a/jablib/src/test/java/org/jabref/logic/openoffice/CitationEntryTypeMetadataTest.java
+++ b/jablib/src/test/java/org/jabref/logic/openoffice/CitationEntryTypeMetadataTest.java
@@ -1,0 +1,111 @@
+package org.jabref.logic.openoffice;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.types.StandardEntryType;
+
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@NullMarked
+class CitationEntryTypeMetadataTest {
+
+    private static final String ZOTERO_JOURNAL_ARTICLE = """
+            ZOTERO_ITEM CSL_CITATION {
+              "citationItems": [
+                {
+                  "id": 587,
+                  "itemData": {
+                    "type": "article-journal",
+                    "title": "Test article"
+                  }
+                }
+              ]
+            } test1234
+            """;
+
+    @Test
+    void mergeEntryTypesStoresCitationKeyAndEntryType() {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("Keen2020");
+
+        String metadata = CitationEntryTypeMetadata.mergeEntryTypes(Optional.empty(), List.of(entry));
+
+        assertEquals(Map.of("Keen2020", "article"), CitationEntryTypeMetadata.readEntryTypes(metadata));
+    }
+
+    @Test
+    void mergeEntryTypesKeepsExistingEntryTypes() {
+        BibEntry entry = new BibEntry(StandardEntryType.InProceedings)
+                .withCitationKey("Smith2021");
+        String existingMetadata = """
+                {
+                  "schemaVersion": 1,
+                  "citationTypeMap": {
+                    "Keen2020": {
+                      "jabrefEntryType": "article"
+                    }
+                  }
+                }
+                """;
+
+        String metadata = CitationEntryTypeMetadata.mergeEntryTypes(Optional.of(existingMetadata), List.of(entry));
+
+        assertEquals(Map.of(
+                "Keen2020", "article",
+                "Smith2021", "inproceedings"), CitationEntryTypeMetadata.readEntryTypes(metadata));
+    }
+
+    @Test
+    void mergeEntryTypesUpdatesExistingCitationKey() {
+        BibEntry entry = new BibEntry(StandardEntryType.Book)
+                .withCitationKey("Keen2020");
+        String existingMetadata = """
+                {
+                  "schemaVersion": 1,
+                  "citationTypeMap": {
+                    "Keen2020": {
+                      "jabrefEntryType": "article"
+                    }
+                  }
+                }
+                """;
+
+        String metadata = CitationEntryTypeMetadata.mergeEntryTypes(Optional.of(existingMetadata), List.of(entry));
+
+        assertEquals(Map.of("Keen2020", "book"), CitationEntryTypeMetadata.readEntryTypes(metadata));
+    }
+
+    @Test
+    void readEntryTypesReturnsEmptyMapForInvalidMetadata() {
+        assertEquals(Map.of(), CitationEntryTypeMetadata.readEntryTypes("not json"));
+    }
+
+    @Test
+    void parseZoteroEntriesUsesCslToJabRefMapping() {
+        // [utest->req~openoffice.citation-entrytype-metadata~1]
+        List<BibEntry> entries = CitationEntryTypeMetadata.parseZoteroEntries(List.of("JR_cite_1_Keen2020", ZOTERO_JOURNAL_ARTICLE));
+
+        assertEquals(1, entries.size());
+        BibEntry entry = entries.getFirst();
+        assertEquals(StandardEntryType.Article, entry.getType());
+        assertEquals(Optional.of("Zotero-587"), entry.getCitationKey());
+    }
+
+    @Test
+    void parseZoteroEntriesUsesStoredEntryTypeMetadata() {
+        List<BibEntry> entries = CitationEntryTypeMetadata.parseZoteroEntries(
+                List.of(ZOTERO_JOURNAL_ARTICLE),
+                Map.of("Zotero-587", "book"));
+
+        assertEquals(1, entries.size());
+        BibEntry entry = entries.getFirst();
+        assertEquals(StandardEntryType.Book, entry.getType());
+        assertEquals(Optional.of("Zotero-587"), entry.getCitationKey());
+    }
+}

--- a/jablib/src/test/java/org/jabref/logic/openoffice/CitationEntryTypeMetadataTest.java
+++ b/jablib/src/test/java/org/jabref/logic/openoffice/CitationEntryTypeMetadataTest.java
@@ -93,11 +93,12 @@ class CitationEntryTypeMetadataTest {
         List<BibEntry> entries = CitationEntryTypeMetadata.parseZoteroEntries(
                 List.of("JR_cite_1_Keen2020", ZOTERO_JOURNAL_ARTICLE),
                 Map.of());
+        BibEntry expectedEntry = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("Zotero-587")
+                .withField(StandardField.TITLE, "Test article")
+                .withField(StandardField.JOURNALTITLE, "Journal of Test");
 
-        assertEquals(1, entries.size());
-        BibEntry entry = entries.getFirst();
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("Zotero-587"), entry.getCitationKey());
+        assertEquals(List.of(expectedEntry), entries);
     }
 
     @Test
@@ -105,12 +106,11 @@ class CitationEntryTypeMetadataTest {
         List<BibEntry> entries = CitationEntryTypeMetadata.parseZoteroEntries(
                 List.of(ZOTERO_JOURNAL_ARTICLE),
                 Map.of("Zotero-587", "book"));
+        BibEntry expectedEntry = new BibEntry(StandardEntryType.Book)
+                .withCitationKey("Zotero-587")
+                .withField(StandardField.TITLE, "Test article")
+                .withField(StandardField.JOURNALTITLE, "Journal of Test");
 
-        assertEquals(1, entries.size());
-        BibEntry entry = entries.getFirst();
-        assertEquals(StandardEntryType.Book, entry.getType());
-        assertEquals(Optional.of("Zotero-587"), entry.getCitationKey());
-        assertEquals(Optional.of("Test article"), entry.getField(StandardField.TITLE));
-        assertEquals(Optional.of("Journal of Test"), entry.getField(StandardField.JOURNALTITLE));
+        assertEquals(List.of(expectedEntry), entries);
     }
 }


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/16209

### PR Description
This PR inserts jabref-entrytype information into LibreOffice document's meta.xml.

Example:
```
{
  "schemaVersion": 1,
  "citationTypeMap": {
    "Keen2020": {
      "jabrefEntryType": "article"
    },
    "Zotero-123": {
      "jabrefEntryType": "inproceedings"
    }
  }
}
```

Two scenarios will trigger this logic:
1. Inserting citations from JabRef
2. First time reading a reference from Zotero

### Steps to test
1. Create a test.odt in LibreOffice, cites some references from Zotero and save
<img width="1340" height="424" alt="image" src="https://github.com/user-attachments/assets/510cc807-93a3-4e07-919f-53bf820f50c4" />

2. Rename .odt to .zip, unzip and open meta.xml

3. Look for keyword `meta:user-defined`, notice that there are only Zotero side records
<img width="665" height="387" alt="image" src="https://github.com/user-attachments/assets/649beb5a-3ead-4ed5-b43a-4e6b29d7ead3" />

4. Open JabRef, connect the same document, repeat 2 again
 
5. Notice that there are JabRef side records
<img width="762" height="628" alt="image" src="https://github.com/user-attachments/assets/6d949d05-d858-4f8e-9123-ada1850dee04" />

### AI usage
I use codex 5.5 to help me create test and parsing/inserting metadata logic. All AI-generated code was reviewed by myself.
_____

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)



### AI usage
I use codex 5.5 to help me create test and parsing/inserting metadata logic. All AI-generated code was reviewed by myself.
_____

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

