### PR TITLE
Fix macOS key binding tests with platform-specific shortcut modifier

### DIFF
--- a/jabgui/src/test/java/org/jabref/gui/keyboard/KeyBindingsTabModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/keyboard/KeyBindingsTabModelTest.java
@@ -79,8 +79,11 @@ class KeyBindingsTabModelTest {
 
     @Test
     void randomNewKeyKeyBindingInRepository() {
+        boolean controlDown = !OS.OS_X;
+        boolean metaDown = OS.OS_X;
+
         setKeyBindingViewModel(KeyBinding.CLEANUP);
-        KeyEvent shortcutKeyEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "K", "K", KeyCode.K, true, true, true, false);
+        KeyEvent shortcutKeyEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "K", "K", KeyCode.K, true, controlDown, true, metaDown);
         assertFalse(keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLEANUP, shortcutKeyEvent));
         model.setNewBindingForCurrent(shortcutKeyEvent);
 

--- a/jabgui/src/test/java/org/jabref/gui/keyboard/KeyBindingsTabModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/keyboard/KeyBindingsTabModelTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -79,11 +78,8 @@ class KeyBindingsTabModelTest {
 
     @Test
     void randomNewKeyKeyBindingInRepository() {
-        boolean controlDown = !OS.OS_X;
-        boolean metaDown = OS.OS_X;
-
         setKeyBindingViewModel(KeyBinding.CLEANUP);
-        KeyEvent shortcutKeyEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "K", "K", KeyCode.K, true, controlDown, true, metaDown);
+        KeyEvent shortcutKeyEvent = createShortcutKeyEvent("K", KeyCode.K);
         assertFalse(keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLEANUP, shortcutKeyEvent));
         model.setNewBindingForCurrent(shortcutKeyEvent);
 
@@ -96,10 +92,8 @@ class KeyBindingsTabModelTest {
 
     @Test
     void saveNewKeyBindingsToPreferences() {
-        assumeFalse(OS.OS_X);
-
         setKeyBindingViewModel(KeyBinding.MERGE_ENTRIES);
-        KeyEvent shortcutKeyEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "J", "J", KeyCode.J, true, true, true, false);
+        KeyEvent shortcutKeyEvent = createShortcutKeyEvent("J", KeyCode.J);
         assertFalse(keyBindingRepository.checkKeyCombinationEquality(KeyBinding.MERGE_ENTRIES, shortcutKeyEvent));
         model.setNewBindingForCurrent(shortcutKeyEvent);
 
@@ -123,10 +117,8 @@ class KeyBindingsTabModelTest {
 
     @Test
     void setAllKeyBindingsToDefault() {
-        assumeFalse(OS.OS_X);
-
         setKeyBindingViewModel(KeyBinding.MERGE_ENTRIES);
-        KeyEvent shortcutKeyEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "C", "C", KeyCode.C, true, true, true, false);
+        KeyEvent shortcutKeyEvent = createShortcutKeyEvent("C", KeyCode.C);
 
         assertFalse(keyBindingRepository.checkKeyCombinationEquality(KeyBinding.MERGE_ENTRIES, shortcutKeyEvent));
 
@@ -159,10 +151,8 @@ class KeyBindingsTabModelTest {
 
     @Test
     void setSingleKeyBindingToDefault() {
-        assumeFalse(OS.OS_X);
-
         KeyBindingViewModel viewModel = setKeyBindingViewModel(KeyBinding.MERGE_ENTRIES);
-        KeyEvent shortcutKeyEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "C", "C", KeyCode.C, true, true, true, false);
+        KeyEvent shortcutKeyEvent = createShortcutKeyEvent("C", KeyCode.C);
 
         assertFalse(keyBindingRepository.checkKeyCombinationEquality(KeyBinding.MERGE_ENTRIES, shortcutKeyEvent));
 
@@ -178,6 +168,13 @@ class KeyBindingsTabModelTest {
         // it back to default is still considered a change in the repository state.
         // Therefore, MERGE_ENTRIES is still expected to match this shortcut here.
         assertTrue(keyBindingRepository.checkKeyCombinationEquality(KeyBinding.MERGE_ENTRIES, shortcutKeyEvent));
+    }
+
+    private KeyEvent createShortcutKeyEvent(String character, KeyCode keyCode) {
+        boolean controlDown = !OS.OS_X;
+        boolean metaDown = OS.OS_X;
+
+        return new KeyEvent(KeyEvent.KEY_PRESSED, character, character, keyCode, true, controlDown, true, metaDown);
     }
 
     private KeyBindingViewModel setKeyBindingViewModel(KeyBinding binding) {


### PR DESCRIPTION
### Related issues and pull requests

Closes #16208

### PR Description

Key-binding tests in `KeyBindingsTabModelTest` were skipped on macOS because synthetic `KeyEvent`s used Control instead of Meta/Command. A small helper now builds shortcut events with the correct platform modifier, re-enabling those tests without changing application behavior.

### Steps to test

1. Run the key-binding tests:
   ```bash
   ./gradlew :jabgui:test --tests "org.jabref.gui.keyboard.KeyBindingsTabModelTest"
   ```
2. Confirm all tests pass, including on macOS:
   - `randomNewKeyKeyBindingInRepository`
   - `saveNewKeyBindingsToPreferences`
   - `setAllKeyBindingsToDefault`
   - `setSingleKeyBindingToDefault`

No GUI or user-facing behavior changes.

### AI usage

None.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

N/A — no AI tools were used.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)


### Analogies
Like honey from different hives, shortcuts differ by platform. Like tempered chocolate, the right modifier makes the binding set. Like the moon, the tests stay the same while looking right from each OS.

jabref-contrib-policy:4.2:reviewed​:ok