### PR TITLE
SLR: paged fetchers raw query

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ISIDOREFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ISIDOREFetcher.java
@@ -95,19 +95,33 @@ public class ISIDOREFetcher implements PagedSearchBasedParserFetcher {
     public URL getURLForQuery(BaseQueryNode queryNode, int pageNumber) throws URISyntaxException, MalformedURLException {
         ISIDOREQueryTransformer queryTransformer = new ISIDOREQueryTransformer();
         String transformedQuery = queryTransformer.transformSearchQuery(queryNode).orElse("");
+        URIBuilder uriBuilder = new URIBuilder(buildSearchURL(transformedQuery, pageNumber).toURI());
+        queryTransformer.getParameterMap().forEach(uriBuilder::addParameter);
+
+        URL url = uriBuilder.build().toURL();
+        LOGGER.debug("URl for query {}", url);
+        return url;
+    }
+
+    @Override
+    public URL getURLForRawQuery(String rawQuery, int pageNumber) throws URISyntaxException, MalformedURLException {
+        return buildSearchURL(rawQuery, pageNumber);
+    }
+
+    /// Builds the search URL for the given query string
+    ///
+    /// The query is sent as the `q` parameter, so raw queries
+    /// bypass [ISIDOREQueryTransformer] and are passed unchanged to the catalog
+    private URL buildSearchURL(String query, int pageNumber) throws URISyntaxException, MalformedURLException {
         URIBuilder uriBuilder = new URIBuilder(SOURCE_WEB_SEARCH);
-        uriBuilder.addParameter("q", transformedQuery);
+        uriBuilder.addParameter("q", query);
         if (pageNumber > 1) {
             uriBuilder.addParameter("page", String.valueOf(pageNumber));
         }
         uriBuilder.addParameter("replies", String.valueOf(getPageSize()));
         uriBuilder.addParameter("lang", "en");
         uriBuilder.addParameter("output", "xml");
-        queryTransformer.getParameterMap().forEach(uriBuilder::addParameter);
-
-        URL url = uriBuilder.build().toURL();
-        LOGGER.debug("URl for query {}", url);
-        return url;
+        return uriBuilder.build().toURL();
     }
 
     private List<BibEntry> parseXMl(Element element) {

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/LOBIDFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/LOBIDFetcher.java
@@ -50,9 +50,23 @@ public class LOBIDFetcher implements PagedSearchBasedParserFetcher, IdBasedParse
     /// @return URL
     @Override
     public URL getURLForQuery(BaseQueryNode queryNode, int pageNumber) throws URISyntaxException, MalformedURLException {
+        String transformedQuery = new LOBIDQueryTransformer().transformSearchQuery(queryNode).orElse("");
+        return buildSearchURL(transformedQuery, pageNumber);
+    }
+
+    @Override
+    public URL getURLForRawQuery(String rawQuery, int pageNumber) throws URISyntaxException, MalformedURLException {
+        return buildSearchURL(rawQuery, pageNumber);
+    }
+
+    /// Builds the search URL for the given query string.
+    ///
+    /// The query is sent verbatim as the `q` parameter, so raw queries
+    /// bypass [LOBIDQueryTransformer] and are passed unchanged to the catalog.
+    private URL buildSearchURL(String query, int pageNumber) throws URISyntaxException, MalformedURLException {
         URIBuilder uriBuilder = new URIBuilder(API_URL);
-        uriBuilder.addParameter("q", new LOBIDQueryTransformer().transformSearchQuery(queryNode).orElse("")); // search query
-        uriBuilder.addParameter("from", String.valueOf(getPageSize() * pageNumber)); // from entry number, starts indexing at 0
+        uriBuilder.addParameter("q", query);
+        uriBuilder.addParameter("from", String.valueOf(getPageSize() * pageNumber));
         uriBuilder.addParameter("size", String.valueOf(getPageSize()));
         uriBuilder.addParameter("format", "json");
         return uriBuilder.build().toURL();

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ScholarArchiveFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ScholarArchiveFetcher.java
@@ -44,8 +44,22 @@ public class ScholarArchiveFetcher implements PagedSearchBasedParserFetcher {
     /// @return URL
     @Override
     public URL getURLForQuery(BaseQueryNode queryNode, int pageNumber) throws URISyntaxException, MalformedURLException {
+        String transformedQuery = new ScholarArchiveQueryTransformer().transformSearchQuery(queryNode).orElse("");
+        return buildSearchURL(transformedQuery, pageNumber);
+    }
+
+    @Override
+    public URL getURLForRawQuery(String rawQuery, int pageNumber) throws URISyntaxException, MalformedURLException {
+        return buildSearchURL(rawQuery, pageNumber);
+    }
+
+    /// Builds the search URL for the given query string.
+    ///
+    /// The query is sent as the `q` parameter, so raw queries
+    /// bypass [ScholarArchiveQueryTransformer] and are passed unchanged to the catalog.
+    private URL buildSearchURL(String query, int pageNumber) throws URISyntaxException, MalformedURLException {
         URIBuilder uriBuilder = new URIBuilder(API_URL);
-        uriBuilder.addParameter("q", new ScholarArchiveQueryTransformer().transformSearchQuery(queryNode).orElse(""));
+        uriBuilder.addParameter("q", query);
         uriBuilder.addParameter("from", String.valueOf(getPageSize() * pageNumber));
         uriBuilder.addParameter("size", String.valueOf(getPageSize()));
         uriBuilder.addParameter("format", "json");

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/SemanticScholar.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/SemanticScholar.java
@@ -135,8 +135,22 @@ public class SemanticScholar implements FulltextFetcher, PagedSearchBasedParserF
 
     @Override
     public URL getURLForQuery(BaseQueryNode queryNode, int pageNumber) throws URISyntaxException, MalformedURLException {
+        String transformedQuery = new DefaultQueryTransformer().transformSearchQuery(queryNode).orElse("");
+        return buildSearchURL(transformedQuery, pageNumber);
+    }
+
+    @Override
+    public URL getURLForRawQuery(String rawQuery, int pageNumber) throws URISyntaxException, MalformedURLException {
+        return buildSearchURL(rawQuery, pageNumber);
+    }
+
+    /// Builds the search URL for the given query string
+    ///
+    /// The query is sent as the `query` parameter, so raw queries
+    /// bypass [DefaultQueryTransformer] and are passed unchanged to the catalog
+    private URL buildSearchURL(String query, int pageNumber) throws URISyntaxException, MalformedURLException {
         URIBuilder uriBuilder = new URIBuilder(SOURCE_WEB_SEARCH);
-        uriBuilder.addParameter("query", new DefaultQueryTransformer().transformSearchQuery(queryNode).orElse(""));
+        uriBuilder.addParameter("query", query);
         uriBuilder.addParameter("offset", String.valueOf(pageNumber * getPageSize()));
         uriBuilder.addParameter("limit", String.valueOf(Math.min(getPageSize(), 10000 - pageNumber * getPageSize())));
         // All fields need to be specified

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/ISIDOREFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/ISIDOREFetcherTest.java
@@ -7,6 +7,7 @@ import org.jabref.logic.importer.FetcherException;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.paging.Page;
 import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +15,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @FetcherTest
 class ISIDOREFetcherTest {
@@ -107,5 +110,17 @@ class ISIDOREFetcherTest {
                 .withField(StandardField.TITLE, "Le rôle des pépinières dans le développement des entreprises accueillies : essai d'évaluation. L'exemple du Yorkshire -Humberside (R.U.)")
                 .withField(StandardField.YEAR, "1990")
         ), actual);
+    }
+
+    @Test
+    void performRawSearchQueryPagedWithBlankQueryReturnsEmptyPage() throws FetcherException {
+        Page<BibEntry> result = fetcher.performRawSearchQueryPaged("", 0);
+        assertTrue(result.getContent().isEmpty());
+    }
+
+    @Test
+    void performRawSearchQueryPagedFindsEntry() throws FetcherException {
+        Page<BibEntry> page = fetcher.performRawSearchQueryPaged("Corporate Social Responsibility", 0);
+        assertFalse(page.getContent().isEmpty());
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/LOBIDFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/LOBIDFetcherTest.java
@@ -8,6 +8,7 @@ import org.jabref.logic.importer.SearchBasedFetcher;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.paging.Page;
 import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +16,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @FetcherTest
 class LOBIDFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherTest {
@@ -82,6 +85,18 @@ class LOBIDFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
     @Test
     void searchByEmptyQueryFindsNothing() throws FetcherException {
         assertEquals(List.of(), fetcher.performSearch(""));
+    }
+
+    @Test
+    void performRawSearchQueryPagedWithBlankQueryReturnsEmptyPage() throws FetcherException {
+        Page<BibEntry> result = fetcher.performRawSearchQueryPaged("", 0);
+        assertTrue(result.getContent().isEmpty());
+    }
+
+    @Test
+    void performRawSearchQueryPagedFindsEntry() throws FetcherException {
+        Page<BibEntry> page = fetcher.performRawSearchQueryPaged("isbn:9783862065752", 0);
+        assertFalse(page.getContent().isEmpty());
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/ScholarArchiveFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/ScholarArchiveFetcherTest.java
@@ -6,6 +6,7 @@ import org.jabref.logic.importer.FetcherException;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.paging.Page;
 import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +41,12 @@ class ScholarArchiveFetcherTest {
         List<BibEntry> fetchedEntries = fetcher.performSearch("bpelscript");
         fetchedEntries.forEach(entry -> entry.clearField(StandardField.ABSTRACT));
         assertTrue(fetchedEntries.contains(bibEntry), "Found the following entries " + fetchedEntries);
+    }
+
+    @Test
+    void performRawSearchQueryPagedWithBlankQueryReturnsEmptyPage() throws FetcherException {
+        Page<BibEntry> result = fetcher.performRawSearchQueryPaged("", 0);
+        assertTrue(result.getContent().isEmpty());
     }
 }
 

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/SemanticScholarTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/SemanticScholarTest.java
@@ -17,6 +17,7 @@ import org.jabref.logic.util.BuildInfo;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.paging.Page;
 import org.jabref.model.search.query.SearchQuery;
 import org.jabref.support.DisabledOnCIServer;
 import org.jabref.testutils.category.FetcherTest;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -131,6 +133,18 @@ public class SemanticScholarTest implements PagedSearchFetcherTest {
         SearchQueryVisitor visitor = new SearchQueryVisitor(searchQueryObject.getSearchFlags());
         URL url = fetcher.getURLForQuery(visitor.visitStart(searchQueryObject.getContext()), 0);
         assertEquals("https://api.semanticscholar.org/graph/v1/paper/search?query=Software%20engineering&offset=0&limit=20&fields=paperId%2CexternalIds%2Curl%2Ctitle%2Cabstract%2Cvenue%2Cyear%2Cauthors", url.toString());
+    }
+
+    @Test
+    void getURLForRawQuery() throws MalformedURLException, URISyntaxException, FetcherException {
+        URL url = fetcher.getURLForRawQuery("Software engineering", 0);
+        assertEquals("https://api.semanticscholar.org/graph/v1/paper/search?query=Software%20engineering&offset=0&limit=20&fields=paperId%2CexternalIds%2Curl%2Ctitle%2Cabstract%2Cvenue%2Cyear%2Cauthors", url.toString());
+    }
+
+    @Test
+    void performRawSearchQueryPagedWithBlankQueryReturnsEmptyPage() throws FetcherException {
+        Page<BibEntry> result = fetcher.performRawSearchQueryPaged("", 0);
+        assertTrue(result.getContent().isEmpty());
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/SemanticScholarTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/SemanticScholarTest.java
@@ -137,8 +137,9 @@ public class SemanticScholarTest implements PagedSearchFetcherTest {
 
     @Test
     void getURLForRawQuery() throws MalformedURLException, URISyntaxException, FetcherException {
-        URL url = fetcher.getURLForRawQuery("Software engineering", 0);
-        assertEquals("https://api.semanticscholar.org/graph/v1/paper/search?query=Software%20engineering&offset=0&limit=20&fields=paperId%2CexternalIds%2Curl%2Ctitle%2Cabstract%2Cvenue%2Cyear%2Cauthors", url.toString());
+        String expected = "https://api.semanticscholar.org/graph/v1/paper/search?query=Software%20engineering&offset=0&limit=20&fields=paperId%2CexternalIds%2Curl%2Ctitle%2Cabstract%2Cvenue%2Cyear%2Cauthors";
+        String actual = fetcher.getURLForRawQuery("Software engineering", 0).toString();
+        assertEquals(expected, actual);
     }
 
     @Test


### PR DESCRIPTION
### Related issues and pull requests

part of series of the raw query support for SLR

### PR Description
Migrates four paged fetchers (LOBID, ScholarArchive, SemanticScholar, ISIDORE) to the getURLForRawQuery. 
Each fetcher extracts a buildSearchURL helper and adds a one line hook override, so raw queries are sent unchanged to the catalog

note: The ADS is excluded becase needs it is own override style, so i will make a separate PR 
### Steps to test

  
### AI usage
Claude Sonnet 5 to investigate files and review my code

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
