### PR TITLE
Background radius reduced fixed issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ## [Unreleased]
 
+- We fixed an issue where the button shape changed when hovering over it. [#16188](https://github.com/JabRef/jabref/issues/16188)
+
 ### Added
 
 - The HTTP import endpoint (`POST /libraries/{id}/entries`) now accepts CSL-JSON (`application/vnd.citationstyles.csl+json`), mapping each item to the correct entry type (e.g. conference paper, book chapter, thesis) via the citation-js-based mapping. [#16151](https://github.com/JabRef/jabref/pull/16151)
@@ -2062,7 +2064,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where opening the menu 'Library properties' marked the library as modified. [#6451](https://github.com/JabRef/jabref/issues/6451)
 - We fixed an issue when importing resulted in an exception. [#7343](https://github.com/JabRef/jabref/issues/7343)
 - We fixed an issue where the field in the Field formatter dropdown selection were sorted in random order. [#7710](https://github.com/JabRef/jabref/issues/7710)
-- We fixed an issue where the button shape changed when hovering over it. [#16188](https://github.com/JabRef/jabref/issues/16188)
+
 ### Removed
 
 - The feature to "mark entries" was removed and merged with the groups functionality. For migration, a group is created for every value of the `__markedentry` field and the entry is added to this group.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ## [Unreleased]
 
-- We fixed an issue where the button shape changed when hovering over it. [#16188](https://github.com/JabRef/jabref/issues/16188)
+
 
 ### Added
 
@@ -79,6 +79,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where renaming a linked file with a very long title showed a misleading "file is being used by another process" error instead of renaming successfully. [#14771](https://github.com/JabRef/jabref/issues/14771)
 - We fixed an issue where JabRef would trigger `The libray has been changed` while still saving. [#4877](https://github.com/JabRef/jabref/issues/4877)
 - We fixed preview tooltip height calculation in the main table. [#16219](https://github.com/JabRef/jabref/issues/16219)
+- We fixed an issue where the button shape changed when hovering over it. [#16188](https://github.com/JabRef/jabref/issues/16188)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ## [Unreleased]
 
-
-
 ### Added
 
 - The HTTP import endpoint (`POST /libraries/{id}/entries`) now accepts CSL-JSON (`application/vnd.citationstyles.csl+json`), mapping each item to the correct entry type (e.g. conference paper, book chapter, thesis) via the citation-js-based mapping. [#16151](https://github.com/JabRef/jabref/pull/16151)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2062,7 +2062,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where opening the menu 'Library properties' marked the library as modified. [#6451](https://github.com/JabRef/jabref/issues/6451)
 - We fixed an issue when importing resulted in an exception. [#7343](https://github.com/JabRef/jabref/issues/7343)
 - We fixed an issue where the field in the Field formatter dropdown selection were sorted in random order. [#7710](https://github.com/JabRef/jabref/issues/7710)
-
+- We fixed an issue where the button shape changed when hovering over it. [#16188](https://github.com/JabRef/jabref/issues/16188)
 ### Removed
 
 - The feature to "mark entries" was removed and merged with the groups functionality. For migration, a group is created for every value of the `__markedentry` field and the entry is added to this group.

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -1159,6 +1159,7 @@ We want to have a look that matches our icons in the tool-bar */
 
 #entryEditor .all-fields-add-chip {
     -fx-background-radius: 3;
+    -fx-border-radius: 3;
     -fx-padding: 3 12 3 12;
 }
 

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -1158,7 +1158,7 @@ We want to have a look that matches our icons in the tool-bar */
 }
 
 #entryEditor .all-fields-add-chip {
-    -fx-background-radius: 14;
+    -fx-background-radius: 3;
     -fx-padding: 3 12 3 12;
 }
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/dbcb5c95-62f2-4c55-a094-22b1f6bd814a

<img width="1440" height="852" alt="Screenshot Author" src="https://github.com/user-attachments/assets/d3f37a69-b463-480d-8303-93b0af015499" />




### Related issues and pull requests


Closes #16188 

### PR Description



This change keeps the optional field "add" chips in the entry editor from changing shape when hovered. The background color still changes on hover, but the border radius has been adjusted so the button appearance remains consistent.

   `jabref-contrib-policy:4.2:reviewed​:ok`

Analogies

Like honey, this change is small but smooths the overall experience.
Like chocolate, it is a small improvement that makes the interface more pleasant.
Like the moon, it does not change how the application works, but it makes the appearance more consistent.
 

### Steps to test

 

1. Start JabRef
2. Open or create a bibliography
3. Select and entry and open the Entry Editor
4. Location options fields such as Subtitle
5. Hover over one of the chips. 
6. Verify that the background changes while the shape stays the same. 

### AI usage

_____


ChatGPT (OpenAI GPT-5.5)

### Checklist
<details>
<summary>AI CHECKLIST.md walkthrough</summary>


- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)


</details>




