### PR TITLE
Fix javadoc class link in CLIPreferences

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -2523,7 +2523,7 @@ public class JabRefCliPreferences implements CliPreferences {
         return openOfficePreferences;
     }
 
-    /// Reconstructs the persisted [OOStyle] from its stored path: a CSL style file becomes a [CitationStyle], otherwise
+    /// Reconstructs the persisted [OOStyle] from its stored path: a CSL style file becomes a [org.jabref.logic.citationstyle.CitationStyle], otherwise
     /// it is treated as a [JStyle] (requiring `journalAbbreviationRepository`). Falls back to `defaultStyle` when the
     /// path is absent, the repository is missing, or the JStyle cannot be created.
     private OOStyle getCurrentOOStyle(OOStyle defaultStyle, JournalAbbreviationRepository journalAbbreviationRepository) {


### PR DESCRIPTION
### Related issues and pull requests

Closes NA

Triggered by https://github.com/JabRef/jabref/pull/16152#issuecomment-4946923589

### PR Description

### Steps to test

NA
Before:
<img width="659" height="299" alt="image" src="https://github.com/user-attachments/assets/cc8b8271-ca42-44f8-a9ab-d9c90aac3ebe" />


After:
<img width="657" height="324" alt="image" src="https://github.com/user-attachments/assets/2f4c61f0-14f5-467d-99de-59bc14520a68" />


### AI usage
NA
_____

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
