### PR TITLE
Add no-arg constructor

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/CitationEntryTypeMetadata.java
@@ -18,6 +18,9 @@ class CitationEntryTypeMetadata {
     static class CitationEntryType {
         @Nullable String jabrefEntryType;
 
+        CitationEntryType() {
+        }
+
         CitationEntryType(String jabrefEntryType) {
             this.jabrefEntryType = jabrefEntryType;
         }


### PR DESCRIPTION
### Related issues and pull requests

Follow-up of https://github.com/JabRef/jabref/issues/16210

### PR Description
JabRef throws exeption below when connecting to a document.
```
java.lang.RuntimeException: Unable to create instance of class org.jabref.logic.openoffice.CitationEntryTypeMetadata$CitationEntryType. Registering an InstanceCreator or a TypeAdapter for this type, or adding a no-args constructor may fix this problem. 
```
Added no-arg constructor in `CitationEntryTypeMetadata#CitationEntryType` to fix this issue

### Steps to test

NA

### AI usage

None

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [.] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
