### PR TITLE
Move linked-files editor buttons into trailing row

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -567,7 +567,7 @@ public class AllFieldsTab extends FieldsEditorTab {
     private static void applyNaturalHeight(FieldEditorFX editor) {
         normalizeInputHeights(editor.getNode());
         if (editor instanceof LinkedFilesEditor) {
-            // Sizes itself to (file count + 1) rows; a fixed weight-based height would override that.
+            // Sizes itself to the file rows plus the trailing button row; a fixed weight-based height would override that.
             return;
         }
         if ((editor.getWeight() > 1) && (editor.getNode() instanceof Region region)) {

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -8,19 +8,16 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
 import javafx.css.PseudoClass;
-import javafx.event.EventTarget;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
-import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.OverrunStyle;
 import javafx.scene.control.ProgressBar;
 import javafx.scene.control.ProgressIndicator;
-import javafx.scene.control.ScrollBar;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.ClipboardContent;
@@ -32,6 +29,7 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 
 import org.jabref.gui.DialogService;
@@ -68,7 +66,7 @@ import com.tobiasdiez.easybind.EasyBind;
 import com.tobiasdiez.easybind.optional.ObservableOptionalValue;
 import jakarta.inject.Inject;
 
-public class LinkedFilesEditor extends HBox implements FieldEditorFX {
+public class LinkedFilesEditor extends VBox implements FieldEditorFX {
 
     // Upper bound on how many rows the ListView grows to before it starts scrolling internally,
     // so entries with many linked files cannot expand the entry editor layout indefinitely.
@@ -76,6 +74,8 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
 
     @FXML
     private ListView<LinkedFileViewModel> listView;
+    @FXML
+    private HBox buttonRow;
     @FXML
     private JabRefIconView fulltextFetcher;
     @FXML
@@ -167,51 +167,25 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
                 .install(listView);
         listView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 
-        // Size the control to (number of files + 1) rows, so it ends right after the content instead of leaving blank
+        // Size the list to exactly the number of files, so it ends right after the content instead of leaving blank
         // space, but cap it at MAX_VISIBLE_ROWS so large file lists scroll internally rather than growing the layout.
         // The row height comes from the CSS-driven fixed cell size, so theming and font scaling adjust it naturally.
         listView.prefHeightProperty().bind(Bindings.createDoubleBinding(
-                () -> Math.min(listView.getItems().size() + 1, MAX_VISIBLE_ROWS) * listView.getFixedCellSize(),
+                () -> Math.min(listView.getItems().size(), MAX_VISIBLE_ROWS) * listView.getFixedCellSize(),
                 listView.getItems(),
                 listView.fixedCellSizeProperty()));
         listView.maxHeightProperty().bind(listView.fixedCellSizeProperty().multiply(MAX_VISIBLE_ROWS));
+        // Allow the list to collapse completely when there are no files; the button row below stays visible.
+        listView.setMinHeight(0);
+
+        // The button row acts as the list's trailing row: same height as a list row, buttons only.
+        buttonRow.prefHeightProperty().bind(listView.fixedCellSizeProperty());
+        buttonRow.minHeightProperty().bind(listView.fixedCellSizeProperty());
 
         fulltextFetcher.visibleProperty().bind(viewModel.fulltextLookupInProgressProperty().not());
         progressIndicator.visibleProperty().bind(viewModel.fulltextLookupInProgressProperty());
 
         setUpKeyBindings();
-
-        // Double-clicking the empty row below the files (the "+1" row) adds a new file, same as the add button.
-        listView.setOnMouseClicked(event -> {
-            if ((event.getButton() == MouseButton.PRIMARY) && (event.getClickCount() == 2) && isEmptyRow(event.getTarget())) {
-                addNewFile();
-            }
-        });
-    }
-
-    private static boolean isEmptyRow(EventTarget target) {
-        if (!(target instanceof Node node)) {
-            return false;
-        }
-        // Walk up from the clicked node to the ListView. The handler sits on the ListView, so
-        // events from scrollbars and other skin sub-controls bubble up here too; only clicks on
-        // the list's content background (no enclosing cell, no scrollbar crossed) count as the
-        // empty area and behave like double-clicking the trailing empty "+1" row.
-        for (Node current = node; current != null; current = current.getParent()) {
-            if (current instanceof ListCell<?> cell) {
-                return cell.isEmpty();
-            }
-            if (current instanceof ScrollBar) {
-                return false;
-            }
-            if (current instanceof ListView) {
-                // Reached the list itself without crossing a cell or a scrollbar: the click
-                // landed on the content background (the blank space below the files, or the
-                // whole control when no files exist yet).
-                return true;
-            }
-        }
-        return false;
     }
 
     private void handleOnDragOver(LinkedFileViewModel originalItem, DragEvent event) {

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.control.ProgressIndicator?>
@@ -8,9 +9,13 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import org.jabref.gui.icon.JabRefIconView?>
-<fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
+<fx:root xmlns:fx="http://javafx.com/fxml/1" type="VBox" xmlns="http://javafx.com/javafx/8.0.112"
          fx:controller="org.jabref.gui.fieldeditors.LinkedFilesEditor">
-    <VBox>
+    <ListView fx:id="listView" styleClass="linked-files-list"/>
+    <HBox fx:id="buttonRow" alignment="CENTER_LEFT" spacing="2.0">
+        <padding>
+            <Insets left="4.0"/>
+        </padding>
         <Button onAction="#addNewFile" styleClass="icon-button">
             <graphic>
                 <JabRefIconView glyph="LINKED_FILE_ADD"/>
@@ -38,6 +43,5 @@
                 <Tooltip text="%Download from URL"/>
             </tooltip>
         </Button>
-    </VBox>
-    <ListView fx:id="listView" styleClass="linked-files-list" HBox.hgrow="ALWAYS" />
+    </HBox>
 </fx:root>


### PR DESCRIPTION
### Related issues and pull requests

- follow-up to https://github.com/JabRef/jabref/pull/16172
- replaces https://github.com/JabRef/jabref/pull/16192

### PR Description

<img width="1113" height="223" alt="grafik" src="https://github.com/user-attachments/assets/1086d672-8034-405d-91b7-352e1c41108f" />

### Steps to test

Start JabRef and navigate to "Files and links" - w/ an existing file.

### AI usage

Calude did the work

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
