### PR TITLE
Run JabKit PDF native smoke tests with GraalVM on macOS

### DIFF
--- a/.github/workflows/jabkit-native-smoke-test.yml
+++ b/.github/workflows/jabkit-native-smoke-test.yml
@@ -44,16 +44,8 @@ jobs:
           show-progress: 'false'
 
       - uses: ./.github/actions/setup-gradle
-
-      # In graalvm/setup-graalvm, distribution "liberica" means Liberica NIK.
-      # jdk+fx maps to the Full Liberica package, used here for the AWT/java.desktop path triggered by PDFBox.
-      - name: Set up Liberica NIK (native-image with AWT support)
-        uses: graalvm/setup-graalvm@v1
         with:
-          distribution: 'liberica'
-          java-package: 'jdk+fx'
-          java-version: '25'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          distribution: graalvm
 
       - name: Build JabKit native binary
         run: gradle :jabkit:nativeCompile
@@ -70,10 +62,6 @@ jobs:
 
       - name: Run JabKit offline smoke tests
         run: cd jabkit && /tmp/clitest src/test/nativeimage/jabkit-offline.md
-
-      - name: Run JabKit PDF native smoke test (Linux only)
-        if: ${{ runner.os == 'Linux' }}
-        run: cd jabkit && /tmp/clitest src/test/nativeimage/jabkit-offline-pdf.md
 
       - name: Run JabKit online smoke tests
         if: ${{ inputs.run-online-tests }}

--- a/jabkit/src/test/nativeimage/jabkit-offline-pdf.md
+++ b/jabkit/src/test/nativeimage/jabkit-offline-pdf.md
@@ -1,8 +1,0 @@
-$ JABKIT=build/native/nativeCompile/jabkit
-$ mkdir -p build/tmp
-$ cp ../jablib/src/test/resources/org/jabref/logic/importer/util/LNCS-minimal.pdf build/tmp/native-metadata.pdf
-$ sed "s|__PDF_PATH__|$PWD/build/tmp/native-metadata.pdf|" src/test/nativeimage/native-metadata-template.bib > build/tmp/native-metadata.bib
-$ "$JABKIT" pdf update --porcelain --format=bibtex-attachment --citation-key=NativePdfSmoke --input-format=bibtex --input=build/tmp/native-metadata.bib > build/tmp/pdfupdate.out 2>/dev/null; echo $?
-0
-$ grep -c "Successfully embedded metadata" build/tmp/pdfupdate.out
-1

--- a/jabkit/src/test/nativeimage/jabkit-offline.md
+++ b/jabkit/src/test/nativeimage/jabkit-offline.md
@@ -32,3 +32,9 @@ $ grep -c "^@Book{Einstein1920," build/tmp/search.out
 1
 $ grep -c "^@Book{" build/tmp/search.out
 1
+$ cp ../jablib/src/test/resources/org/jabref/logic/importer/util/LNCS-minimal.pdf build/tmp/native-metadata.pdf
+$ sed "s|__PDF_PATH__|$PWD/build/tmp/native-metadata.pdf|" src/test/nativeimage/native-metadata-template.bib > build/tmp/native-metadata.bib
+$ "$JABKIT" pdf update --porcelain --format=bibtex-attachment --citation-key=NativePdfSmoke --input-format=bibtex --input=build/tmp/native-metadata.bib > build/tmp/pdfupdate.out 2>/dev/null; echo $?
+0
+$ grep -c "Successfully embedded metadata" build/tmp/pdfupdate.out
+1

--- a/jabls-cli/build.gradle.kts
+++ b/jabls-cli/build.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 plugins {
     id("org.jabref.gradle.module")
     id("org.jabref.gradle.feature.shadowjar")
+    id("org.jabref.gradle.feature.nativecompile")
     id("application")
 }
 


### PR DESCRIPTION
### Related issues and pull requests

Closes no related issue.

This PR is part of the [JabRef components as native images](https://jabref.github.io/GSoC/projects/#jabref-components-as-native-images) project.

### PR Description

We previously switched to Liberica NIK because loading a PDF initialized AWT and failed with regular GraalVM on macOS. PDFBox 3.0.8 fixes this issue, so this PR switches the native smoke test back to GraalVM and runs the PDF check as part of the regular offline smoke test on both Linux and macOS.

### Steps to test

1. Ensure that Java and `native-image` use GraalVM 25.
2. Build a fresh JabKit native image:
```
./gradlew :jabkit:clean :jabkit:nativeCompile
```

3. Run the offline smoke test:
```
cd jabkit
clitest src/test/nativeimage/jabkit-offline.md
```
The test should finish with:
```
OK: 22 of 22 tests passed
```
for both Linux and macOS

### AI usage
Claude Opus 4.8

### Checklist
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
