### PR TITLE
Fix exit of LspClientHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed preview tooltip height calculation in the main table. [#16219](https://github.com/JabRef/jabref/issues/16219)
 - We fixed an issue where stale main table search results could remain visible after consecutive searches. [#15710](https://github.com/JabRef/jabref/issues/15710)
 - We fixed an issue where the button shape changed when hovering over it. [#16188](https://github.com/JabRef/jabref/issues/16188)
+- We fixed handling of `exit` in the LSP server.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed preview tooltip height calculation in the main table. [#16219](https://github.com/JabRef/jabref/issues/16219)
 - We fixed an issue where stale main table search results could remain visible after consecutive searches. [#15710](https://github.com/JabRef/jabref/issues/15710)
 - We fixed an issue where the button shape changed when hovering over it. [#16188](https://github.com/JabRef/jabref/issues/16188)
-- We fixed handling of `exit` in the LSP server.
+- We fixed handling of `exit` in the LSP server. [#16268](https://github.com/JabRef/jabref/pull/16268)
 
 ### Removed
 

--- a/jabls/src/main/java/org/jabref/languageserver/LspClientHandler.java
+++ b/jabls/src/main/java/org/jabref/languageserver/LspClientHandler.java
@@ -82,8 +82,8 @@ public class LspClientHandler implements LanguageServer, LanguageClientAware {
         return CompletableFuture.completedFuture(null);
     }
 
-    /// When running in JabGUI: NOOP, because the JabGui has the lifecycle control.
-    /// When running standalone: immediately exits.
+    /// When running in JabGui: NOOP, because the JabGui has the lifecycle control.
+    /// When running standalone: immediately exits. We accept issues if mutlitple clients are connected.
     @Override
     public void exit() {
         if (standalone) {

--- a/jabls/src/main/java/org/jabref/languageserver/LspClientHandler.java
+++ b/jabls/src/main/java/org/jabref/languageserver/LspClientHandler.java
@@ -77,8 +77,8 @@ public class LspClientHandler implements LanguageServer, LanguageClientAware {
         return CompletableFuture.completedFuture(null);
     }
 
-    /// When running in JabGUI: NOOP, because the JabGui has the lifecycle control
-    /// When running standalone: immediately exits
+    /// When running in JabGUI: NOOP, because the JabGui has the lifecycle control.
+    /// When running standalone: immediately exits.
     @Override
     public void exit() {
         if (standalone) {

--- a/jabls/src/main/java/org/jabref/languageserver/LspClientHandler.java
+++ b/jabls/src/main/java/org/jabref/languageserver/LspClientHandler.java
@@ -77,11 +77,13 @@ public class LspClientHandler implements LanguageServer, LanguageClientAware {
         return CompletableFuture.completedFuture(null);
     }
 
-    /// currently not implemented because it comes from the LanguageServer interface and is documented like here
-    /// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#exit
-    /// we have to decide how to implement this so jabls gets stopped only when started before by a lsp client
+    /// When running in JabGUI: NOOP, because the JabGui has the lifecycle control
+    /// When running standalone: immediately exits
     @Override
     public void exit() {
+        if (standalone) {
+            System.exit(0);
+        }
     }
 
     @Override

--- a/jabls/src/main/java/org/jabref/languageserver/LspClientHandler.java
+++ b/jabls/src/main/java/org/jabref/languageserver/LspClientHandler.java
@@ -52,6 +52,11 @@ public class LspClientHandler implements LanguageServer, LanguageClientAware {
         this.messageHandler = messageHandler;
     }
 
+    public LspClientHandler(RemoteMessageHandler messageHandler, CliPreferences cliPreferences, JournalAbbreviationRepository abbreviationRepository, BibEntryTypesManager bibEntryTypesManager, boolean standalone) {
+        this(messageHandler, cliPreferences, abbreviationRepository, bibEntryTypesManager);
+        this.standalone = standalone;
+    }
+
     @Override
     public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
         ServerCapabilities capabilities = new ServerCapabilities();
@@ -106,10 +111,6 @@ public class LspClientHandler implements LanguageServer, LanguageClientAware {
         workspaceService.setClient(client);
         textDocumentService.setClient(client);
         client.logMessage(new MessageParams(MessageType.Warning, "BibtexLSPServer connected."));
-    }
-
-    public void setStandalone(boolean standalone) {
-        this.standalone = standalone;
     }
 
     public boolean isStandalone() {

--- a/jabls/src/main/java/org/jabref/languageserver/LspLauncher.java
+++ b/jabls/src/main/java/org/jabref/languageserver/LspLauncher.java
@@ -83,8 +83,7 @@ public class LspLauncher extends Thread {
     }
 
     private void handleClient(Socket socket) {
-        LspClientHandler clientHandler = new LspClientHandler(messageHandler, cliPreferences, abbreviationRepository, bibEntryTypesManager);
-        clientHandler.setStandalone(standalone);
+        LspClientHandler clientHandler = new LspClientHandler(messageHandler, cliPreferences, abbreviationRepository, bibEntryTypesManager, true);
         LOGGER.debug("LSP clientHandler started.");
         try (socket; // socket should be closed on error
              InputStream in = socket.getInputStream();


### PR DESCRIPTION

### PR Description

LspServer did not exit when asked to.

### Steps to test

Start LspServer stand alone

### AI usage

🧠

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
