### PR TITLE
Fix cursor jumping to end of BibEntry code in source editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where the caret position jumped to the end when switching entries in the Source tab. [#8173](https://github.com/JabRef/jabref/issues/8173)
 - We fixed an issue where canceling the duplicate resolution dialog did not stop the background duplicate scan and kept the left entry. [#16234](https://github.com/JabRef/jabref/pull/16234)
 - We fixed an issue where entries imported or updated by an arXiv number could end up with the paper's automatic DOI web address as their citation key instead of a proper one; the INSPIRE literature database's key is now used when available, and updating an existing entry no longer silently drops its own or the fetched citation key. [#12292](https://github.com/JabRef/jabref/issues/12292)
 - We fixed an issue where a BibTeX entry printed on the first page of a PDF was not imported when other text (such as author email addresses) appeared above it. [#16245](https://github.com/JabRef/jabref/pull/16245)
@@ -93,7 +94,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where stale main table search results could remain visible after consecutive searches. [#15710](https://github.com/JabRef/jabref/issues/15710)
 - We fixed an issue where the button shape changed when hovering over it. [#16188](https://github.com/JabRef/jabref/issues/16188)
 - We fixed handling of `exit` in the LSP server. [#16268](https://github.com/JabRef/jabref/pull/16268)
-- Fixed the cursor jumping to the end of the source editor after editing an entry and switching to another application. [#8173](https://github.com/JabRef/jabref/issues/8173)
 
 ### Removed
 
@@ -2020,7 +2020,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We changed the behavior of merging that the entry which has "smaller" bibkey will be selected. [#7395](https://github.com/JabRef/jabref/issues/7395)
 
 ### Fixed
-- ### Fixed
 
 - We fixed an issue where JabRef died silently for the user without enough inotify instances. [#4874](https://github.com/JabRef/jabref/issues/4874)
 - We fixed an issue where corresponding groups are sometimes not highlighted when clicking on entries. [#3112](https://github.com/JabRef/jabref/issues/3112)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where stale main table search results could remain visible after consecutive searches. [#15710](https://github.com/JabRef/jabref/issues/15710)
 - We fixed an issue where the button shape changed when hovering over it. [#16188](https://github.com/JabRef/jabref/issues/16188)
 - We fixed handling of `exit` in the LSP server. [#16268](https://github.com/JabRef/jabref/pull/16268)
+- Fixed the cursor jumping to the end of the source editor after editing an entry and switching to another application. [#8173](https://github.com/JabRef/jabref/issues/8173)
 
 ### Removed
 
@@ -2019,6 +2020,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We changed the behavior of merging that the entry which has "smaller" bibkey will be selected. [#7395](https://github.com/JabRef/jabref/issues/7395)
 
 ### Fixed
+- ### Fixed
 
 - We fixed an issue where JabRef died silently for the user without enough inotify instances. [#4874](https://github.com/JabRef/jabref/issues/4874)
 - We fixed an issue where corresponding groups are sometimes not highlighted when clicking on entries. [#3112](https://github.com/JabRef/jabref/issues/3112)

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -237,10 +237,14 @@ public class SourceTab extends EntryEditorTab {
             BibDatabaseMode mode = stateManager.getActiveDatabase().map(BibDatabaseContext::getMode)
                                                .orElse(BibDatabaseMode.BIBLATEX);
 
+            int caretPosition = codeArea.getCaretPosition();
             codeArea.clear();
             try {
                 codeArea.appendText(getSourceString(getCurrentEntry(), mode, fieldPreferences));
                 codeArea.setEditable(true);
+                // Restore caret position, clamped to new text length
+                int newPosition = Math.min(caretPosition, codeArea.getLength());
+                codeArea.displaceCaret(newPosition);
                 Platform.runLater(this::highlightSearchPattern);
             } catch (IOException ex) {
                 codeArea.setEditable(false);


### PR DESCRIPTION


### Related issues and pull requests

Closes #8173

### PR Description
The change modifies updateCodeArea() in jabref/jabgui/src/main/java/org/jabref/gui/entryeditor/SourceTab.java.

Before clearing the codeArea, the current caret position is stored. After the editor content is updated, the caret is restored to its previous position. This ensures the cursor remains at the expected location instead of moving to the end of the editor.
<img width="1356" height="598" alt="image" src="https://github.com/user-attachments/assets/386f1fde-aa36-4f09-8dfa-31dd12f6a445" />
fig1. after making an edit and switching from jabref to another app and then back to jabref.

<img width="1356" height="598" alt="image" src="https://github.com/user-attachments/assets/40ae40bd-ec48-41d2-815d-9c8241a72453" />
fig2. entry in jabref

Analogies: This fix is like honey - sweet and simple, making the user experience smoother. It's like chocolate - a small treat that improves the overall flavor of the application. And like the moon, it provides a steady, reliable presence in the UI that users can depend on.


        `jabref-contrib-policy:4.2:reviewed​:ok`


### Steps to Test
1. Open an entry in the entry editor.
2. Switch to the Source tab.
3. Place the cursor in the middle of the BibTeX entry and make an edit.
4. Switch to another application and then return to JabRef.
5. Verify that the cursor remains at the same position where it was before switching applications, rather than moving to the end of the source.


### AI usage

none

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
