### PR TITLE
Show error box to users during critical errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where a critical error occurring during application startup (e.g. while constructing the main window) was only written to the log, leaving the user with no visible feedback and an apparently silent crash. [#14967](https://github.com/JabRef/jabref/issues/14967)
 - We fixed an issue where canceling the duplicate resolution dialog did not stop the background duplicate scan and kept the left entry. [#16234](https://github.com/JabRef/jabref/pull/16234)
 - We fixed an issue where entries imported or updated by an arXiv number could end up with the paper's automatic DOI web address as their citation key instead of a proper one; the INSPIRE literature database's key is now used when available, and updating an existing entry no longer silently drops its own or the fetched citation key. [#12292](https://github.com/JabRef/jabref/issues/12292)
 - We fixed an issue where a BibTeX entry printed on the first page of a PDF was not imported when other text (such as author email addresses) appeared above it. [#16245](https://github.com/JabRef/jabref/pull/16245)

--- a/docs/requirements/ux.md
+++ b/docs/requirements/ux.md
@@ -32,4 +32,12 @@ Since some data fetchers take time, we need to open the dialog and wait until al
 
 Needs: impl
 
+## Critical startup failures show an error dialog
+`req~ux.startup.critical-error-dialog~1`
+
+If a critical error occurs before the main window is fully constructed, it must not fail silently.
+The user needs a visible error dialog, in addition to the log entry, since [digging through log files is not accessible to most users](https://github.com/JabRef/jabref/issues/14967).
+
+Needs: impl
+
 <!-- markdownlint-disable-file MD022 -->

--- a/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -109,10 +109,8 @@ public class JabRefGUI extends Application {
     public void start(Stage stage) {
         // Installed before the try block below (not after) so background threads started during
         // initialize() are also covered, not just ones started once the main window is up.
-        FallbackExceptionHandler.installExceptionHandler((exception, thread) -> UiTaskExecutor.runInJavaFXThread(() -> {
-            DialogService exceptionDialogService = Injector.instantiateModelOrService(DialogService.class);
-            exceptionDialogService.showErrorDialogAndWait("Uncaught exception occurred in " + thread, exception);
-        }));
+        FallbackExceptionHandler.installExceptionHandler((exception, thread) -> UiTaskExecutor.runInJavaFXThread(() ->
+                showCriticalErrorDialog(Localization.lang("Uncaught exception occurred in %0", thread.toString()), exception)));
 
         try {
             this.mainStage = stage;
@@ -160,27 +158,30 @@ public class JabRefGUI extends Application {
             setupProxy();
         } catch (Throwable throwable) {
             LOGGER.error("Error during initialization", throwable);
-            showStartupErrorDialog(throwable);
+            showCriticalErrorDialog(Localization.lang("Unhandled exception occurred."), throwable);
             throw throwable;
         }
     }
 
     /// [impl->req~ux.startup.critical-error-dialog~1]
     ///
-    /// Does not go through [DialogService], since a startup failure can happen before
-    /// [#initialize()] sets it up. `Dialog.initOwner` throws a NullPointerException if the
-    /// owner window has no [Scene] yet, which is only set in [#openWindow()], so the owner
-    /// is skipped in that case.
-    private void showStartupErrorDialog(Throwable throwable) {
+    /// Used both for startup failures (from [#start(Stage)]'s catch block) and for uncaught
+    /// exceptions on other threads ([FallbackExceptionHandler], installed before [#initialize()]
+    /// so it also covers background threads started during startup). In both cases, [DialogService]
+    /// or [Scene] may not exist yet: [DialogService] is only set up in [#initialize()], and `Scene`
+    /// is only set in [#openWindow()]. Calling [DialogService] or `Dialog.initOwner` before then
+    /// throws a NullPointerException, so this falls back to an ownerless [ExceptionDialog] instead.
+    private void showCriticalErrorDialog(String header, Throwable throwable) {
         try {
-            ExceptionDialog exceptionDialog = new ExceptionDialog(throwable);
-            exceptionDialog.setHeaderText(Localization.lang("Unhandled exception occurred."));
-            if (mainStage.getScene() != null) {
-                exceptionDialog.initOwner(mainStage);
+            if (mainStage != null && mainStage.getScene() != null) {
+                Injector.instantiateModelOrService(DialogService.class).showErrorDialogAndWait(header, throwable);
+                return;
             }
+            ExceptionDialog exceptionDialog = new ExceptionDialog(throwable);
+            exceptionDialog.setHeaderText(header);
             exceptionDialog.showAndWait();
         } catch (Throwable dialogFailure) {
-            LOGGER.error("Could not show startup error dialog", dialogFailure);
+            LOGGER.error("Could not show critical error dialog", dialogFailure);
         }
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -165,15 +165,17 @@ public class JabRefGUI extends Application {
         }
     }
 
-    /// Does not go through {@link DialogService}, since a startup failure can happen before
-    /// {@link #initialize()} sets it up. `Dialog.initOwner` throws a NullPointerException if the
-    /// owner window has no {@link Scene} yet, which is only set in {@link #openWindow()}, so the owner
+    /// [impl->req~ux.startup.critical-error-dialog~1]
+    ///
+    /// Does not go through [DialogService], since a startup failure can happen before
+    /// [#initialize()] sets it up. `Dialog.initOwner` throws a NullPointerException if the
+    /// owner window has no [Scene] yet, which is only set in [#openWindow()], so the owner
     /// is skipped in that case.
     private void showStartupErrorDialog(Throwable throwable) {
         try {
             ExceptionDialog exceptionDialog = new ExceptionDialog(throwable);
             exceptionDialog.setHeaderText(Localization.lang("Unhandled exception occurred."));
-            if (mainStage != null && mainStage.getScene() != null) {
+            if (mainStage.getScene() != null) {
                 exceptionDialog.initOwner(mainStage);
             }
             exceptionDialog.showAndWait();

--- a/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -65,6 +65,7 @@ import com.dlsc.gemsfx.infocenter.InfoCenterPane;
 import com.dlsc.gemsfx.infocenter.InfoCenterViewPos;
 import com.tobiasdiez.easybind.EasyBind;
 import kong.unirest.core.Unirest;
+import org.controlsfx.dialog.ExceptionDialog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,6 +107,13 @@ public class JabRefGUI extends Application {
 
     @Override
     public void start(Stage stage) {
+        // Installed before the try block below (not after) so background threads started during
+        // initialize() are also covered, not just ones started once the main window is up.
+        FallbackExceptionHandler.installExceptionHandler((exception, thread) -> UiTaskExecutor.runInJavaFXThread(() -> {
+            DialogService exceptionDialogService = Injector.instantiateModelOrService(DialogService.class);
+            exceptionDialogService.showErrorDialogAndWait("Uncaught exception occurred in " + thread, exception);
+        }));
+
         try {
             this.mainStage = stage;
             Injector.setModelOrService(Stage.class, mainStage);
@@ -152,13 +160,26 @@ public class JabRefGUI extends Application {
             setupProxy();
         } catch (Throwable throwable) {
             LOGGER.error("Error during initialization", throwable);
+            showStartupErrorDialog(throwable);
             throw throwable;
         }
+    }
 
-        FallbackExceptionHandler.installExceptionHandler((exception, thread) -> UiTaskExecutor.runInJavaFXThread(() -> {
-            DialogService dialogService = Injector.instantiateModelOrService(DialogService.class);
-            dialogService.showErrorDialogAndWait("Uncaught exception occurred in " + thread, exception);
-        }));
+    /// Does not go through {@link DialogService}, since a startup failure can happen before
+    /// {@link #initialize()} sets it up. `Dialog.initOwner` throws a NullPointerException if the
+    /// owner window has no {@link Scene} yet, which is only set in {@link #openWindow()}, so the owner
+    /// is skipped in that case.
+    private void showStartupErrorDialog(Throwable throwable) {
+        try {
+            ExceptionDialog exceptionDialog = new ExceptionDialog(throwable);
+            exceptionDialog.setHeaderText(Localization.lang("Unhandled exception occurred."));
+            if (mainStage != null && mainStage.getScene() != null) {
+                exceptionDialog.initOwner(mainStage);
+            }
+            exceptionDialog.showAndWait();
+        } catch (Throwable dialogFailure) {
+            LOGGER.error("Could not show startup error dialog", dialogFailure);
+        }
     }
 
     public void initialize() {

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -1994,6 +1994,7 @@ Copied\ %0\ citations.=Copied %0 citations.
 
 journal\ not\ found\ in\ abbreviation\ list=journal not found in abbreviation list
 Unhandled\ exception\ occurred.=Unhandled exception occurred.
+Uncaught\ exception\ occurred\ in\ %0=Uncaught exception occurred in %0
 
 strings\ included=strings included
 Escape\ underscores=Escape underscores


### PR DESCRIPTION
### Related issues and pull requests

Closes #14967

### PR Description

If `start()` throws before the main window exists, the exception was only logged, leaving users with a silent crash and no way to tell what went wrong short of digging through the log file. `showStartupErrorDialog()` now surfaces it via a ControlsFX `ExceptionDialog`, skipping `initOwner()` when the stage has no `Scene` yet (`openWindow()` sets it later), since JavaFX throws a `NullPointerException` from `initOwner()` on a sceneless owner — found by actually running the induced-crash scenario end-to-end, not just by compiling it. `FallbackExceptionHandler` is also installed earlier, before `initialize()`, so background threads started during startup are covered too.

#15176 attempted the same fix earlier but was closed for an unrelated workflow issue (wrong base branch, formatting check failures). Its review also flagged that a bare `Alert` needs an owner and can itself fail — that's the exact `initOwner`-on-sceneless-stage `NullPointerException` this PR works around.

### Steps to test

1. Temporarily throw an exception early in `JabRefGUI.start()`, right after `initialize()` (before `new JabRefFrame(...)`), e.g. simulating #14630's `InvalidPathException`.
2. Run `./gradlew :jabgui:run`.
3. Confirm an "Unhandled exception occurred." dialog with the full stack trace appears, instead of the app silently closing with only a log line.
4. Remove the temporary exception and confirm the app starts normally with no regression.

### AI usage

Claude Code (model claude-sonnet-5)

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead. *(One exception: `mainStage.getScene() != null`. `Scene` isn't JSpecify-annotated by JavaFX/OpenJFX, and the null case is real — `Scene` is genuinely `null` until `openWindow()` runs, confirmed by an `initOwner` `NullPointerException` hit while testing this fix live.)*
- [x] No `Objects.requireNonNull(...)` — not used.
- [/] New classes annotated with `@NullMarked` — no new classes added.
- [/] `Optional` consumed with `ifPresent` / etc. — no `Optional` in this diff.
- [/] `StringUtil.isBlank(...)` — not applicable.

### Exceptions

- [x] No `catch (Exception e)` — only `catch (Throwable ...)`, matching the pre-existing pattern in this exact method (`start()`'s outer catch already caught `Throwable`, not introduced by this PR). Intentional: `showStartupErrorDialog` is a last-resort error-reporting path that must not itself crash the crash-handler, so it needs to catch anything, not just checked exceptions.
- [x] No new `throw new RuntimeException(...)` / `IllegalStateException(...)`.
- [x] Logged exceptions passed as the last logger argument in both `LOGGER.error(...)` calls.

### Style and idioms

- [/] New `BibEntry` objects — not applicable.
- [/] Modern Java constructs — not applicable, nothing to modernize in this diff.
- [/] Regexes — not applicable.
- [/] Background work via `BackgroundTask` — not applicable, no new threading.
- [x] No commented-out code, no trivial comments, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax (`[ClassName]`, `` `code` ``), not `{@link}`/`{@code}`.

### User-facing text

- [x] All user-facing text localized (`Localization.lang(...)`, reusing an existing key).
- [x] Sentence case, no trailing `!`, no trailing `:`.
- [/] Placeholders vs. concatenation — not applicable, no interpolated localized string added.

### Security

- [/] HTML-escaping of user-controlled data — not applicable, this is a desktop JavaFX dialog, not a `text/html` HTTP response.

### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have tests — this change is in `org.jabref.gui` (`JabRefGUI`, JavaFX `Application` lifecycle), outside this rule's stated scope. No existing tests cover `JabRefGUI` today. Verified instead by running the app and inducing the crash live (see "Steps to test").
- [/] Test assertion conventions — not applicable, no tests added.

## 2. Verification commands

- [x] `./gradlew :jabgui:check` — 865 tests, 2 pre-existing failures unrelated to this change (`KeyBindingViewModelTest.verifyStoreSettingsWritesChanges`: OS-specific modifier-key naming; `MarkdownTextFlowTest.copySelectedTextFromPlainTextUsesVerbatimClipboardContent`: clipboard-interaction flakiness). Neither touches `JabRefGUI`, dialogs, or startup.
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh` (scoped to `:jabgui`, the module changed) — clean.
- [x] `./gradlew :jabgui:modernizer` — clean.
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` — "Applying recipes would make no changes."
- [x] `./gradlew :jabgui:javadoc` — clean.
- [x] `npx markdownlint-cli2 "docs/requirements/ux.md" "CHANGELOG.md"` — 0 issues.
- [/] IntelliJ format Docker step — not needed, `rewriteDryRun` already reported no formatting changes.

## 3. Documentation

- [x] `CHANGELOG.md` entry added, linked to #14967.
- [x] Searched jabref/issues; #14967 was given directly and is a confident match.
- [x] Requirement added to `docs/requirements/ux.md` (`req~ux.startup.critical-error-dialog~1`), linked from the code via `[impl->req~ux.startup.critical-error-dialog~1]`.
- [/] Developer documentation under `docs/` — no architecture change beyond the requirement entry above.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked.
- [x] All HTML comments removed from the PR body.
- [ ] PR created with `gh pr create --body-file <file>` — **not run**: `gh` isn't authenticated in this environment. Branch `fix-14967-critical-error-dialog` is pushed to the fork; opening the PR itself needs a manual `gh auth login` or the GitHub web UI.
- [/] `CHANGELOG.md` `TODO` placeholder replacement — not applicable, it was linked directly to the real, confidently-matched issue #14967 from the start.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable) — no existing tests cover `JabRefGUI`'s `Application` lifecycle; verified instead by inducing the crash live, see "Steps to test"
- [/] I added screenshots in the PR description (if change is visible to the user) — the change only surfaces during a rare startup-crash scenario; described precisely in "Steps to test" instead
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
<img width="1918" height="1192" alt="Ekran görüntüsü 2026-07-18 011556" src="https://github.com/user-attachments/assets/96bf8223-b842-42a5-8285-841623403bc7" />

- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en) — no user-facing workflow changed, only error-reporting behavior on an already-fatal crash path

Addressed both Qodo comments in 475136a9:
- Localized the "Uncaught exception occurred in ..." message (new key `Uncaught exception occurred in %0`).
- Unified the FallbackExceptionHandler callback and the startup-crash path into a single `showCriticalErrorDialog()` that safely falls back when DialogService/Scene aren't ready yet, instead of the handler calling DialogService directly.

@ThiloteE 
**Before:** the app silently exits, no visible feedback, error only in the log.

**After:**
<img width="637" height="542" alt="Ekran görüntüsü 2026-07-18 141721" src="https://github.com/user-attachments/assets/c95ee022-0a43-4494-9557-7f10b3553606" />
"İşlenmemiş istisna oluştu." means "An unhandled exception occurred."(Turkish-English)
