### PR TITLE
SLR: Medline/PubMed raw query

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
@@ -205,7 +205,7 @@ public class MedlineFetcher implements IdBasedParserFetcher, SearchBasedFetcher,
         return searchForEntries(transformedQuery.get());
     }
 
-    /// The raw query is sent as the esearch `term` parameter
+    /// The raw query is sent as the `term` parameter of PubMed's esearch API (see SEARCH_URL)
     @Override
     public @NonNull List<BibEntry> performRawSearchQuery(@NonNull String rawQuery) throws FetcherException {
         if (rawQuery.isBlank()) {

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
@@ -196,29 +196,39 @@ public class MedlineFetcher implements IdBasedParserFetcher, SearchBasedFetcher,
 
     @Override
     public @NonNull List<BibEntry> performSearch(@NonNull BaseQueryNode queryNode) throws FetcherException {
-        List<BibEntry> entryList;
         MedlineQueryTransformer transformer = new MedlineQueryTransformer();
         Optional<String> transformedQuery = transformer.transformSearchQuery(queryNode);
 
         if (transformedQuery.isEmpty() || transformedQuery.get().isBlank()) {
             return List.of();
-        } else {
-            // searching for pubmed ids matching the query
-            List<String> idList = getPubMedIdsFromQuery(transformedQuery.get());
-
-            if (idList.isEmpty()) {
-                LOGGER.info("No results found.");
-                return List.of();
-            }
-            if (numberOfResultsFound > NUMBER_TO_FETCH) {
-                LOGGER.info("{} results found. Only 50 relevant results will be fetched by default.", numberOfResultsFound);
-            }
-
-            // pass the list of ids to fetchMedline to download them. like a id fetcher for mutliple ids
-            entryList = fetchMedline(idList);
-
-            return entryList;
         }
+        return searchForEntries(transformedQuery.get());
+    }
+
+    /// The raw query is sent as the esearch `term` parameter
+    @Override
+    public @NonNull List<BibEntry> performRawSearchQuery(@NonNull String rawQuery) throws FetcherException {
+        if (rawQuery.isBlank()) {
+            return List.of();
+        }
+        return searchForEntries(rawQuery);
+    }
+
+    /// Searches PubMed for IDs matching the query, then fetches the corresponding entries
+    private List<BibEntry> searchForEntries(String query) throws FetcherException {
+        // searching for pubmed ids matching the query
+        List<String> idList = getPubMedIdsFromQuery(query);
+
+        if (idList.isEmpty()) {
+            LOGGER.info("No results found.");
+            return List.of();
+        }
+        if (numberOfResultsFound > NUMBER_TO_FETCH) {
+            LOGGER.info("{} results found. Only 50 relevant results will be fetched by default.", numberOfResultsFound);
+        }
+
+        // pass the list of ids to fetchMedline to download them, like an id fetcher for multiple ids
+        return fetchMedline(idList);
     }
 
     @Override

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/MedlineFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/MedlineFetcherTest.java
@@ -207,6 +207,17 @@ class MedlineFetcherTest {
     }
 
     @Test
+    void performRawSearchQueryWithBlankQueryReturnsEmptyList() throws FetcherException {
+        assertEquals(List.of(), fetcher.performRawSearchQuery(""));
+    }
+
+    @Test
+    void performRawSearchQueryFindsEntries() throws FetcherException {
+        List<BibEntry> entryList = fetcher.performRawSearchQuery("vigmond[au] AND 2021[dp]");
+        assertEquals(18, entryList.size());
+    }
+
+    @Test
     void invalidSearchTerm() {
         assertThrows(FetcherClientException.class, () -> fetcher.performSearchById("this.is.a.invalid.search.term.for.the.medline.fetcher"));
     }


### PR DESCRIPTION
### Related issues and pull requests

Part of non-paged fetcher SLR

### PR Description

overrides performRawSearchQuery directly instead of the getURLForRawQuery, because the search has two steps (esearch returns IDs, efetch downloads them). 
The shared search steps were moved into a searchForEntries helper, used by both the normal and the raw path, the raw query is sent as is to the esearch term parameter

### Steps to test

### AI usage
Claude Sonnet 5 to investigate files and review my code

### Checklist


- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
