### PR TITLE
Fix autocomplete popup obscuring search field in Entry Types preferences tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where the field-name suggestions dropdown in the "Entry Types" preferences tab could obscure the search field it belonged to. [#16030](https://github.com/JabRef/jabref/issues/16030)
 - We fixed an issue where canceling the duplicate resolution dialog did not stop the background duplicate scan and kept the left entry. [#16234](https://github.com/JabRef/jabref/pull/16234)
 - We fixed an issue where entries imported or updated by an arXiv number could end up with the paper's automatic DOI web address as their citation key instead of a proper one; the INSPIRE literature database's key is now used when available, and updating an existing entry no longer silently drops its own or the fetched citation key. [#12292](https://github.com/JabRef/jabref/issues/12292)
 - We fixed an issue where a BibTeX entry printed on the first page of a PDF was not imported when other text (such as author email addresses) appeared above it. [#16245](https://github.com/JabRef/jabref/pull/16245)

--- a/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
@@ -285,12 +285,13 @@ public class CustomEntryTypesTab extends AbstractPreferenceTabView<CustomEntryTy
                 .setOnDragExited(this::handleOnDragExited)
                 .install(fields);
 
+        // Cap the popup height so it always fits below the field instead of JavaFX flipping it above and obscuring it
         TextFields.bindAutoCompletion(
                 addNewField,
                 viewModel.fieldsForAdding().stream()
                          .map(Field::getName)
                          .collect(Collectors.toList())
-        );
+        ).setVisibleRowCount(5);
 
         // selected field will show in addNewField box with its properties
         fields.getSelectionModel().selectedItemProperty().addListener((obs, oldSelection, newSelection) -> {


### PR DESCRIPTION
Fixes #16030

## What

Caps the autocomplete suggestions popup in the "Entry Types" preferences tab (`CustomEntryTypesTab`) at 5 visible rows.

## Why

The "add new field" text box uses `TextFields.bindAutoCompletion(...)` without a row limit, so the popup could grow tall enough that JavaFX flips it to render above the field instead of below. In that state, the popup overlapped and obscured the search field it belongs to, making it hard to see what was being typed.

## How

Chained `.setVisibleRowCount(5)` onto the `AutoCompletionBinding` returned by `TextFields.bindAutoCompletion(...)` so the popup height is bounded and consistently opens below the field.

## Testing

- Verified the change compiles against the ControlsFX version JabRef uses (11.2.3): `AutoCompletionBinding#setVisibleRowCount(int)` is a public API, and `TextFields.bindAutoCompletion(...)` returns `AutoCompletionBinding<T>`, so chaining `.setVisibleRowCount(5)` is type-correct. The change is a single call appended to already-compiling code and does not alter completion logic—only the popup height.
- Full build + test suite will run via JabRef CI on this PR.