### PR TITLE
fix: add x-api-key header to SemanticScholar search requests

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/SemanticScholar.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/SemanticScholar.java
@@ -53,6 +53,14 @@ public class SemanticScholar implements FulltextFetcher, PagedSearchBasedParserF
         this.importerPreferences = importerPreferences;
     }
 
+    @Override
+    public URLDownload getUrlDownload(URL url) {
+        URLDownload download = new URLDownload(url);
+        importerPreferences.getApiKey(getName()).ifPresent(
+                key -> download.addHeader("x-api-key", key));
+        return download;
+    }
+
     /// Tries to find a fulltext URL for a given BibTex entry.
     ///
     /// Uses the DOI if present, otherwise the arXiv identifier.


### PR DESCRIPTION
## Description

The SemanticScholar API requires the API key in the 'x-api-key' HTTP header for all requests. The `findFullText()` and `getURLBySource()` methods correctly set this header, but search requests (via `buildSearchURL()` → `getUrlDownload()`) did not, resulting in HTTP 429 rate limiting errors.

## Fix

Override `getUrlDownload()` in `SemanticScholar` to add the 'x-api-key' header, matching the pattern already used in `getURLBySource()`.

## Verification

- `findFullText()` sets header via Jsoup: key -> jsoupRequest.header("x-api-key", key) ✓
- `getURLBySource()` sets header via URLDownload: download.addHeader("x-api-key", key) ✓
- `buildSearchURL()` → parent `getBibEntries()` → `getUrlDownload()` → **was missing header** ✗
- Now overridden to add header before returning URLDownload ✓