### PR TITLE
SLR: study lock file

### DIFF
--- a/docs/requirements/slr.md
+++ b/docs/requirements/slr.md
@@ -42,6 +42,8 @@ This applies to all catalogs the system supports, regardless of whether the rese
 ## Lock file for reproducibility
 `req~slr.lock-file~1`
 
+Needs: impl
+
 Covers: `feat~slr~1`
 
 After each crawl, the system shall record the exact query sent to each catalog so the crawl can be reproduced. The record shall be machine-readable and produce identical content when the same study is crawled again with no changes.

--- a/docs/requirements/slr.md
+++ b/docs/requirements/slr.md
@@ -46,6 +46,4 @@ Covers: `feat~slr~1`
 
 After each crawl, the system shall record the exact query sent to each catalog so the crawl can be reproduced. The record shall be machine-readable and produce identical content when the same study is crawled again with no changes.
 
-> Planned. Not yet implemented.
-
 <!-- markdownlint-disable-file MD022 -->

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -464,7 +464,7 @@ public class StudyRepository {
 
     private StudyQuery toLockQuery(StudyQuery query) {
         Map<String, String> overrides = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        overrides.putAll(query.getCatalogSpecific());
+        query.getCatalogSpecific().forEach(overrides::putIfAbsent);
 
         Map<String, String> effectiveQueries = new LinkedHashMap<>();
         for (StudyCatalog catalog : getActiveLibraryEntries()) {

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -63,6 +64,7 @@ public class StudyRepository {
     // Tests work with study.yml
     public static final String STUDY_DEFINITION_FILE_NAME = "study.yml";
     public static final int DEFAULT_RESULT_LIMIT = 100;
+    public static final String STUDY_LOCK_FILE_NAME = "study-lock.yml";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StudyRepository.class);
 
@@ -434,6 +436,46 @@ public class StudyRepository {
             addFetcherGroupToMetaData(existingStudyResultEntries, fetcherName);
         }
         writeResultToFile(getPathToStudyResultFile(), existingStudyResultEntries);
+
+        writeStudyLockFile();
+    }
+
+    /// Writes the study lock file, it records the exact query sent to each catalog, so a crawl can be reproduced.
+    ///
+    /// The content depends only on the study definition, crawling the same unchanged study again produces identical content.
+    // [impl->req~slr.lock-file~1]
+    private void writeStudyLockFile() throws IOException {
+        new StudyYamlParser().writeStudyYamlFile(buildStudyLock(), repositoryPath.resolve(STUDY_LOCK_FILE_NAME));
+    }
+
+    /// Builds the lock representation of the study.
+    ///
+    /// For each query, the catalog-specific map lists every enabled catalog with its effective query:
+    /// the catalog-specific override if one is defined for it, otherwise the query string itself.
+    /// Disabled catalogs are not listed, as no query is sent to them.
+    private Study buildStudyLock() {
+        List<StudyQuery> lockQueries = study.getQueries().stream()
+                                            .map(this::toLockQuery)
+                                            .toList();
+        Study lock = new Study(study.getAuthors(), study.getTitle(), study.getResearchQuestions(), lockQueries, study.getCatalogs());
+        lock.setMaxResultsPerCatalog(study.getMaxResultsPerCatalog());
+        return lock;
+    }
+
+    private StudyQuery toLockQuery(StudyQuery query) {
+        Map<String, String> overrides = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        overrides.putAll(query.getCatalogSpecific());
+
+        Map<String, String> effectiveQueries = new LinkedHashMap<>();
+        for (StudyCatalog catalog : getActiveLibraryEntries()) {
+            String override = overrides.get(catalog.getName());
+            boolean hasOverride = override != null && !override.isBlank();
+            effectiveQueries.put(catalog.getName(), hasOverride ? override : query.getQuery());
+        }
+
+        StudyQuery lockQuery = new StudyQuery(query.getQuery());
+        lockQuery.setCatalogSpecific(effectiveQueries);
+        return lockQuery;
     }
 
     private void generateCiteKeys(BibDatabaseContext existingEntries, BibDatabase targetEntries) {

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -33,6 +33,7 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.os.OS;
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.util.io.FileNameCleaner;
+import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -205,6 +206,14 @@ public class StudyRepository {
                     .toList();
     }
 
+    /// Returns the fetchers of all enabled catalogs, catalogs without a matching fetcher are not returned
+    private List<SearchBasedFetcher> getActiveFetchers() {
+        return new StudyCatalogToFetcherConverter(
+                getActiveLibraryEntries(),
+                preferences.getImportFormatPreferences(),
+                preferences.getImporterPreferences()).getActiveFetchers();
+    }
+
     /// returns the effective result limit per catalog: its own override, else the study wide
     /// default, else [#DEFAULT_RESULT_LIMIT], keys match catalog names case-insensitively
     public Map<String, Integer> getResultLimitsPerCatalog() {
@@ -291,14 +300,10 @@ public class StudyRepository {
     /// Create for each query a folder, and for each fetcher a bib file in the query folder to store its results.
     private void setUpRepositoryStructureForQueriesAndFetchers() throws IOException {
         // Cannot use stream here since IOException has to be thrown
-        StudyCatalogToFetcherConverter converter = new StudyCatalogToFetcherConverter(
-                this.getActiveLibraryEntries(),
-                preferences.getImportFormatPreferences(),
-                preferences.getImporterPreferences());
+        List<SearchBasedFetcher> activeFetchers = getActiveFetchers();
         for (String query : this.getSearchQueryStrings()) {
             createQueryResultFolder(query);
-            converter.getActiveFetchers()
-                     .forEach(searchBasedFetcher -> createFetcherResultFile(query, searchBasedFetcher));
+            activeFetchers.forEach(searchBasedFetcher -> createFetcherResultFile(query, searchBasedFetcher));
             createQueryResultFile(query);
         }
         createStudyResultFile();
@@ -450,27 +455,29 @@ public class StudyRepository {
 
     /// Builds the lock representation of the study.
     ///
-    /// For each query, the catalog-specific map lists every enabled catalog with its effective query:
+    /// For each query, the catalog-specific map lists every catalog that is queried with its effective query:
     /// the catalog-specific override if one is defined for it, otherwise the query string itself.
-    /// Disabled catalogs are not listed, as no query is sent to them.
+    /// Disabled catalogs and catalogs without a matching fetcher are not listed, as no query is sent to them.
     private Study buildStudyLock() {
+        List<String> catalogNames = getActiveFetchers().stream()
+                                                       .map(SearchBasedFetcher::getName)
+                                                       .toList();
         List<StudyQuery> lockQueries = study.getQueries().stream()
-                                            .map(this::toLockQuery)
+                                            .map(query -> toLockQuery(query, catalogNames))
                                             .toList();
         Study lock = new Study(study.getAuthors(), study.getTitle(), study.getResearchQuestions(), lockQueries, study.getCatalogs());
         lock.setMaxResultsPerCatalog(study.getMaxResultsPerCatalog());
         return lock;
     }
 
-    private StudyQuery toLockQuery(StudyQuery query) {
+    private StudyQuery toLockQuery(StudyQuery query, List<String> catalogNames) {
         Map<String, String> overrides = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         query.getCatalogSpecific().forEach(overrides::putIfAbsent);
 
         Map<String, String> effectiveQueries = new LinkedHashMap<>();
-        for (StudyCatalog catalog : getActiveLibraryEntries()) {
-            String override = overrides.get(catalog.getName());
-            boolean hasOverride = override != null && !override.isBlank();
-            effectiveQueries.put(catalog.getName(), hasOverride ? override : query.getQuery());
+        for (String catalogName : catalogNames) {
+            String override = overrides.get(catalogName);
+            effectiveQueries.put(catalogName, StringUtil.isBlank(override) ? query.getQuery() : override);
         }
 
         StudyQuery lockQuery = new StudyQuery(query.getQuery());

--- a/jablib/src/main/java/org/jabref/model/study/Study.java
+++ b/jablib/src/main/java/org/jabref/model/study/Study.java
@@ -111,7 +111,7 @@ public class Study {
         return maxResultsPerCatalog;
     }
 
-    public void setMaxResultsPerCatalog(Integer maxResultsPerCatalog) {
+    public void setMaxResultsPerCatalog(@Nullable Integer maxResultsPerCatalog) {
         this.maxResultsPerCatalog = maxResultsPerCatalog;
     }
 

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -36,6 +36,7 @@ import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.study.FetchResult;
 import org.jabref.model.study.QueryResult;
 import org.jabref.model.study.Study;
+import org.jabref.model.study.StudyQuery;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -253,6 +254,88 @@ class StudyRepositoryTest {
         limits.forEach((catalog, limit) ->
                 assertEquals(StudyRepository.DEFAULT_RESULT_LIMIT, limit,
                         () -> "Catalog '" + catalog + "' did not resolve to the default"));
+    }
+
+    @Test
+    void studyLockFileCreatedAfterPersist() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        studyRepository.persist(getMockResults());
+
+        assertTrue(Files.exists(tempRepositoryDirectory.resolve(StudyRepository.STUDY_LOCK_FILE_NAME)));
+    }
+
+    @Test
+    void studyLockRecordsEffectiveQueryForEachEnabledCatalog() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        studyRepository.persist(getMockResults());
+
+        Study lock = parseStudyLock();
+
+        assertEquals(3, lock.getQueries().size());
+        StudyQuery quantumLock = lock.getQueries().getFirst();
+        assertEquals("Quantum", quantumLock.getQuery());
+        assertEquals(Map.of("Springer", "Quantum", "ArXiv", "Quantum", "Medline/PubMed", "Quantum"), quantumLock.getCatalogSpecific());
+    }
+
+    @Test
+    void studyLockExcludesDisabledCatalogs() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        studyRepository.persist(getMockResults());
+
+        assertFalse(parseStudyLock().getQueries().getFirst().getCatalogSpecific().containsKey("IEEEXplore"));
+    }
+
+    @Test
+    void studyLockPreservesCatalogSpecificOverride() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        studyRepository.getStudy().getQueries().getFirst().getCatalogSpecific().put("ArXiv", "ti:Quantum");
+
+        studyRepository.persist(getMockResults());
+
+        Map<String, String> effectiveQueries = parseStudyLock().getQueries().getFirst().getCatalogSpecific();
+        assertEquals("ti:Quantum", effectiveQueries.get("ArXiv"));
+        assertEquals("Quantum", effectiveQueries.get("Springer"));
+    }
+
+    @Test
+    void studyLockMatchesOverrideCaseInsensitively() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        studyRepository.getStudy().getQueries().getFirst().getCatalogSpecific().put("arxiv", "ti:Quantum");
+
+        studyRepository.persist(getMockResults());
+
+        assertEquals("ti:Quantum", parseStudyLock().getQueries().getFirst().getCatalogSpecific().get("ArXiv"));
+    }
+
+    @Test
+    void studyLockFallsBackToQueryForBlankOverride() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        studyRepository.getStudy().getQueries().getFirst().getCatalogSpecific().put("ArXiv", " ");
+
+        studyRepository.persist(getMockResults());
+
+        assertEquals("Quantum", parseStudyLock().getQueries().getFirst().getCatalogSpecific().get("ArXiv"));
+    }
+
+    @Test
+    void studyLockContentIsIdenticalWhenPersistedAgain() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        Path lockFile = tempRepositoryDirectory.resolve(StudyRepository.STUDY_LOCK_FILE_NAME);
+
+        studyRepository.persist(getMockResults());
+        String firstContent = Files.readString(lockFile);
+        studyRepository.persist(getMockResults());
+
+        assertEquals(firstContent, Files.readString(lockFile));
+    }
+
+    @Test
+    void studyLockPreservesResultLimits() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        studyRepository.getStudy().setMaxResultsPerCatalog(100);
+        studyRepository.getStudy().getCatalogs().getFirst().setMaxResults(500);
+
+        studyRepository.persist(getMockResults());
+
+        Study lock = parseStudyLock();
+        assertEquals(100, lock.getMaxResultsPerCatalog());
+        assertEquals(500, lock.getCatalogs().getFirst().getMaxResults());
+    }
+
+    private Study parseStudyLock() throws IOException {
+        return new StudyYamlParser().parseStudyYamlFile(tempRepositoryDirectory.resolve(StudyRepository.STUDY_LOCK_FILE_NAME));
     }
 
     private StudyRepository getTestStudyRepository() throws IOException, URISyntaxException, JabRefException {

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -36,6 +36,7 @@ import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.study.FetchResult;
 import org.jabref.model.study.QueryResult;
 import org.jabref.model.study.Study;
+import org.jabref.model.study.StudyCatalog;
 import org.jabref.model.study.StudyQuery;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
@@ -272,7 +273,16 @@ class StudyRepositoryTest {
         assertEquals(3, lock.getQueries().size());
         StudyQuery quantumLock = lock.getQueries().getFirst();
         assertEquals("Quantum", quantumLock.getQuery());
-        assertEquals(Map.of("Springer", "Quantum", "ArXiv", "Quantum", "Medline/PubMed", "Quantum"), quantumLock.getCatalogSpecific());
+        assertEquals(Map.of("Springer", "Quantum", "arXiv", "Quantum", "Medline/PubMed", "Quantum"), quantumLock.getCatalogSpecific());
+    }
+
+    @Test
+    void studyLockExcludesCatalogsWithoutFetcher() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        studyRepository.getStudy().getCatalogs().add(new StudyCatalog("NotAFetcher", true));
+
+        studyRepository.persist(getMockResults());
+
+        assertFalse(parseStudyLock().getQueries().getFirst().getCatalogSpecific().containsKey("NotAFetcher"));
     }
 
     @Test
@@ -284,43 +294,43 @@ class StudyRepositoryTest {
 
     @Test
     void studyLockPreservesCatalogSpecificOverride() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
-        studyRepository.getStudy().getQueries().getFirst().getCatalogSpecific().put("ArXiv", "ti:Quantum");
+        studyRepository.getStudy().getQueries().getFirst().getCatalogSpecific().put("arXiv", "ti:Quantum");
 
         studyRepository.persist(getMockResults());
 
         Map<String, String> effectiveQueries = parseStudyLock().getQueries().getFirst().getCatalogSpecific();
-        assertEquals("ti:Quantum", effectiveQueries.get("ArXiv"));
+        assertEquals("ti:Quantum", effectiveQueries.get("arXiv"));
         assertEquals("Quantum", effectiveQueries.get("Springer"));
     }
 
     @Test
     void studyLockMatchesOverrideCaseInsensitively() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
-        studyRepository.getStudy().getQueries().getFirst().getCatalogSpecific().put("arxiv", "ti:Quantum");
+        studyRepository.getStudy().getQueries().getFirst().getCatalogSpecific().put("ARXIV", "ti:Quantum");
 
         studyRepository.persist(getMockResults());
 
-        assertEquals("ti:Quantum", parseStudyLock().getQueries().getFirst().getCatalogSpecific().get("ArXiv"));
+        assertEquals("ti:Quantum", parseStudyLock().getQueries().getFirst().getCatalogSpecific().get("arXiv"));
     }
 
     @Test
     void studyLockUsesFirstOverrideWhenKeysDifferOnlyByCase() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
         Map<String, String> catalogSpecific = studyRepository.getStudy().getQueries().getFirst().getCatalogSpecific();
         catalogSpecific.put("arxiv", "ti:First");
-        catalogSpecific.put("ArXiv", "ti:Second");
+        catalogSpecific.put("ARXIV", "ti:Second");
 
         studyRepository.persist(getMockResults());
 
         // StudyFetcher uses the first case-insensitive match, so the lock must record the same one
-        assertEquals("ti:First", parseStudyLock().getQueries().getFirst().getCatalogSpecific().get("ArXiv"));
+        assertEquals("ti:First", parseStudyLock().getQueries().getFirst().getCatalogSpecific().get("arXiv"));
     }
 
     @Test
     void studyLockFallsBackToQueryForBlankOverride() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
-        studyRepository.getStudy().getQueries().getFirst().getCatalogSpecific().put("ArXiv", " ");
+        studyRepository.getStudy().getQueries().getFirst().getCatalogSpecific().put("arXiv", " ");
 
         studyRepository.persist(getMockResults());
 
-        assertEquals("Quantum", parseStudyLock().getQueries().getFirst().getCatalogSpecific().get("ArXiv"));
+        assertEquals("Quantum", parseStudyLock().getQueries().getFirst().getCatalogSpecific().get("arXiv"));
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -303,6 +303,18 @@ class StudyRepositoryTest {
     }
 
     @Test
+    void studyLockUsesFirstOverrideWhenKeysDifferOnlyByCase() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
+        Map<String, String> catalogSpecific = studyRepository.getStudy().getQueries().getFirst().getCatalogSpecific();
+        catalogSpecific.put("arxiv", "ti:First");
+        catalogSpecific.put("ArXiv", "ti:Second");
+
+        studyRepository.persist(getMockResults());
+
+        // StudyFetcher uses the first case-insensitive match, so the lock must record the same one
+        assertEquals("ti:First", parseStudyLock().getQueries().getFirst().getCatalogSpecific().get("ArXiv"));
+    }
+
+    @Test
     void studyLockFallsBackToQueryForBlankOverride() throws GitAPIException, SaveException, IOException, URISyntaxException, JabRefException {
         studyRepository.getStudy().getQueries().getFirst().getCatalogSpecific().put("ArXiv", " ");
 


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/12640

### PR Description
Now after each crawl, now writes a study-lock.yml file next to study.yml, it records the exact query sent to each enabled catalog. the content depends only on the study definition, so crawling the same unchanged study again produces identical content, as in `req~slr.lock-file~1`

### Steps to test
1-Tools menu -> "Start new systematic literature review", add all required fields and enable one or two catalogs.
2-a new file study-lock.yml exists, it lists every enabled catalog with the query that was sent to it.
### AI usage
Claude Sonnet 5 to investigate files and review my code, also helped me to generate tests, all ai-generated code was reviewed by myself.
### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
