### PR TITLE
Make follow-up timeline stricter

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,13 +31,13 @@ jobs:
           stale-pr-label: "status: stale"
           remove-pr-stale-when-updated: false
 
-          days-before-pr-stale: 10
+          days-before-pr-stale: 3
           stale-pr-message: >
-            The requested changes were not addressed for 10 days.
-            Please follow-up in the next 10 days or your PR will be automatically closed.
+            The requested changes were not addressed for 3 days.
+            Please follow-up in the next 7 days or your PR will be automatically closed.
             You can check the [contributing guidelines](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md#pull-request-process) for hints on the pull request process.
 
-          days-before-pr-close: 10
+          days-before-pr-close: 7
           close-pr-message: >
             This PR is being closed due to continued inactivity.
       - uses: actions/checkout@v7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,6 +17,9 @@ jobs:
   stale:
     if: github.repository == 'JabRef/jabref'
     runs-on: ubuntu-slim
+    env:
+      DAYS_BEFORE_PR_STALE: 3
+      DAYS_BEFORE_PR_CLOSE: 7
     steps:
       - uses: actions/stale@v10
         id: stale
@@ -31,13 +34,13 @@ jobs:
           stale-pr-label: "status: stale"
           remove-pr-stale-when-updated: false
 
-          days-before-pr-stale: 3
+          days-before-pr-stale: ${{ env.DAYS_BEFORE_PR_STALE }}
           stale-pr-message: >
-            The requested changes were not addressed for 3 days.
-            Please follow-up in the next 7 days or your PR will be automatically closed.
+            The requested changes were not addressed for ${{ env.DAYS_BEFORE_PR_STALE }} days.
+            Please follow-up in the next ${{ env.DAYS_BEFORE_PR_CLOSE }} days or your PR will be automatically closed.
             You can check the [contributing guidelines](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md#pull-request-process) for hints on the pull request process.
 
-          days-before-pr-close: 7
+          days-before-pr-close: ${{ env.DAYS_BEFORE_PR_CLOSE }}
           close-pr-message: >
             This PR is being closed due to continued inactivity.
       - uses: actions/checkout@v7


### PR DESCRIPTION
### Related issues and pull requests

Triggered by https://github.com/JabRef/jabref/pull/16066#discussion_r3592352554

### PR Description

We have a bot in place, nagging contributors to follow up. This bot is only showing up when "changes required" - not when there are no bot comments. Thus, no increased pressure on the maintainers.

### Steps to test

See more PRs closed automatically.

### AI usage

🧠

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
