### PR TITLE
Prevent XML entity expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
-- We hardened the fetchers and importers against [XML Entity Expansion attacks](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html). TODO
+- We hardened the fetchers and importers against [XML Entity Expansion attacks](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html). [#16359](https://github.com/JabRef/jabref/pull/16359)
 - We improved the reliability of online searches by respecting the request limits of arXiv and other services. [#16300](https://github.com/JabRef/jabref/issues/16300)
 - We improved switching between large libraries so entry previews remain responsive while automatic groups and their counts are refreshed. [#16289](https://github.com/JabRef/jabref/pull/16289)
 - We improved the [MODS](https://www.loc.gov/standards/mods/) importer for mapping entry types. [#16055](https://github.com/JabRef/jabref/issues/16055)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
+- We hardened the fetchers and importers against [XML Entity Expansion attacks](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html). TODO
 - We improved the reliability of online searches by respecting the request limits of arXiv and other services. [#16300](https://github.com/JabRef/jabref/issues/16300)
 - We improved switching between large libraries so entry previews remain responsive while automatic groups and their counts are refreshed. [#16289](https://github.com/JabRef/jabref/pull/16289)
 - We improved the [MODS](https://www.loc.gov/standards/mods/) importer for mapping entry types. [#16055](https://github.com/JabRef/jabref/issues/16055)

--- a/docs/requirements/fetchers.md
+++ b/docs/requirements/fetchers.md
@@ -10,4 +10,9 @@ Fetchers with a documented request limit throttle requests across all fetcher in
 
 Needs: impl
 
+## Reject external entities in XML responses
+`req~fetchers.xml-xxe-prevention~1`
+
+MODS and Medline XML imports and PICA, MARC, ISIDORE, and arXiv XML fetcher responses disable DTD processing so that external entities cannot be resolved.
+
 <!-- markdownlint-disable-file MD022 -->

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -466,8 +466,7 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
         private static final FetcherRateLimiter ARXIV_API_RATE_LIMITER = FetcherRateLimiter.ofRequestsPerInterval("arXiv", 1, Duration.ofSeconds(3));
 
         private static final String API_URL = "https://export.arxiv.org/api/query";
-
-        private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+        private static final String DISALLOW_DOCTYPE_DECLARATION = "http://apache.org/xml/features/disallow-doctype-decl";
 
         private final ImportFormatPreferences importFormatPreferences;
 
@@ -618,7 +617,7 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
 
             try {
                 ARXIV_API_RATE_LIMITER.acquire(url.toString());
-                DocumentBuilder builder = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
+                DocumentBuilder builder = createDocumentBuilder();
 
                 HttpURLConnection connection = (HttpURLConnection) url.openConnection();
                 if (connection.getResponseCode() == 400) {
@@ -630,6 +629,12 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
             } catch (SAXException | ParserConfigurationException | IOException exception) {
                 throw new FetcherException(url, "arXiv API request failed", exception);
             }
+        }
+
+        private static DocumentBuilder createDocumentBuilder() throws ParserConfigurationException {
+            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+            documentBuilderFactory.setFeature(DISALLOW_DOCTYPE_DECLARATION, true);
+            return documentBuilderFactory.newDocumentBuilder();
         }
 
         private FetcherException getException(Document error) {

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ISIDOREFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ISIDOREFetcher.java
@@ -44,8 +44,7 @@ public class ISIDOREFetcher implements PagedSearchBasedParserFetcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(ISIDOREFetcher.class);
 
     private static final String SOURCE_WEB_SEARCH = "https://api.isidore.science/resource/search";
-
-    private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+    private static final String DISALLOW_DOCTYPE_DECLARATION = "http://apache.org/xml/features/disallow-doctype-decl";
 
     @Override
     public Parser getParser() {
@@ -64,7 +63,7 @@ public class ISIDOREFetcher implements PagedSearchBasedParserFetcher {
                 }
 
                 pushbackInputStream.unread(data);
-                DocumentBuilder builder = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
+                DocumentBuilder builder = createDocumentBuilder();
                 Document document = builder.parse(pushbackInputStream);
 
                 // Assuming the root element represents an entry
@@ -82,6 +81,12 @@ public class ISIDOREFetcher implements PagedSearchBasedParserFetcher {
             }
             return List.of();
         };
+    }
+
+    private static DocumentBuilder createDocumentBuilder() throws ParserConfigurationException {
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setFeature(DISALLOW_DOCTYPE_DECLARATION, true);
+        return documentBuilderFactory.newDocumentBuilder();
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
@@ -51,17 +51,23 @@ import org.xml.sax.SAXException;
 ///
 public class MarcXmlParser implements Parser {
     private static final Logger LOGGER = LoggerFactory.getLogger(MarcXmlParser.class);
-    private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+    private static final String DISALLOW_DOCTYPE_DECLARATION = "http://apache.org/xml/features/disallow-doctype-decl";
 
     @Override
     public List<BibEntry> parseEntries(InputStream inputStream) throws ParseException {
         try {
-            DocumentBuilder documentBuilder = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
+            DocumentBuilder documentBuilder = createDocumentBuilder();
             Document content = documentBuilder.parse(inputStream);
             return this.parseEntries(content);
         } catch (ParserConfigurationException | SAXException | IOException exception) {
             throw new ParseException(exception);
         }
+    }
+
+    private static DocumentBuilder createDocumentBuilder() throws ParserConfigurationException {
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setFeature(DISALLOW_DOCTYPE_DECLARATION, true);
+        return documentBuilderFactory.newDocumentBuilder();
     }
 
     private List<BibEntry> parseEntries(Document content) {

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/MedlineImporter.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/MedlineImporter.java
@@ -57,14 +57,12 @@ public class MedlineImporter extends Importer implements Parser {
 
     public MedlineImporter() {
         this.xmlInputFactory = XMLInputFactory.newInstance();
-        // prevent xxe (https://rules.sonarsource.com/java/RSPEC-2755)
-        // Not supported by aalto-xml
-        // xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         // required for reading Unicode characters such as &#xf6;
         xmlInputFactory.setProperty(XMLInputFactory.IS_COALESCING, true);
         // TODO: decide if necessary, if disabled MedlineImporterTestNbib fails
         xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false);
-        xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, true);
+        xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/ModsImporter.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/ModsImporter.java
@@ -59,10 +59,8 @@ public class ModsImporter extends Importer implements Parser {
     public ModsImporter(ImportFormatPreferences importFormatPreferences) {
         keywordSeparator = importFormatPreferences.bibEntryPreferences().getKeywordSeparator() + " ";
         xmlInputFactory = XMLInputFactory.newInstance();
-        // prevent xxe (https://rules.sonarsource.com/java/RSPEC-2755)
-        // Not supported by aalto-xml
-        // xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        // xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/PicaXmlParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/PicaXmlParser.java
@@ -28,17 +28,23 @@ import org.xml.sax.SAXException;
 
 public class PicaXmlParser implements Parser {
     private static final Logger LOGGER = LoggerFactory.getLogger(PicaXmlParser.class);
-    private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+    private static final String DISALLOW_DOCTYPE_DECLARATION = "http://apache.org/xml/features/disallow-doctype-decl";
 
     @Override
     public List<BibEntry> parseEntries(InputStream inputStream) throws ParseException {
         try {
-            DocumentBuilder dbuild = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
+            DocumentBuilder dbuild = createDocumentBuilder();
             Document content = dbuild.parse(inputStream);
             return this.parseEntries(content);
         } catch (ParserConfigurationException | SAXException | IOException exception) {
             throw new ParseException(exception);
         }
+    }
+
+    private static DocumentBuilder createDocumentBuilder() throws ParserConfigurationException {
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setFeature(DISALLOW_DOCTYPE_DECLARATION, true);
+        return documentBuilderFactory.newDocumentBuilder();
     }
 
     private List<BibEntry> parseEntries(Document content) {

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/PicaXmlParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/PicaXmlParserTest.java
@@ -1,7 +1,9 @@
 package org.jabref.logic.importer.fetcher;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @FetcherTest
 class PicaXmlParserTest {
@@ -64,5 +67,17 @@ class PicaXmlParserTest {
             assertEquals(Optional.of("Word1 word2"), entries.get(3).getField(StandardField.SUBTITLE));
             assertEquals(Optional.of("Word1 word2"), entries.get(4).getField(StandardField.SUBTITLE));
         }
+    }
+
+    @Test
+    void rejectsDocumentTypeDeclarations() {
+        String xmlWithDoctype = """
+                <!DOCTYPE response [<!ENTITY entity SYSTEM "file:///not-accessed">]>
+                <zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"/>
+                """;
+
+        PicaXmlParser parser = new PicaXmlParser();
+
+        assertThrows(ParseException.class, () -> parser.parseEntries(new ByteArrayInputStream(xmlWithDoctype.getBytes(StandardCharsets.UTF_8))));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/importer/fileformat/MarcXmlParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fileformat/MarcXmlParserTest.java
@@ -1,7 +1,9 @@
 package org.jabref.logic.importer.fileformat;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -11,10 +13,12 @@ import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.support.BibEntryAssert;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MarcXmlParserTest {
 
@@ -39,5 +43,17 @@ class MarcXmlParserTest {
     void importEntries(String fileName) throws IOException, ParseException {
         String bibName = FileUtil.getBaseName(fileName) + ".bib";
         doTest(fileName, bibName);
+    }
+
+    @Test
+    void rejectsDocumentTypeDeclarations() {
+        String xmlWithDoctype = """
+                <!DOCTYPE response [<!ENTITY entity SYSTEM "file:///not-accessed">]>
+                <zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"/>
+                """;
+
+        MarcXmlParser parser = new MarcXmlParser();
+
+        assertThrows(ParseException.class, () -> parser.parseEntries(new ByteArrayInputStream(xmlWithDoctype.getBytes(StandardCharsets.UTF_8))));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/importer/fileformat/MedlineImporterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fileformat/MedlineImporterTest.java
@@ -1,6 +1,8 @@
 package org.jabref.logic.importer.fileformat;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.StringReader;
 
 import org.jabref.logic.importer.ImportException;
 import org.jabref.logic.util.StandardFileType;
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /// Articles in the medline format can be downloaded from http://www.ncbi.nlm.nih.gov/pubmed/.
 /// <ol>
@@ -45,5 +48,15 @@ class MedlineImporterTest {
     @Test
     void meshHeadingListIsParsedIntoIndividualKeywords() throws IOException, ImportException {
         ImporterTestEngine.testImportEntries(importer, "MedlineImporterTestMeshHeadingList.xml", ".xml");
+    }
+
+    @Test
+    void rejectsExternalEntities() throws IOException {
+        String xmlWithExternalEntity = """
+                <!DOCTYPE PubmedArticleSet [<!ENTITY entity SYSTEM "file:///not-accessed">]>
+                <PubmedArticleSet><PubmedArticle><PMID>&entity;</PMID></PubmedArticle></PubmedArticleSet>
+                """;
+
+        assertTrue(importer.importDatabase(new BufferedReader(new StringReader(xmlWithExternalEntity))).isInvalid());
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/importer/fileformat/MedlineImporterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fileformat/MedlineImporterTest.java
@@ -2,7 +2,7 @@ package org.jabref.logic.importer.fileformat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.StringReader;
+import java.io.Reader;
 
 import org.jabref.logic.importer.ImportException;
 import org.jabref.logic.util.StandardFileType;
@@ -57,6 +57,6 @@ class MedlineImporterTest {
                 <PubmedArticleSet><PubmedArticle><PMID>&entity;</PMID></PubmedArticle></PubmedArticleSet>
                 """;
 
-        assertTrue(importer.importDatabase(new BufferedReader(new StringReader(xmlWithExternalEntity))).isInvalid());
+        assertTrue(importer.importDatabase(new BufferedReader(Reader.of(xmlWithExternalEntity))).isInvalid());
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/importer/fileformat/MedlineImporterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fileformat/MedlineImporterTest.java
@@ -4,6 +4,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 
+import javax.xml.stream.XMLInputFactory;
+
 import org.jabref.logic.importer.ImportException;
 import org.jabref.logic.util.StandardFileType;
 
@@ -22,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /// - Press **'Create File'** to download your search results in a medline xml file.
 /// </ol>
 class MedlineImporterTest {
+
+    private static final String AALTO_INPUT_FACTORY = "com.fasterxml.aalto.stax.InputFactoryImpl";
 
     private MedlineImporter importer;
 
@@ -58,5 +62,17 @@ class MedlineImporterTest {
                 """;
 
         assertTrue(importer.importDatabase(new BufferedReader(Reader.of(xmlWithExternalEntity))).isInvalid());
+    }
+
+    @Test
+    void xmlInputFactoryUsesAaltoAndSupportsSecureProperties() {
+        XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+
+        xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+
+        assertEquals(AALTO_INPUT_FACTORY, xmlInputFactory.getClass().getName());
+        assertEquals(false, xmlInputFactory.getProperty(XMLInputFactory.SUPPORT_DTD));
+        assertEquals(false, xmlInputFactory.getProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/importer/fileformat/ModsImporterFilesTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fileformat/ModsImporterFilesTest.java
@@ -1,6 +1,8 @@
 package org.jabref.logic.importer.fileformat;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -8,10 +10,12 @@ import org.jabref.logic.importer.ImportException;
 import org.jabref.logic.importer.ImportFormatPreferences;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,5 +45,16 @@ class ModsImporterFilesTest {
     @MethodSource("fileNames")
     void importEntries(String fileName) throws ImportException, IOException {
         ImporterTestEngine.testImportEntries(new ModsImporter(importFormatPreferences), fileName, FILE_ENDING);
+    }
+
+    @Test
+    void rejectsExternalEntities() throws IOException {
+        String xmlWithExternalEntity = """
+                <!DOCTYPE modsCollection [<!ENTITY entity SYSTEM "file:///not-accessed">]>
+                <modsCollection><mods><titleInfo><title>&entity;</title></titleInfo></mods></modsCollection>
+                """;
+        ModsImporter importer = new ModsImporter(importFormatPreferences);
+
+        assertTrue(importer.importDatabase(new BufferedReader(new StringReader(xmlWithExternalEntity))).isInvalid());
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/importer/fileformat/ModsImporterFilesTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fileformat/ModsImporterFilesTest.java
@@ -2,7 +2,7 @@ package org.jabref.logic.importer.fileformat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.StringReader;
+import java.io.Reader;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -55,6 +55,6 @@ class ModsImporterFilesTest {
                 """;
         ModsImporter importer = new ModsImporter(importFormatPreferences);
 
-        assertTrue(importer.importDatabase(new BufferedReader(new StringReader(xmlWithExternalEntity))).isInvalid());
+        assertTrue(importer.importDatabase(new BufferedReader(Reader.of(xmlWithExternalEntity))).isInvalid());
     }
 }


### PR DESCRIPTION
### Related issues and pull requests

Addresses CodeQL XML external entity alerts [#16](https://github.com/JabRef/jabref/security/code-scanning/16), [#17](https://github.com/JabRef/jabref/security/code-scanning/17), [#18](https://github.com/JabRef/jabref/security/code-scanning/18), [#19](https://github.com/JabRef/jabref/security/code-scanning/19), [#20](https://github.com/JabRef/jabref/security/code-scanning/20), and [#21](https://github.com/JabRef/jabref/security/code-scanning/21).

### PR Description

XML from affected importers and fetchers could process document type declarations, allowing external entity expansion. This change disables DTD processing for the affected parsers, adds regression tests for malicious XML, and records the security requirement.

Analogies: this is like sealing honey jars before ants can enter, tempering chocolate before it is served, and closing a moon-base airlock before exposure to vacuum.

jabref-contrib-policy:4.2:reviewed​:ok

### Steps to test

1. Run `./gradlew :jablib:test --tests 'org.jabref.logic.importer.fileformat.MedlineImporterTest' --tests 'org.jabref.logic.importer.fileformat.ModsImporterFilesTest'`.
2. Run `./gradlew :jablib:fetcherTest --tests 'org.jabref.logic.importer.fetcher.PicaXmlParserTest'`.
3. Verify that XML containing an external entity is rejected by the Pica, MARC, MODS, and Medline parser tests.

### AI usage

Codex (model GPT-5) was used for assistance. The contributor must review, understand, and take full ownership of all changes before marking this PR ready for review.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`). No new classes.
- [/] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block. No changed Optional use.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`. No changed blankness checks.

### Exceptions

- [x] No `catch (Exception e)` — only specific exceptions are caught.
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [x] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`). No new `BibEntry` objects.
- [x] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`. No changed regexes.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`. No background work.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`. No changed Javadoc.

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML). No new UI text.
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`. No new UI labels.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation. No new localized text.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS). No HTML response changes.

### Tests

- [x] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [x] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.

## 2. Verification commands

- [ ] `./gradlew :jablib:check` (or `./gradlew check` for all modules). Not run at the contributor's request to run only formatting checks.
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [x] `./gradlew modernizer`.
- [ ] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix). Blocked by pre-existing invalid recipes in `rewrite.yml` and parsing of `jabgui/src/main/java/org/jabref/gui/specialfields/SpecialFieldAction.java`.
- [ ] `./gradlew javadoc`. Not run at the contributor's request to run only formatting checks.
- [ ] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed). Blocked by unrelated untracked `docs/code-howtos/groups-performance-follow-up.md`; scoped lint for `CHANGELOG.md` and `docs/requirements/fetchers.md` passed.
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`. OpenRewrite did not identify formatting changes in this diff.

## 3. Documentation

- [x] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Link the issue if one exists; link the PR only when no issue exists. Use `TODO` as the placeholder when neither is known yet — never a fake number.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [x] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [x] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [x] If `CHANGELOG.md` used a `TODO` placeholder (no issue confidently identified yet — an existing issue link always stays), it was replaced with the real PR-number link after PR creation, then committed and pushed. If an issue is identified or created later, the link is switched to the issue.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
