### PR TITLE
fix: skip AI embeddings generation for online-only linked files

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/ai/ingestion/logic/ingestion/LinkedFileIngestor.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/ingestion/logic/ingestion/LinkedFileIngestor.java
@@ -43,6 +43,11 @@ public class LinkedFileIngestor {
     public void ingest(BibDatabaseContext bibDatabaseContext, LinkedFile linkedFile) throws InterruptedException {
         LOGGER.debug("Generating embeddings for file \"{}\"", linkedFile.getLink());
 
+        if (linkedFile.isOnlineLink()) {
+            LOGGER.debug("Skipping embeddings generation for \"{}\", because it is an online link and not a local file", linkedFile.getLink());
+            return;
+        }
+
         Optional<Path> path = linkedFile.findIn(bibDatabaseContext, filePreferences);
 
         if (path.isEmpty()) {


### PR DESCRIPTION
### Related issues and pull requests

Closes #16123

### PR Description

LinkedFileIngestor.ingest() called findIn() on every linked file, including
online-only links (URLs), which always fail to resolve to a local path and
log a misleading ERROR. This adds an early isOnlineLink() check, matching
the pattern already used elsewhere in the codebase (RemoveLinksToNotExistentFiles,
FileChecker, etc.), and logs at debug level instead.

### Steps to test

1. Add an entry with an online-only linked file (a URL, no local copy).
2. Trigger "Generate embeddings" for that file/entry.
3. Before: an ERROR "Could not find path..." appears in the log.
4. After: a debug-level "Skipping embeddings generation..." message appears instead, no ERROR.

### AI usage

Claude (Sonnet 5) drafted this fix after I asked it to find a well-scoped bug in
this codebase. I reviewed the change and the reasoning myself before submitting.

### Checklist
- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] AI tools were used (Claude, Sonnet 5) — disclosed above; I reviewed, understood, and take full ownership of the change
- [ ] I manually tested my changes in running JabRef   <!-- πρέπει να το κάνεις εσύ -->
- [/] I added JUnit tests for changes  <!-- δεν υπήρχε test-friendly seam χωρίς mock του EmbeddingStore/EmbeddingModel· πες το ειλικρινά αν το αφήσεις έτσι -->
- [/] Screenshots (no UI change)
- [x] I described the change in CHANGELOG.md