### PR TITLE
fix: reject .bst styles with duplicate filenames

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/openoffice/style/BstStyleLoader.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/style/BstStyleLoader.java
@@ -60,6 +60,10 @@ public class BstStyleLoader {
             LOGGER.info("BST style already in list: {}", path);
             return false;
         }
+        if (externalStyles.stream().anyMatch(existing -> existing.getName().equals(style.getName()))) {
+            LOGGER.warn("A BST style with the same filename is already in the list: {}", path);
+            return false;
+        }
         externalStyles.add(style);
         storeExternalStyles();
         return true;

--- a/jablib/src/test/java/org/jabref/logic/openoffice/style/BstStyleLoaderTest.java
+++ b/jablib/src/test/java/org/jabref/logic/openoffice/style/BstStyleLoaderTest.java
@@ -1,0 +1,129 @@
+﻿package org.jabref.logic.openoffice.style;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jabref.logic.openoffice.OpenOfficePreferences;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class BstStyleLoaderTest {
+
+    private static final int NUMBER_OF_INTERNAL_STYLES = 3;
+
+    private BstStyleLoader loader;
+    private OpenOfficePreferences preferences;
+
+    @TempDir
+    private Path styleFolder;
+
+    @BeforeEach
+    void setUp() {
+        preferences = mock(OpenOfficePreferences.class, Answers.RETURNS_DEEP_STUBS);
+        preferences.setExternalBstStyles(List.of());
+        loader = new BstStyleLoader(preferences);
+    }
+
+    private Path createBstFile(Path directory, String filename) throws IOException {
+        Files.createDirectories(directory);
+        Path file = directory.resolve(filename);
+        Files.writeString(file, "% dummy bst file for tests");
+        return file;
+    }
+
+    @Test
+    void getStylesWithEmptyExternalContainsOnlyInternalStyles() {
+        assertEquals(NUMBER_OF_INTERNAL_STYLES, loader.getStyles().size());
+    }
+
+    @Test
+    void addValidStyleLeadsToOneMoreStyle() throws IOException {
+        Path bstFile = createBstFile(styleFolder, "mystyle.bst");
+
+        assertTrue(loader.addStyleIfValid(bstFile));
+        assertEquals(NUMBER_OF_INTERNAL_STYLES + 1, loader.getStyles().size());
+    }
+
+    @Test
+    void addNonBstFileIsRejected() throws IOException {
+        Path notBst = createBstFile(styleFolder, "mystyle.txt");
+
+        assertFalse(loader.addStyleIfValid(notBst));
+        assertEquals(NUMBER_OF_INTERNAL_STYLES, loader.getStyles().size());
+    }
+
+    @Test
+    void addNonExistentFileIsRejected() {
+        Path missing = styleFolder.resolve("doesNotExist.bst");
+
+        assertFalse(loader.addStyleIfValid(missing));
+        assertEquals(NUMBER_OF_INTERNAL_STYLES, loader.getStyles().size());
+    }
+
+    @Test
+    void addSamePathTwiceLeadsToOneMoreStyle() throws IOException {
+        Path bstFile = createBstFile(styleFolder, "mystyle.bst");
+
+        assertTrue(loader.addStyleIfValid(bstFile));
+        assertFalse(loader.addStyleIfValid(bstFile));
+        assertEquals(NUMBER_OF_INTERNAL_STYLES + 1, loader.getStyles().size());
+    }
+
+    @Test
+    void addingTwoDifferentFilesWithTheSameFilenameIsRejected() throws IOException {
+        Path firstDir = styleFolder.resolve("first");
+        Path secondDir = styleFolder.resolve("second");
+        Path firstFile = createBstFile(firstDir, "mystyle.bst");
+        Path secondFile = createBstFile(secondDir, "mystyle.bst");
+
+        assertTrue(loader.addStyleIfValid(firstFile));
+        assertFalse(loader.addStyleIfValid(secondFile));
+        assertEquals(NUMBER_OF_INTERNAL_STYLES + 1, loader.getStyles().size());
+    }
+
+    @Test
+    void addingFilesWithDifferentFilenamesBothSucceed() throws IOException {
+        Path firstFile = createBstFile(styleFolder, "mystyle.bst");
+        Path secondFile = createBstFile(styleFolder, "otherstyle.bst");
+
+        assertTrue(loader.addStyleIfValid(firstFile));
+        assertTrue(loader.addStyleIfValid(secondFile));
+        assertEquals(NUMBER_OF_INTERNAL_STYLES + 2, loader.getStyles().size());
+    }
+
+    @Test
+    void removeExternalStyleLeadsToOneLessStyle() throws IOException {
+        Path bstFile = createBstFile(styleFolder, "mystyle.bst");
+        loader.addStyleIfValid(bstFile);
+        int beforeRemoving = loader.getStyles().size();
+
+        BstStyle toRemove = loader.getStyles().stream()
+                                   .filter(style -> !style.isInternalStyle())
+                                   .findFirst()
+                                   .orElseThrow();
+
+        assertTrue(loader.removeStyle(toRemove));
+        assertEquals(beforeRemoving - 1, loader.getStyles().size());
+    }
+
+    @Test
+    void removeInternalStyleReturnsFalseAndDoesNotRemove() {
+        BstStyle internalStyle = loader.getStyles().stream()
+                                        .filter(BstStyle::isInternalStyle)
+                                        .findFirst()
+                                        .orElseThrow();
+
+        assertFalse(loader.removeStyle(internalStyle));
+        assertEquals(NUMBER_OF_INTERNAL_STYLES, loader.getStyles().size());
+    }
+}


### PR DESCRIPTION
### Related issues and pull requests

Closes #16360

### PR Description

BstStyleLoader.addStyleIfValid() only rejected exact-path duplicates
(externalStyles.contains(style)), not duplicate filenames. So two .bst
files with the same filename but in different directories (e.g.
/foo/mystyle.bst and /bar/mystyle.bst) could both be added, ending up
as two indistinguishable entries in the style list — the displayed
name is derived from the filename only, so there was no way to tell
them apart. This adds a filename-collision check alongside the
existing path check, plus a new BstStyleLoaderTest covering both the
old behavior (duplicate path, valid add, invalid extension, missing
file) and the new one (duplicate filename in different directories).

### Steps to test

1. Open Preferences > OpenOffice/LibreOffice > BST styles (or wherever
   the style picker lives in your build).
2. Add an external .bst file, e.g. mystyle.bst from folder A.
3. Try adding a different file also named mystyle.bst from folder B.
4. Before: both get added, list shows two "mystyle" entries.
5. After: the second add is rejected; log shows a warning
   "A BST style with the same filename is already in the list".

### AI usage

Claude (Sonnet 5) drafted this fix and the accompanying test after I
asked it to find a well-scoped bug in this codebase. I reviewed the
change and the reasoning myself before submitting.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] AI tools were used (Claude, Sonnet 5) — disclosed above; I reviewed, understood, and take full ownership of the change
- [ ] I manually tested my changes in running JabRef   <!-- κάν' το πριν το PR -->
- [x] I added JUnit tests for changes
- [/] I added screenshots (no UI change beyond the existing style list rejecting the add)
- [x] I described the change in CHANGELOG.md