### PR TITLE
fix: prevent compounding superscript/subscript on citation marker regeneration

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/openoffice/frontend/UpdateCitationMarkers.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/frontend/UpdateCitationMarkers.java
@@ -78,6 +78,11 @@ public class UpdateCitationMarkers {
                 ZERO_WIDTH_SPACE = "\u200b";
             }
             citationText2 = OOText.fromString(ZERO_WIDTH_SPACE + citationText2.toString());
+            // Citation markers are overwritten in place whenever citations are updated. Without this,
+            // a superscript/subscript style (e.g. Nature, AMA) would compute its escapement relative to
+            // whatever escapement was left over from the previous update, shrinking a little more on
+            // every regeneration.
+            OOTextIntoOO.resetCharEscapement(cursor);
             OOTextIntoOO.write(doc, cursor, citationText2);
         } else {
             cursor.setString("");

--- a/jablib/src/main/java/org/jabref/model/openoffice/ootext/OOTextIntoOO.java
+++ b/jablib/src/main/java/org/jabref/model/openoffice/ootext/OOTextIntoOO.java
@@ -63,6 +63,7 @@ public class OOTextIntoOO {
      */
     private static final String CHAR_ESCAPEMENT_HEIGHT = "CharEscapementHeight";
     private static final String CHAR_ESCAPEMENT = "CharEscapement";
+    private static final String CHAR_AUTO_ESCAPEMENT = "CharAutoEscapement";
     private static final String CHAR_STYLE_NAME = "CharStyleName";
     private static final String CHAR_UNDERLINE = "CharUnderline";
     private static final String CHAR_STRIKEOUT = "CharStrikeout";
@@ -369,6 +370,26 @@ public class OOTextIntoOO {
                 continue;
             }
             LOGGER.warn("OOTextIntoOO.removeDirectFormatting failed on '{}'", p.Name);
+        }
+    }
+
+    /// Reset only the super/subscript ("escapement") properties of the cursor to their default (baseline, 100%) values.
+    ///
+    /// [#setCharEscapement] computes super/subscript size and position relative to whatever escapement is
+    /// already present at the cursor. That is correct for nesting `<sup>`/`<sub>` inside each other within a
+    /// single [#write] call, but if the cursor is positioned over text that already carries a direct
+    /// escapement from an earlier `write` (e.g. a citation marker being regenerated), the new escapement
+    /// would be computed relative to the old one, shrinking (or growing) further on every regeneration.
+    ///
+    /// Call this before writing text whose escapement should always start from the normal baseline,
+    /// regardless of what was there before - e.g. citation markers, which are overwritten in place whenever
+    /// citations are updated.
+    public static void resetCharEscapement(XTextCursor cursor) {
+        XMultiPropertyStates mpss = UnoCast.cast(XMultiPropertyStates.class, cursor).get();
+        try {
+            mpss.setPropertiesToDefault(new String[] {CHAR_AUTO_ESCAPEMENT, CHAR_ESCAPEMENT, CHAR_ESCAPEMENT_HEIGHT});
+        } catch (UnknownPropertyException ex) {
+            LOGGER.warn("OOTextIntoOO.resetCharEscapement failed", ex);
         }
     }
 


### PR DESCRIPTION
### Related issues and pull requests

Closes #16351

### PR Description

Citation markers are written onto a cursor over the persistent reference-mark
range (see Backend52.getFillCursorForCitationGroup -> NamedRange.getFillCursor),
which is reused every time citations are regenerated - it is not a fresh cursor.

setCharEscapement() (used for super/subscript citation styles like Nature/AMA)
always computes the new escapement height relative to whatever escapement is
currently on the cursor, so that nested <sup>/<sub> works correctly within a
single write() call. But when the cursor already carries direct escapement
left over from a *previous* write (i.e. every regeneration after the first),
that previous value becomes the new baseline, so the citation shrinks a bit
more on every regeneration - matching the reported behavior exactly.

Fix: added OOTextIntoOO.resetCharEscapement(cursor), which resets only
CharEscapement/CharEscapementHeight/CharAutoEscapement to default before
writing - unlike the existing removeDirectFormatting(), it does not touch
font, style name, or other direct formatting, so it's safe to call on a
citation marker without stripping the surrounding text's formatting.

### Steps to test

1. In LibreOffice Writer with the JabRef extension, set citation style to
   Nature or AMA (superscript numeric).
2. Insert 2-3 citations.
3. Regenerate/update citations or the bibliography 3-4 times in a row.
4. Before: superscript numbers get visibly smaller each time.
5. After: size stays constant across regenerations.

### AI usage

Claude (Sonnet 5) traced this bug to its root cause in OOTextIntoOO's
relative-escapement calculation and drafted the fix after I asked it to find
well-scoped issues in this codebase. I reviewed the reasoning and the diff
myself before submitting.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] AI tools were used (Claude, Sonnet 5) — disclosed above; I reviewed, understood, and take full ownership of the change
- [ ] I manually tested my changes in running JabRef   <!-- ΠΡΕΠΕΙ να το κάνεις, βλ. Steps to test -->
- [ ] I added JUnit tests for changes   <!-- δεν υπάρχει test infra για UNO cursors σε αυτές τις κλάσεις -->
- [ ] Screenshots   <!-- βάλε before/after αν μπορείς, βοηθάει πολύ σε visual bugs σαν αυτό -->
- [x] I described the change in CHANGELOG.md