### PR TITLE
fix: reapply group filter after removing entries

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
@@ -63,6 +63,7 @@ public class MainTableDataModel {
     private final Subscription searchDisplayModeSubscription;
     private final Subscription selectedGroupsSubscription;
     private final Subscription groupViewModeSubscription;
+    private final ListProperty<GroupTreeNode> selectedGroupsProperty;
     private final SearchIndexListener indexUpdatedListener;
     private final OptionalObjectProperty<SearchQuery> searchQueryProperty;
     @Nullable private final SearchContext searchContext;
@@ -85,6 +86,7 @@ public class MainTableDataModel {
         this.searchQueryProperty = searchQueryProperty;
         this.indexUpdatedListener = new SearchIndexListener();
         this.groupsMatcher = createGroupMatcher(selectedGroupsProperty.get(), groupsPreferences);
+        this.selectedGroupsProperty = selectedGroupsProperty;
 
         this.bibDatabaseContext.getDatabase().registerListener(indexUpdatedListener);
         resetFieldFormatter();
@@ -290,6 +292,12 @@ public class MainTableDataModel {
                     clearSearchMatches();
                 }
             }).onSuccess(result -> FilteredListProxy.refilterListReflection(entriesFiltered)).executeWith(taskExecutor);
+
+            // The search refresh above touches every remaining entry's search-match flags, but never
+            // its group-match flags. Without re-applying the currently selected groups here as well,
+            // entries outside the selected group(s) would incorrectly become visible again as soon as
+            // any entry is removed from the library.
+            updateGroupMatches(selectedGroupsProperty.get());
         }
     }
 }

--- a/jabgui/src/test/java/org/jabref/gui/maintable/MainTableDataModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/maintable/MainTableDataModelTest.java
@@ -329,6 +329,62 @@ class MainTableDataModelTest {
         assertFalse(vmB.isVisibleByGroup().get());
     }
 
+    @Test
+    void removingEntryKeepsGroupFilterAppliedToRemainingEntries() {
+        BibDatabaseContext bibDatabaseContext = new BibDatabaseContext();
+
+        BibEntry bibEntryA = new BibEntry()
+                .withCitationKey("A")
+                .withField(StandardField.AUTHOR, "Alice");
+
+        BibEntry bibEntryB = new BibEntry()
+                .withCitationKey("B")
+                .withField(StandardField.AUTHOR, "Bob");
+
+        BibEntry bibEntryC = new BibEntry()
+                .withCitationKey("C")
+                .withField(StandardField.AUTHOR, "Alice");
+
+        bibDatabaseContext.getDatabase().insertEntries(List.of(bibEntryA, bibEntryB, bibEntryC));
+
+        GuiPreferences preferences = mock(GuiPreferences.class);
+        when(preferences.getGroupsPreferences()).thenReturn(GroupsPreferences.getDefault());
+        when(preferences.getSearchPreferences()).thenReturn(
+                new SearchPreferences(SearchDisplayMode.FILTER, false, false, false, false, false, false, 0, 0, 0));
+        when(preferences.getNameDisplayPreferences()).thenReturn(NameDisplayPreferences.getDefault());
+
+        CurrentThreadTaskExecutor taskExecutor = new CurrentThreadTaskExecutor();
+
+        SimpleListProperty<GroupTreeNode> selectedGroups = new SimpleListProperty<>(FXCollections.observableArrayList());
+        OptionalObjectProperty<SearchQuery> searchQueryProperty = OptionalObjectProperty.empty();
+        IntegerProperty resultSize = new SimpleIntegerProperty();
+
+        MainTableDataModel model = new MainTableDataModel(
+                bibDatabaseContext,
+                preferences,
+                taskExecutor,
+                null,
+                selectedGroups,
+                searchQueryProperty,
+                resultSize);
+
+        BibEntryTableViewModel vmB = model.getViewModelByCitationKey("B").orElseThrow();
+
+        // Select a group that only matches Alice's entries (A and C). Bob's entry (B) is filtered out.
+        selectedGroups.set(FXCollections.observableArrayList(getKeywordGroup(StandardField.AUTHOR, "Alice")));
+
+        assertFalse(vmB.isVisibleByGroup().get());
+        assertEquals(2, resultSize.get());
+
+        // Remove one of the entries that *matches* the selected group (A). B should stay excluded by
+        // the group filter - it must not become visible again just because some entry was removed.
+        bibDatabaseContext.getDatabase().removeEntries(List.of(bibEntryA));
+
+        assertFalse(vmB.isVisibleByGroup().get());
+        assertFalse(vmB.isVisible());
+        assertEquals(1, resultSize.get());
+    }
+
     private static GroupTreeNode getKeywordGroup(Field field, String searchExpression) {
         return GroupTreeNode.fromGroup(new WordKeywordGroup(searchExpression, GroupHierarchyType.INDEPENDENT, field, searchExpression, true, ',', false));
     }


### PR DESCRIPTION
### Related issues and pull requests

Related to #16036 (see note below - not marked as Closes, see PR Description)

### PR Description

MainTableDataModel's EntriesRemovedEvent listener refreshes search-match
state for every remaining entry when an entry is removed, but never
refreshes group-match state. This adds a call to updateGroupMatches()
in that listener, plus a regression test that reproduces the gap directly
at the data-model level: select a group, remove an entry that belongs to
that group, and check that another entry outside the group stays hidden.

Note for reviewers: I traced this from #16036's repro steps, and this is
a real, independently-verifiable gap in the group-filter refresh logic.
I was not able to fully confirm whether this is the complete fix for the
symptom described in #16036 (visually, the sidebar keeps the group
highlighted while the table falls back to "All entries") - part of that
may involve the TreeView/GroupTreeView selection-model binding
(BindingsHelper.bindContentBidirectional in GroupTreeView.java), which I
could not verify without running the app. Happy to narrow this down
further with reviewer input, or split it out if it turns out to be
unrelated.

### Steps to test

1. Run the new test: `MainTableDataModelTest#removingEntryKeepsGroupFilterAppliedToRemainingEntries`.
2. Manually: open a library, select a group with 2+ entries and at least
   one entry outside it, delete one of the entries inside the group,
   check whether entries outside the group stay hidden and whether the
   view still reflects the selected group (per #16036's repro steps).

### AI usage

Claude (Sonnet 5) traced this from the #16036 report and drafted the fix
and test after I asked it to look into that issue. I reviewed the
reasoning and diff myself, and I'm flagging in the PR description itself
that I'm not fully certain this closes the visual symptom end-to-end.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] AI tools were used (Claude, Sonnet 5) — disclosed above; I reviewed, understood, and take full ownership of the change
- [ ] I manually tested my changes in running JabRef   <!-- κάν' το, βλ. Steps to test -->
- [x] I added JUnit tests for changes
- [ ] Screenshots   <!-- πρόσθεσε αν κάνεις manual repro -->
- [x] I described the change in CHANGELOG.md