### PR TITLE
Show subquery results in the tooltip of global search bar (15631)

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/jabgui/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -2,17 +2,21 @@ package org.jabref.gui.search;
 
 import java.lang.reflect.Field;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.swing.undo.UndoManager;
 
+import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
 import javafx.collections.SetChangeListener;
 import javafx.css.PseudoClass;
 import javafx.event.Event;
@@ -60,7 +64,10 @@ import org.jabref.logic.FilePreferences;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.preferences.AutoCompleteFirstNameMode;
 import org.jabref.logic.search.SearchPreferences;
+import org.jabref.logic.search.inmemory.MatchInformation;
+import org.jabref.logic.search.inmemory.MatchInformation.PartialResult;
 import org.jabref.model.entry.Author;
+import org.jabref.model.entry.BibEntry;
 import org.jabref.model.search.SearchDisplayMode;
 import org.jabref.model.search.SearchFlags;
 import org.jabref.model.search.query.SearchQuery;
@@ -244,6 +251,10 @@ public class GlobalSearchBar extends HBox {
                 this.stateManager.addSearchHistory(searchField.textProperty().get());
             }
         });
+
+        stateManager.getSelectedEntries().addListener((InvalidationListener) _ -> {
+            setSearchBarHint();
+        });
     }
 
     private void initSearchModifierButtons() {
@@ -417,14 +428,35 @@ public class GlobalSearchBar extends HBox {
     }
 
     public void setSearchBarHint() {
+        StringBuilder tooltipText = new StringBuilder();
         if (preferences.getWorkspacePreferences().shouldShowAdvancedHints()) {
-            String genericDescription = Localization.lang("Hint:\n\nTo search all fields for <b>Smith</b>, enter:\n<tt>smith</tt>\n\nTo search the field <b>author</b> for <b>Smith</b> and the field <b>title</b> for <b>electrical</b>, enter:\n<tt>author=Smith AND title=electrical</tt>");
-            List<Text> genericDescriptionTexts = TooltipTextUtil.createTextsFromHtml(genericDescription);
+            tooltipText.append(Localization.lang("Hint:\n\nTo search all fields for <b>Smith</b>, enter:\n<tt>smith</tt>\n\nTo search the field <b>author</b> for <b>Smith</b> and the field <b>title</b> for <b>electrical</b>, enter:\n<tt>author=Smith AND title=electrical</tt>"));
+        }
+        Set<PartialResult> prs = getPartialResultsForSelectedBibEntry();
+        if (!prs.isEmpty()) {
+            tooltipText.append(Localization.lang("\n\nDetails of match:\n"));
+            for (PartialResult pr : prs) {
+                tooltipText.append(pr.subquery()).append("->").append(Localization.lang(Boolean.toString(pr.isTrue()))).append("\n");
+            }
+        }
+        if (!tooltipText.isEmpty()) {
+            List<Text> genericDescriptionTexts = TooltipTextUtil.createTextsFromHtml(tooltipText.toString());
 
             TextFlow emptyHintTooltip = new TextFlow();
             emptyHintTooltip.getChildren().setAll(genericDescriptionTexts);
             searchFieldTooltip.setGraphic(emptyHintTooltip);
         }
+    }
+
+    private Set<PartialResult> getPartialResultsForSelectedBibEntry() {
+        Optional<SearchQuery> sq = stateManager.activeSearchQuery(SearchType.NORMAL_SEARCH).get();
+        ObservableList<BibEntry> selectedEntries = stateManager.getSelectedEntries();
+        if (selectedEntries == null || selectedEntries.size() != 1) {
+            return Collections.emptySet();
+        }
+        BibEntry selectedEntry = selectedEntries.getFirst();
+        MatchInformation matchInformation = sq.get().getMatchInformation().get(selectedEntry.getId());
+        return matchInformation != null ? matchInformation.getPartialResults() : Collections.emptySet();
     }
 
     public void setSearchTerm(SearchQuery searchQuery) {

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/BibEntryDetailedMatchVisitor.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/BibEntryDetailedMatchVisitor.java
@@ -1,0 +1,270 @@
+package org.jabref.logic.search.inmemory;
+
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.jabref.logic.search.query.SearchFieldConstants;
+import org.jabref.logic.search.query.SearchQueryConversion;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.search.SearchFlags;
+import org.jabref.search.SearchBaseVisitor;
+import org.jabref.search.SearchParser;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/// Walks a Search.g4 parse tree against a single [BibEntry] and returns of matches for full query and all comparisons separately.
+///
+/// Operator semantics mirror [org.jabref.logic.search.query.SearchToSqlVisitor].
+/// Pseudo-fields supported: `any` / `anyfield`, `key`, `entrytype`, `anykeyword`.
+class BibEntryDetailedMatchVisitor extends SearchBaseVisitor<MatchInformation> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BibEntryDetailedMatchVisitor.class);
+    private static final String GROUPS_FIELD_NAME = StandardField.GROUPS.getName();
+
+    /// Compiled regexes shared across all visitor instances (one instance is created per [BibEntry],
+    /// so an instance-level cache would not help when scanning a library). Keyed by pattern + case mode.
+    private static final Cache<RegexKey, Pattern> COMPILED_PATTERNS =
+            Caffeine.newBuilder()
+                    .expireAfterWrite(Duration.ofMinutes(15))
+                    .expireAfterAccess(Duration.ofMinutes(15))
+                    .build();
+
+    private record RegexKey(String pattern, boolean caseSensitive) {
+    }
+
+    private final BibEntry entry;
+    private final EnumSet<SearchFlags> searchBarFlags;
+    private final Character keywordSeparator;
+
+    BibEntryDetailedMatchVisitor(BibEntry entry, EnumSet<SearchFlags> searchBarFlags, Character keywordSeparator) {
+        this.entry = entry;
+        this.searchBarFlags = searchBarFlags;
+        this.keywordSeparator = keywordSeparator;
+    }
+
+    @Override
+    public MatchInformation visitStart(SearchParser.StartContext ctx) {
+        // start : EOF | andExpression EOF — empty query matches everything
+        if (ctx.andExpression() == null) {
+            return new MatchInformation(true);
+        }
+        return visit(ctx.andExpression());
+    }
+
+    @Override
+    public MatchInformation visitImplicitAndExpression(SearchParser.ImplicitAndExpressionContext ctx) {
+        MatchInformation result = new MatchInformation(true);
+        var expressions = ctx.expression();
+        for (var expression : expressions) {
+            MatchInformation partialResult = visit(expression);
+            result.setResult(Boolean.TRUE.equals(result.getResult()) && Boolean.TRUE.equals(partialResult.getResult()));
+            result.getPartialResults().addAll(partialResult.getPartialResults());
+        }
+        return result;
+    }
+
+    @Override
+    public MatchInformation visitParenExpression(SearchParser.ParenExpressionContext ctx) {
+        return visit(ctx.andExpression());
+    }
+
+    @Override
+    public MatchInformation visitNegatedExpression(SearchParser.NegatedExpressionContext ctx) {
+        MatchInformation result = visit(ctx.expression());
+        result.setResult(!result.getResult());
+        return result;
+    }
+
+    @Override
+    public MatchInformation visitBinaryExpression(SearchParser.BinaryExpressionContext ctx) {
+        MatchInformation result = visit(ctx.left);
+        MatchInformation right = visit(ctx.right);
+        result.getPartialResults().addAll(right.getPartialResults());
+        if (ctx.bin_op.getType() == SearchParser.AND) {
+            result.setResult(Boolean.TRUE.equals(result.getResult()) && Boolean.TRUE.equals(right.getResult()));
+        } else {
+            result.setResult(Boolean.TRUE.equals(result.getResult()) || Boolean.TRUE.equals(right.getResult()));
+        }
+        return result;
+    }
+
+    @Override
+    public MatchInformation visitComparisonExpression(SearchParser.ComparisonExpressionContext ctx) {
+        return visit(ctx.comparison());
+    }
+
+    @Override
+    public MatchInformation visitComparison(SearchParser.ComparisonContext ctx) {
+        String term = SearchQueryConversion.unescapeSearchValue(ctx.searchValue());
+
+        if (ctx.FIELD() == null) {
+            // Unfielded bareword: apply search-bar flags
+            boolean caseSensitive = searchBarFlags.contains(SearchFlags.CASE_SENSITIVE);
+            SearchFlags matchKind = searchBarFlags.contains(SearchFlags.REGULAR_EXPRESSION)
+                                    ? SearchFlags.REGULAR_EXPRESSION
+                                    : SearchFlags.INEXACT_MATCH;
+            boolean result = matchAnyField(term, matchKind, caseSensitive);
+            return new MatchInformation(result, new MatchInformation.PartialResult(result, ctx.getText()));
+        }
+
+        String fieldName = ctx.FIELD().getText().toLowerCase(Locale.ROOT);
+        int operator = ctx.operator().getStart().getType();
+        OperatorFlags flags = mapOperator(operator);
+
+        // field = "" / field != "" — presence/absence
+        if (term.isEmpty()) {
+            boolean present = isFieldPresent(fieldName);
+            boolean result = flags.negation ? present : !present;
+            return new MatchInformation(result, new MatchInformation.PartialResult(result, ctx.getText()));
+        }
+
+        boolean matched = matchField(fieldName, term, flags.matchKind, flags.caseSensitive);
+        boolean result = flags.negation != matched;
+        return new MatchInformation(result, new MatchInformation.PartialResult(result, ctx.getText()));
+    }
+
+    private boolean isFieldPresent(String fieldName) {
+        return switch (fieldName) {
+            case SearchFieldConstants.KEY,
+                 SearchFieldConstants.CITATION_KEY ->
+                    entry.getCitationKey().isPresent();
+            case SearchFieldConstants.ENTRY_TYPE ->
+                    true; // every entry has a type
+            case SearchFieldConstants.ANY_FIELD,
+                 SearchFieldConstants.ANY_FIELD_ALIAS ->
+                    entry.getFields().stream()
+                         .anyMatch(f -> !GROUPS_FIELD_NAME.equals(f.getName()));
+            case SearchFieldConstants.ANY_KEYWORD ->
+                    entry.getField(StandardField.KEYWORDS).isPresent();
+            default ->
+                    entry.getFields().stream()
+                         .anyMatch(f -> f.getName().equalsIgnoreCase(fieldName));
+        };
+    }
+
+    private boolean matchField(String fieldName, String term, SearchFlags matchKind, boolean caseSensitive) {
+        return switch (fieldName) {
+            case SearchFieldConstants.KEY,
+                 SearchFieldConstants.CITATION_KEY ->
+                    entry.getCitationKey()
+                         .map(v -> matchValue(v, term, matchKind, caseSensitive))
+                         .orElse(false);
+            case SearchFieldConstants.ENTRY_TYPE ->
+                    matchValue(entry.getType().getName(), term, matchKind, caseSensitive);
+            case SearchFieldConstants.ANY_FIELD,
+                 SearchFieldConstants.ANY_FIELD_ALIAS ->
+                    matchAnyField(term, matchKind, caseSensitive);
+            case SearchFieldConstants.ANY_KEYWORD ->
+                    matchAnyKeyword(term, matchKind, caseSensitive);
+            default ->
+                    matchNamedField(fieldName, term, matchKind, caseSensitive);
+        };
+    }
+
+    private boolean matchNamedField(String fieldName, String term, SearchFlags matchKind, boolean caseSensitive) {
+        for (Field field : entry.getFields()) {
+            if (!field.getName().equalsIgnoreCase(fieldName)) {
+                continue;
+            }
+            if (entry.getField(field)
+                     .filter(value -> matchValue(value, term, matchKind, caseSensitive))
+                     .isPresent()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matchAnyField(String term, SearchFlags matchKind, boolean caseSensitive) {
+        for (Field field : entry.getFields()) {
+            if (GROUPS_FIELD_NAME.equals(field.getName())) {
+                continue;
+            }
+            if (entry.getField(field)
+                     .filter(value -> matchValue(value, term, matchKind, caseSensitive))
+                     .isPresent()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matchAnyKeyword(String term, SearchFlags matchKind, boolean caseSensitive) {
+        List<String> keywords = entry.getKeywords(keywordSeparator).stream().map(Object::toString).toList();
+        return keywords.stream().anyMatch(k -> matchValue(k, term, matchKind, caseSensitive));
+    }
+
+    /// @param matchKind one of [SearchFlags#INEXACT_MATCH], [SearchFlags#EXACT_MATCH], [SearchFlags#REGULAR_EXPRESSION]
+    private static boolean matchValue(String value, String term, SearchFlags matchKind, boolean caseSensitive) {
+        return switch (matchKind) {
+            case INEXACT_MATCH ->
+                    caseSensitive
+                    ? value.contains(term)
+                    : value.toLowerCase(Locale.ROOT).contains(term.toLowerCase(Locale.ROOT));
+            case EXACT_MATCH ->
+                    caseSensitive ? value.equals(term) : value.equalsIgnoreCase(term);
+            case REGULAR_EXPRESSION ->
+                    matchRegex(value, term, caseSensitive);
+            default ->
+                    throw new IllegalArgumentException("matchKind must be INEXACT_MATCH, EXACT_MATCH, or REGULAR_EXPRESSION, got " + matchKind);
+        };
+    }
+
+    private static boolean matchRegex(String value, String pattern, boolean caseSensitive) {
+        try {
+            Pattern compiled = COMPILED_PATTERNS.asMap().computeIfAbsent(
+                    new RegexKey(pattern, caseSensitive),
+                    key -> Pattern.compile(key.pattern(), key.caseSensitive() ? 0 : Pattern.CASE_INSENSITIVE));
+            return compiled.matcher(value).find();
+        } catch (PatternSyntaxException e) {
+            LOGGER.debug("Invalid regex pattern '{}': {}", pattern, e.getMessage());
+            return false;
+        }
+    }
+
+    /// @param matchKind one of [SearchFlags#INEXACT_MATCH], [SearchFlags#EXACT_MATCH], [SearchFlags#REGULAR_EXPRESSION]
+    private record OperatorFlags(SearchFlags matchKind, boolean caseSensitive, boolean negation) {
+    }
+
+    private static OperatorFlags mapOperator(int tokenType) {
+        return switch (tokenType) {
+            case SearchParser.EQUAL,
+                 SearchParser.CONTAINS ->
+                    new OperatorFlags(SearchFlags.INEXACT_MATCH, false, false);
+            case SearchParser.CEQUAL ->
+                    new OperatorFlags(SearchFlags.INEXACT_MATCH, true, false);
+            case SearchParser.EEQUAL,
+                 SearchParser.MATCHES ->
+                    new OperatorFlags(SearchFlags.EXACT_MATCH, false, false);
+            case SearchParser.CEEQUAL ->
+                    new OperatorFlags(SearchFlags.EXACT_MATCH, true, false);
+            case SearchParser.REQUAL ->
+                    new OperatorFlags(SearchFlags.REGULAR_EXPRESSION, false, false);
+            case SearchParser.CREEQUAL ->
+                    new OperatorFlags(SearchFlags.REGULAR_EXPRESSION, true, false);
+            case SearchParser.NEQUAL ->
+                    new OperatorFlags(SearchFlags.INEXACT_MATCH, false, true);
+            case SearchParser.NCEQUAL ->
+                    new OperatorFlags(SearchFlags.INEXACT_MATCH, true, true);
+            case SearchParser.NEEQUAL ->
+                    new OperatorFlags(SearchFlags.EXACT_MATCH, false, true);
+            case SearchParser.NCEEQUAL ->
+                    new OperatorFlags(SearchFlags.EXACT_MATCH, true, true);
+            case SearchParser.NREQUAL ->
+                    new OperatorFlags(SearchFlags.REGULAR_EXPRESSION, false, true);
+            case SearchParser.NCREEQUAL ->
+                    new OperatorFlags(SearchFlags.REGULAR_EXPRESSION, true, true);
+            default ->
+                    new OperatorFlags(SearchFlags.INEXACT_MATCH, false, false);
+        };
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLibrarySearcher.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLibrarySearcher.java
@@ -2,6 +2,8 @@ package org.jabref.logic.search.inmemory;
 
 import java.util.List;
 
+import javafx.util.Pair;
+
 import org.jabref.logic.search.LibrarySearcher;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -33,15 +35,21 @@ public class InMemoryLibrarySearcher implements LibrarySearcher {
 
     @Override
     public List<BibEntry> getMatches(SearchQuery query) {
-        if (!query.isValid()) {
-            LOGGER.warn("Search failed: invalid search expression '{}'", query.getSearchExpression());
+        if (!validate(query)) {
             return List.of();
-        }
-        if (query.getSearchFlags().contains(SearchFlags.FULLTEXT)) {
-            LOGGER.warn("In-memory searcher does not support FULLTEXT search; matching against metadata only");
         }
         return databaseContext.getDatabase().getEntries().stream()
                               .filter(entry -> matchesParsedQuery(entry, query))
+                              .toList();
+    }
+
+    public List<Pair<BibEntry, MatchInformation>> getDetailedMatches(SearchQuery query) {
+        if (!validate(query)) {
+            return List.of();
+        }
+        return databaseContext.getDatabase().getEntries().stream()
+                              .map(entry -> new Pair<>(entry, getMatchInformation(entry, query)))
+                              .filter(pair -> pair.getValue().getResult())
                               .toList();
     }
 
@@ -57,5 +65,20 @@ public class InMemoryLibrarySearcher implements LibrarySearcher {
     private boolean matchesParsedQuery(BibEntry entry, SearchQuery query) {
         return Boolean.TRUE.equals(
                 new BibEntryMatchVisitor(entry, query.getSearchFlags(), keywordSeparator).visit(query.getContext()));
+    }
+
+    private MatchInformation getMatchInformation(BibEntry entry, SearchQuery query) {
+        return new BibEntryDetailedMatchVisitor(entry, query.getSearchFlags(), keywordSeparator).visit(query.getContext());
+    }
+
+    private boolean validate(SearchQuery query) {
+        if (!query.isValid()) {
+            LOGGER.warn("Search failed: invalid search expression '{}'", query.getSearchExpression());
+            return false;
+        }
+        if (query.getSearchFlags().contains(SearchFlags.FULLTEXT)) {
+            LOGGER.warn("In-memory searcher does not support FULLTEXT search; matching against metadata only");
+        }
+        return true;
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemorySearchBackend.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemorySearchBackend.java
@@ -2,6 +2,8 @@ package org.jabref.logic.search.inmemory;
 
 import java.util.List;
 
+import javafx.util.Pair;
+
 import org.jabref.logic.search.SearchBackend;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -26,10 +28,12 @@ public class InMemorySearchBackend implements SearchBackend {
 
     @Override
     public SearchResults search(SearchQuery query) {
+        query.getMatchInformation().clear();
         SearchResults results = new SearchResults();
         SearchResult marker = new SearchResult();
-        for (BibEntry entry : searcher.getMatches(query)) {
-            results.addSearchResult(entry.getId(), marker);
+        for (Pair<BibEntry, MatchInformation> entry : searcher.getDetailedMatches(query)) {
+            results.addSearchResult(entry.getKey().getId(), marker);
+            query.getMatchInformation().put(entry.getKey().getId(), entry.getValue());
         }
         query.setSearchResults(results);
         return results;

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/MatchInformation.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/MatchInformation.java
@@ -1,0 +1,78 @@
+package org.jabref.logic.search.inmemory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public class MatchInformation {
+
+    private Boolean result;
+    private Set<PartialResult> partialResults = new HashSet<>();
+
+    public MatchInformation(Boolean result) {
+        this.result = result;
+    }
+
+    public MatchInformation(Boolean result, PartialResult... partialResults) {
+        this.result = result;
+        Collections.addAll(this.partialResults, partialResults);
+    }
+
+    public Boolean getResult() {
+        return result;
+    }
+
+    public void setResult(Boolean result) {
+        this.result = result;
+    }
+
+    public Set<PartialResult> getPartialResults() {
+        return partialResults;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MatchInformation that = (MatchInformation) o;
+        return Objects.equals(result, that.result) && Objects.equals(partialResults, that.partialResults);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(result, partialResults);
+    }
+
+    @Override
+    public String toString() {
+        return "MatchInformation{" +
+                "result=" + result +
+                ", partialResults=" + partialResults +
+                '}';
+    }
+
+    public record PartialResult(boolean isTrue, String subquery) {
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass())
+                return false;
+            PartialResult that = (PartialResult) o;
+            return isTrue == that.isTrue && Objects.equals(subquery, that.subquery);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(isTrue, subquery);
+        }
+
+        @Override
+        public String toString() {
+            return "PartialResult{" +
+                    "isTrue=" + isTrue +
+                    ", subquery='" + subquery + '\'' +
+                    '}';
+        }
+    }
+}
+

--- a/jablib/src/main/java/org/jabref/model/search/query/SearchQuery.java
+++ b/jablib/src/main/java/org/jabref/model/search/query/SearchQuery.java
@@ -1,8 +1,11 @@
 package org.jabref.model.search.query;
 
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
+import org.jabref.logic.search.inmemory.MatchInformation;
 import org.jabref.model.search.SearchFlags;
 import org.jabref.model.search.ThrowingErrorListener;
 import org.jabref.search.SearchLexer;
@@ -25,6 +28,7 @@ public class SearchQuery {
     private SearchParser.StartContext context;
     private boolean isValidExpression;
     private SearchResults searchResults;
+    private final Map<String, MatchInformation> matchInformation = new HashMap<>();
 
     public SearchQuery(String searchExpression) {
         this(searchExpression, EnumSet.noneOf(SearchFlags.class));
@@ -66,6 +70,10 @@ public class SearchQuery {
 
     public SearchParser.StartContext getContext() {
         return context;
+    }
+
+    public Map<String, MatchInformation> getMatchInformation() {
+        return matchInformation;
     }
 
     @Override

--- a/jablib/src/test/java/org/jabref/logic/search/LibrarySearcherTestCases.java
+++ b/jablib/src/test/java/org/jabref/logic/search/LibrarySearcherTestCases.java
@@ -3,6 +3,10 @@ package org.jabref.logic.search;
 import java.util.List;
 import java.util.stream.Stream;
 
+import javafx.util.Pair;
+
+import org.jabref.logic.search.inmemory.MatchInformation;
+import org.jabref.logic.search.inmemory.MatchInformation.PartialResult;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
@@ -17,6 +21,11 @@ import org.junit.jupiter.params.provider.Arguments;
 /// belong in the per-implementation test class.
 public final class LibrarySearcherTestCases {
 
+    private static final String TITLE_SENTENCE_CASED_AUTHOR = "JamesSensible";
+    private static final String TITLE_MIXED_CASED_AUTHOR = "TomTheHusky";
+    private static final String TITLE_UPPER_CASED_AUTHOR = "ArnoldtheLoud";
+    private static final String AUTHOR_WITH_COMMENT_CHARACTERS_NAME = "Commen/*tiusPavloczyns*/ky";
+
     public static final BibEntry EMPTY_ENTRY = new BibEntry();
 
     public static final BibEntry ARTICLE_HARRER = new BibEntry(StandardEntryType.Article)
@@ -29,15 +38,22 @@ public final class LibrarySearcherTestCases {
 
     public static final BibEntry TITLE_SENTENCE_CASED = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("title-sentence-cased")
-            .withField(StandardField.TITLE, "Title Sentence Cased");
+            .withField(StandardField.TITLE, "Title Sentence Cased")
+            .withField(StandardField.AUTHOR, TITLE_SENTENCE_CASED_AUTHOR);
 
     public static final BibEntry TITLE_MIXED_CASED = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("title-mixed-cased")
-            .withField(StandardField.TITLE, "TiTle MiXed CaSed");
+            .withField(StandardField.TITLE, "TiTle MiXed CaSed")
+            .withField(StandardField.AUTHOR, TITLE_MIXED_CASED_AUTHOR);
 
     public static final BibEntry TITLE_UPPER_CASED = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("title-upper-cased")
-            .withField(StandardField.TITLE, "TITLE UPPER CASED");
+            .withField(StandardField.TITLE, "TITLE UPPER CASED")
+            .withField(StandardField.AUTHOR, TITLE_UPPER_CASED_AUTHOR);
+
+    public static final BibEntry AUTHOR_WITH_COMMENT_CHARACTERS = new BibEntry(StandardEntryType.Misc)
+            .withField(StandardField.TITLE, "A life with a stupid name - my story")
+            .withField(StandardField.AUTHOR, AUTHOR_WITH_COMMENT_CHARACTERS_NAME);
 
     private LibrarySearcherTestCases() {
     }
@@ -84,8 +100,159 @@ public final class LibrarySearcherTestCases {
 
                 // regex on any field
                 Arguments.of(List.of(),
-                        new SearchQuery("any =~ [Y]"),
+                        new SearchQuery("any =~ [Z]"),
                         List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED))
+        );
+    }
+
+    public static Stream<Arguments> detailedSearchCases() {
+        return Stream.of(
+                // empty library
+                Arguments.of(List.of(), new SearchQuery("whatever"), List.of()),
+                Arguments.of(List.of(), new SearchQuery("whatever"), List.of(EMPTY_ENTRY)),
+                Arguments.of(List.of(), new SearchQuery("whatever"), List.of(EMPTY_ENTRY, ARTICLE_HARRER, INCOLLECTION_TONHO)),
+
+                // invalid search syntax → no matches
+                Arguments.of(List.of(), new SearchQuery("author="), List.of(ARTICLE_HARRER)),
+
+                // unfielded bareword (case-insensitive substring on any field);
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                ARTICLE_HARRER,
+                                new MatchInformation(true, new PartialResult(true, "harrer")))
+                        ),
+                        new SearchQuery("harrer"), List.of(ARTICLE_HARRER)
+                ),
+
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                INCOLLECTION_TONHO,
+                                new MatchInformation(true, new PartialResult(true, "tonho")))
+                        ),
+                        new SearchQuery("tonho"), List.of(INCOLLECTION_TONHO)
+                ),
+
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                INCOLLECTION_TONHO,
+                                new MatchInformation(true, new PartialResult(true, "tonho")))
+                        ),
+                        new SearchQuery("tonho"), List.of(ARTICLE_HARRER, INCOLLECTION_TONHO)
+                ),
+
+                // fielded queries
+                Arguments.of(List.of(), new SearchQuery("title= harrer"), List.of(ARTICLE_HARRER)),
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                ARTICLE_HARRER,
+                                new MatchInformation(true, new PartialResult(true, "author=harrer")))
+                        ),
+                        new SearchQuery("author=harrer"), List.of(ARTICLE_HARRER)
+                ),
+
+                // case-insensitive vs case-sensitive contains (=, =!)
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                        TITLE_SENTENCE_CASED,
+                                        new MatchInformation(true, new PartialResult(true, "title=Title"))),
+                                new Pair<BibEntry, MatchInformation>(
+                                        TITLE_MIXED_CASED,
+                                        new MatchInformation(true, new PartialResult(true, "title=Title"))),
+                                new Pair<BibEntry, MatchInformation>(
+                                        TITLE_UPPER_CASED,
+                                        new MatchInformation(true, new PartialResult(true, "title=Title")))
+
+                        ),
+                        new SearchQuery("title=Title"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
+                ),
+
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                TITLE_SENTENCE_CASED,
+                                new MatchInformation(true, new PartialResult(true, "title=!Title")))
+                        ),
+                        new SearchQuery("title=!Title"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
+                ),
+
+                Arguments.of(List.of(), new SearchQuery("title =! TiTLE"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
+
+                // any-field with case-sensitive contains (any =!)
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                TITLE_MIXED_CASED,
+                                new MatchInformation(true, new PartialResult(true, "any=!TiTle")))
+                        ),
+                        new SearchQuery("any=!TiTle"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
+                ),
+                Arguments.of(List.of(), new SearchQuery("any=!TiTLe"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
+
+                // regex on any field
+                Arguments.of(List.of(), new SearchQuery("any =~ [Z]"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
+
+                // testing partial results
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                        TITLE_SENTENCE_CASED,
+                                        new MatchInformation(true,
+                                                new PartialResult(false, "any=~husky"),
+                                                new PartialResult(true, "any=~james")
+                                        )
+                                ),
+                                new Pair<BibEntry, MatchInformation>(
+                                        TITLE_MIXED_CASED,
+                                        new MatchInformation(true,
+                                                new PartialResult(true, "any=~husky"),
+                                                new PartialResult(false, "any=~james")
+                                        )
+                                )
+                        ),
+                        new SearchQuery("any=~husky or any=~james"),
+                        List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
+                ),
+
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                        TITLE_UPPER_CASED,
+                                        new MatchInformation(true,
+                                                new PartialResult(true, "title=title"),
+                                                new PartialResult(true, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
+                                                new PartialResult(false, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
+                                        )
+                                ),
+                                new Pair<BibEntry, MatchInformation>(
+                                        TITLE_MIXED_CASED,
+                                        new MatchInformation(true,
+                                                new PartialResult(true, "title=title"),
+                                                new PartialResult(false, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
+                                                new PartialResult(true, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
+                                        )
+                                )
+                        ),
+                        new SearchQuery(String.format("title=title AND (author=%s OR author=%s)", TITLE_UPPER_CASED_AUTHOR, TITLE_MIXED_CASED_AUTHOR)),
+                        List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
+                ),
+
+                // comments do not modify the query
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                        TITLE_UPPER_CASED,
+                                        new MatchInformation(true,
+                                                new PartialResult(true, "title=title"),
+                                                new PartialResult(true, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
+                                                new PartialResult(false, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
+                                        )
+                                ),
+                                new Pair<BibEntry, MatchInformation>(
+                                        TITLE_MIXED_CASED,
+                                        new MatchInformation(true,
+                                                new PartialResult(true, "title=title"),
+                                                new PartialResult(false, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
+                                                new PartialResult(true, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
+                                        )
+                                )
+                        ),
+                        new SearchQuery(String.format("title=title /*Old Tom Bombadil is a merry fellow*/ AND (author=%s /*Bright blue his jacket is*/ OR author=%s)", TITLE_UPPER_CASED_AUTHOR, TITLE_MIXED_CASED_AUTHOR)),
+                        List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
+                ),
+
+                //comment delimiters inside a string literal are treated as a part of this string literal
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                AUTHOR_WITH_COMMENT_CHARACTERS,
+                                new MatchInformation(true, new PartialResult(true, String.format("author=%s", AUTHOR_WITH_COMMENT_CHARACTERS_NAME))))
+                        ),
+                        new SearchQuery(String.format("author=%s", AUTHOR_WITH_COMMENT_CHARACTERS_NAME)), List.of(AUTHOR_WITH_COMMENT_CHARACTERS)
+                )
+
         );
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLibrarySearcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLibrarySearcherTest.java
@@ -1,7 +1,10 @@
 package org.jabref.logic.search.inmemory;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import javafx.util.Pair;
 
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -35,5 +38,15 @@ class InMemoryLibrarySearcherTest {
         }
         List<BibEntry> matches = new InMemoryLibrarySearcher(databaseContext, bibEntryPreferences).getMatches(query);
         assertEquals(Set.copyOf(expectedMatches), Set.copyOf(matches));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.jabref.logic.search.LibrarySearcherTestCases#detailedSearchCases")
+    void commonDetailedSearchCases(List<Pair<BibEntry, MatchInformation>> expectedMatches, SearchQuery query, List<BibEntry> entries) {
+        for (BibEntry entry : entries) {
+            databaseContext.getDatabase().insertEntry(entry);
+        }
+        List<Pair<BibEntry, MatchInformation>> matches = new InMemoryLibrarySearcher(databaseContext, bibEntryPreferences).getDetailedMatches(query);
+        assertEquals(new HashSet<>(expectedMatches), new HashSet<>(matches));
     }
 }


### PR DESCRIPTION
### Related issues and pull requests
Closes #15631

Description:
Displays in the tooltip of the global search bar all partial comparisons and whether they are true or false.

The draft includes full and tested implementation of the above-mentioned feature for in-memory-search.
Beside that, I've finished a similar implementation of LibrarySearcher for sql queries (not included in the draft for now).
I still need to finish this feature for lucene searches and test them manually.
Question: how to set up local gui application to use SqlBasedLibrarySearcher instead of InMemoryLibrarySearcher?  I set up a shared database but the application imports data from the database and uses in-memory-search.

`jabref-contrib-policy:4.2:reviewed​:ok`

This pull request is sweet like a chocolate, round like a moon and confused like honey produced by very confused bees. 

How to test: enter a global search with an "or" operator, select a bib entry and hover the cursor over global search bar. The tooltip should contain informations about comparisons.

https://github.com/user-attachments/assets/626ea724-cb82-4158-b90f-65e56c7f3238

No Ai Tool was used.


- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [X] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [.] I manually tested my changes in running JabRef (always required)
- [X] I added JUnit tests for changes (if applicable)
- [X] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

Additional notes:
BibEntryDetailedMatchVisitor is in the most part a copy of BibEntryMatchVisitor except for a couple of changes that make it preserve the result of every comparison. There is something to say for removing BibEntryMatchVisitor altogether, but since I am not sure how performance-critical it is and since BEDMV incurs a (very) small performance hit I opted for duplicating the class. At least for now.
The similar story repeated with sql search, btw.

