### PR TITLE
Show subquery results in the tooltip of global search bar (15631)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- We added a match explanation to a global search tooltip showing a breakdown on why the currently selected entry matches the searched group [#15631](https://github.com/JabRef/jabref/issues/15631)
 - We added some missing tooltips to buttons such as "Export Cited" and "Bibliography properties" in the OpenOffice/LibreOffice panel. [#16492](https://github.com/JabRef/jabref/pull/16492)
 - We added support for the `Export cited` functionality with CSL and BST styles in the OpenOffice/LibreOffice integration. [#16491](https://github.com/JabRef/jabref/issues/16491)
 - We added a per-library journal abbreviation preference to Library Properties, allowing automatic LTWA abbreviation on save. [#15495](https://github.com/JabRef/jabref/issues/15495)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added an "add space before citation" option in the LibreOffice integration. [#16349](https://github.com/JabRef/jabref/issues/16349)
 - CSL Citations emitted by JabRef in LibreOffice can now be read by Zotero (under a new preference "Zotero Compatibility Mode") and vice versa. [#15878](https://github.com/JabRef/jabref/issues/15878)
 - We added support for bibliography generation using `.bst` files in the OpenOffice/LibreOffice integration. [#624](https://github.com/JabRef/jabref/issues/624)
+- We added a match explanation to a global search tooltip showing a breakdown on why the currently selected entry matches the searched for group [#15631](https://github.com/JabRef/jabref/issues/15631)
 - The command `jabkit pdf update --format=xmp` now writes XMP metadata to the linked PDF. [#16087](https://github.com/JabRef/jabref/issues/16087)
 - We now offer `jabkit` as a native binary (no Java runtime required, instant startup) for Linux (amd64/arm64) and macOS (Apple Silicon) as part of the binary distribution. [#16291](https://github.com/JabRef/jabref/pull/16291)
 - The HTTP import endpoint (`POST /libraries/{id}/entries`) now accepts CSL-JSON (`application/vnd.citationstyles.csl+json`), mapping each item to the correct entry type (e.g. conference paper, book chapter, thesis) via the citation-js-based mapping. [#16151](https://github.com/JabRef/jabref/pull/16151)

--- a/jabgui/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/jabgui/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -434,7 +434,7 @@ public class GlobalSearchBar extends HBox {
         }
         Set<PartialResult> prs = getPartialResultsForSelectedBibEntry();
         if (!prs.isEmpty()) {
-            tooltipText.append(Localization.lang("\n\nDetails of match:\n"));
+            tooltipText.append(Localization.lang("\n\nDetails of the currently selected match:\n"));
             for (PartialResult pr : prs) {
                 tooltipText.append(pr.subquery()).append("->").append(Localization.lang(Boolean.toString(pr.isTrue()))).append("\n");
             }

--- a/jabgui/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/jabgui/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -2,17 +2,21 @@ package org.jabref.gui.search;
 
 import java.lang.reflect.Field;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.swing.undo.UndoManager;
 
+import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
 import javafx.collections.SetChangeListener;
 import javafx.css.PseudoClass;
 import javafx.event.Event;
@@ -60,7 +64,10 @@ import org.jabref.logic.FilePreferences;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.preferences.AutoCompleteFirstNameMode;
 import org.jabref.logic.search.SearchPreferences;
+import org.jabref.logic.search.inmemory.MatchInformation;
+import org.jabref.logic.search.inmemory.MatchInformation.PartialResult;
 import org.jabref.model.entry.Author;
+import org.jabref.model.entry.BibEntry;
 import org.jabref.model.search.SearchDisplayMode;
 import org.jabref.model.search.SearchFlags;
 import org.jabref.model.search.query.SearchQuery;
@@ -244,6 +251,10 @@ public class GlobalSearchBar extends HBox {
                 this.stateManager.addSearchHistory(searchField.textProperty().get());
             }
         });
+
+        stateManager.getSelectedEntries().addListener((InvalidationListener) _ -> {
+            setSearchBarHint();
+        });
     }
 
     private void initSearchModifierButtons() {
@@ -417,14 +428,35 @@ public class GlobalSearchBar extends HBox {
     }
 
     public void setSearchBarHint() {
+        StringBuilder tooltipText = new StringBuilder();
         if (preferences.getWorkspacePreferences().shouldShowAdvancedHints()) {
-            String genericDescription = Localization.lang("Hint:\n\nTo search all fields for <b>Smith</b>, enter:\n<tt>smith</tt>\n\nTo search the field <b>author</b> for <b>Smith</b> and the field <b>title</b> for <b>electrical</b>, enter:\n<tt>author=Smith AND title=electrical</tt>");
-            List<Text> genericDescriptionTexts = TooltipTextUtil.createTextsFromHtml(genericDescription);
+            tooltipText.append(Localization.lang("Hint:\n\nTo search all fields for <b>Smith</b>, enter:\n<tt>smith</tt>\n\nTo search the field <b>author</b> for <b>Smith</b> and the field <b>title</b> for <b>electrical</b>, enter:\n<tt>author=Smith AND title=electrical</tt>"));
+        }
+        Set<PartialResult> prs = getPartialResultsForSelectedBibEntry();
+        if (!prs.isEmpty()) {
+            tooltipText.append(Localization.lang("\n\nDetails of match:\n"));
+            for (PartialResult pr : prs) {
+                tooltipText.append(pr.subquery()).append("->").append(Localization.lang(Boolean.toString(pr.isTrue()))).append("\n");
+            }
+        }
+        if (!tooltipText.isEmpty()) {
+            List<Text> genericDescriptionTexts = TooltipTextUtil.createTextsFromHtml(tooltipText.toString());
 
             TextFlow emptyHintTooltip = new TextFlow();
             emptyHintTooltip.getChildren().setAll(genericDescriptionTexts);
             searchFieldTooltip.setGraphic(emptyHintTooltip);
         }
+    }
+
+    private Set<PartialResult> getPartialResultsForSelectedBibEntry() {
+        Optional<SearchQuery> sq = stateManager.activeSearchQuery(SearchType.NORMAL_SEARCH).get();
+        ObservableList<BibEntry> selectedEntries = stateManager.getSelectedEntries();
+        if (sq.isEmpty() || selectedEntries == null || selectedEntries.size() != 1) {
+            return Collections.emptySet();
+        }
+        BibEntry selectedEntry = selectedEntries.getFirst();
+        MatchInformation matchInformation = sq.get().getMatchInformation().get(selectedEntry.getId());
+        return matchInformation != null ? matchInformation.getPartialResults() : Collections.emptySet();
     }
 
     public void setSearchTerm(SearchQuery searchQuery) {

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/BibEntryDetailedMatchVisitor.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/BibEntryDetailedMatchVisitor.java
@@ -1,0 +1,270 @@
+package org.jabref.logic.search.inmemory;
+
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.jabref.logic.search.query.SearchFieldConstants;
+import org.jabref.logic.search.query.SearchQueryConversion;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.search.SearchFlags;
+import org.jabref.search.SearchBaseVisitor;
+import org.jabref.search.SearchParser;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/// Walks a Search.g4 parse tree against a single [BibEntry] and returns whether the entry matches the full query and all operations separately.
+///
+/// Operator semantics mirror [org.jabref.logic.search.query.SearchToSqlVisitor].
+/// Pseudo-fields supported: `any` / `anyfield`, `key`, `entrytype`, `anykeyword`.
+class BibEntryDetailedMatchVisitor extends SearchBaseVisitor<MatchInformation> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BibEntryDetailedMatchVisitor.class);
+    private static final String GROUPS_FIELD_NAME = StandardField.GROUPS.getName();
+
+    /// Compiled regexes shared across all visitor instances (one instance is created per [BibEntry],
+    /// so an instance-level cache would not help when scanning a library). Keyed by pattern + case mode.
+    private static final Cache<RegexKey, Pattern> COMPILED_PATTERNS =
+            Caffeine.newBuilder()
+                    .expireAfterWrite(Duration.ofMinutes(15))
+                    .expireAfterAccess(Duration.ofMinutes(15))
+                    .build();
+
+    private record RegexKey(String pattern, boolean caseSensitive) {
+    }
+
+    private final BibEntry entry;
+    private final EnumSet<SearchFlags> searchBarFlags;
+    private final Character keywordSeparator;
+
+    BibEntryDetailedMatchVisitor(BibEntry entry, EnumSet<SearchFlags> searchBarFlags, Character keywordSeparator) {
+        this.entry = entry;
+        this.searchBarFlags = searchBarFlags;
+        this.keywordSeparator = keywordSeparator;
+    }
+
+    @Override
+    public MatchInformation visitStart(SearchParser.StartContext ctx) {
+        // start : EOF | andExpression EOF — empty query matches everything
+        if (ctx.andExpression() == null) {
+            return new MatchInformation(true);
+        }
+        return visit(ctx.andExpression());
+    }
+
+    @Override
+    public MatchInformation visitImplicitAndExpression(SearchParser.ImplicitAndExpressionContext ctx) {
+        MatchInformation result = new MatchInformation(true);
+        var expressions = ctx.expression();
+        for (var expression : expressions) {
+            MatchInformation partialResult = visit(expression);
+            result.setResult(Boolean.TRUE.equals(result.getResult()) && Boolean.TRUE.equals(partialResult.getResult()));
+            result.getPartialResults().addAll(partialResult.getPartialResults());
+        }
+        return result;
+    }
+
+    @Override
+    public MatchInformation visitParenExpression(SearchParser.ParenExpressionContext ctx) {
+        return visit(ctx.andExpression());
+    }
+
+    @Override
+    public MatchInformation visitNegatedExpression(SearchParser.NegatedExpressionContext ctx) {
+        MatchInformation result = visit(ctx.expression());
+        result.setResult(!result.getResult());
+        return result;
+    }
+
+    @Override
+    public MatchInformation visitBinaryExpression(SearchParser.BinaryExpressionContext ctx) {
+        MatchInformation result = visit(ctx.left);
+        MatchInformation right = visit(ctx.right);
+        result.getPartialResults().addAll(right.getPartialResults());
+        if (ctx.bin_op.getType() == SearchParser.AND) {
+            result.setResult(Boolean.TRUE.equals(result.getResult()) && Boolean.TRUE.equals(right.getResult()));
+        } else {
+            result.setResult(Boolean.TRUE.equals(result.getResult()) || Boolean.TRUE.equals(right.getResult()));
+        }
+        return result;
+    }
+
+    @Override
+    public MatchInformation visitComparisonExpression(SearchParser.ComparisonExpressionContext ctx) {
+        return visit(ctx.comparison());
+    }
+
+    @Override
+    public MatchInformation visitComparison(SearchParser.ComparisonContext ctx) {
+        String term = SearchQueryConversion.unescapeSearchValue(ctx.searchValue());
+
+        if (ctx.FIELD() == null) {
+            // Unfielded bareword: apply search-bar flags
+            boolean caseSensitive = searchBarFlags.contains(SearchFlags.CASE_SENSITIVE);
+            SearchFlags matchKind = searchBarFlags.contains(SearchFlags.REGULAR_EXPRESSION)
+                                    ? SearchFlags.REGULAR_EXPRESSION
+                                    : SearchFlags.INEXACT_MATCH;
+            boolean result = matchAnyField(term, matchKind, caseSensitive);
+            return new MatchInformation(result, new MatchInformation.PartialResult(result, ctx.getText()));
+        }
+
+        String fieldName = ctx.FIELD().getText().toLowerCase(Locale.ROOT);
+        int operator = ctx.operator().getStart().getType();
+        OperatorFlags flags = mapOperator(operator);
+
+        // field = "" / field != "" — presence/absence
+        if (term.isEmpty()) {
+            boolean present = isFieldPresent(fieldName);
+            boolean result = flags.negation ? present : !present;
+            return new MatchInformation(result, new MatchInformation.PartialResult(result, ctx.getText()));
+        }
+
+        boolean matched = matchField(fieldName, term, flags.matchKind, flags.caseSensitive);
+        boolean result = flags.negation != matched;
+        return new MatchInformation(result, new MatchInformation.PartialResult(result, ctx.getText()));
+    }
+
+    private boolean isFieldPresent(String fieldName) {
+        return switch (fieldName) {
+            case SearchFieldConstants.KEY,
+                 SearchFieldConstants.CITATION_KEY ->
+                    entry.getCitationKey().isPresent();
+            case SearchFieldConstants.ENTRY_TYPE ->
+                    true; // every entry has a type
+            case SearchFieldConstants.ANY_FIELD,
+                 SearchFieldConstants.ANY_FIELD_ALIAS ->
+                    entry.getFields().stream()
+                         .anyMatch(f -> !GROUPS_FIELD_NAME.equals(f.getName()));
+            case SearchFieldConstants.ANY_KEYWORD ->
+                    entry.getField(StandardField.KEYWORDS).isPresent();
+            default ->
+                    entry.getFields().stream()
+                         .anyMatch(f -> f.getName().equalsIgnoreCase(fieldName));
+        };
+    }
+
+    private boolean matchField(String fieldName, String term, SearchFlags matchKind, boolean caseSensitive) {
+        return switch (fieldName) {
+            case SearchFieldConstants.KEY,
+                 SearchFieldConstants.CITATION_KEY ->
+                    entry.getCitationKey()
+                         .map(v -> matchValue(v, term, matchKind, caseSensitive))
+                         .orElse(false);
+            case SearchFieldConstants.ENTRY_TYPE ->
+                    matchValue(entry.getType().getName(), term, matchKind, caseSensitive);
+            case SearchFieldConstants.ANY_FIELD,
+                 SearchFieldConstants.ANY_FIELD_ALIAS ->
+                    matchAnyField(term, matchKind, caseSensitive);
+            case SearchFieldConstants.ANY_KEYWORD ->
+                    matchAnyKeyword(term, matchKind, caseSensitive);
+            default ->
+                    matchNamedField(fieldName, term, matchKind, caseSensitive);
+        };
+    }
+
+    private boolean matchNamedField(String fieldName, String term, SearchFlags matchKind, boolean caseSensitive) {
+        for (Field field : entry.getFields()) {
+            if (!field.getName().equalsIgnoreCase(fieldName)) {
+                continue;
+            }
+            if (entry.getField(field)
+                     .filter(value -> matchValue(value, term, matchKind, caseSensitive))
+                     .isPresent()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matchAnyField(String term, SearchFlags matchKind, boolean caseSensitive) {
+        for (Field field : entry.getFields()) {
+            if (GROUPS_FIELD_NAME.equals(field.getName())) {
+                continue;
+            }
+            if (entry.getField(field)
+                     .filter(value -> matchValue(value, term, matchKind, caseSensitive))
+                     .isPresent()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matchAnyKeyword(String term, SearchFlags matchKind, boolean caseSensitive) {
+        List<String> keywords = entry.getKeywords(keywordSeparator).stream().map(Object::toString).toList();
+        return keywords.stream().anyMatch(k -> matchValue(k, term, matchKind, caseSensitive));
+    }
+
+    /// @param matchKind one of [SearchFlags#INEXACT_MATCH], [SearchFlags#EXACT_MATCH], [SearchFlags#REGULAR_EXPRESSION]
+    private static boolean matchValue(String value, String term, SearchFlags matchKind, boolean caseSensitive) {
+        return switch (matchKind) {
+            case INEXACT_MATCH ->
+                    caseSensitive
+                    ? value.contains(term)
+                    : value.toLowerCase(Locale.ROOT).contains(term.toLowerCase(Locale.ROOT));
+            case EXACT_MATCH ->
+                    caseSensitive ? value.equals(term) : value.equalsIgnoreCase(term);
+            case REGULAR_EXPRESSION ->
+                    matchRegex(value, term, caseSensitive);
+            default ->
+                    throw new IllegalArgumentException("matchKind must be INEXACT_MATCH, EXACT_MATCH, or REGULAR_EXPRESSION, got " + matchKind);
+        };
+    }
+
+    private static boolean matchRegex(String value, String pattern, boolean caseSensitive) {
+        try {
+            Pattern compiled = COMPILED_PATTERNS.asMap().computeIfAbsent(
+                    new RegexKey(pattern, caseSensitive),
+                    key -> Pattern.compile(key.pattern(), key.caseSensitive() ? 0 : Pattern.CASE_INSENSITIVE));
+            return compiled.matcher(value).find();
+        } catch (PatternSyntaxException e) {
+            LOGGER.debug("Invalid regex pattern '{}': {}", pattern, e.getMessage());
+            return false;
+        }
+    }
+
+    /// @param matchKind one of [SearchFlags#INEXACT_MATCH], [SearchFlags#EXACT_MATCH], [SearchFlags#REGULAR_EXPRESSION]
+    private record OperatorFlags(SearchFlags matchKind, boolean caseSensitive, boolean negation) {
+    }
+
+    private static OperatorFlags mapOperator(int tokenType) {
+        return switch (tokenType) {
+            case SearchParser.EQUAL,
+                 SearchParser.CONTAINS ->
+                    new OperatorFlags(SearchFlags.INEXACT_MATCH, false, false);
+            case SearchParser.CEQUAL ->
+                    new OperatorFlags(SearchFlags.INEXACT_MATCH, true, false);
+            case SearchParser.EEQUAL,
+                 SearchParser.MATCHES ->
+                    new OperatorFlags(SearchFlags.EXACT_MATCH, false, false);
+            case SearchParser.CEEQUAL ->
+                    new OperatorFlags(SearchFlags.EXACT_MATCH, true, false);
+            case SearchParser.REQUAL ->
+                    new OperatorFlags(SearchFlags.REGULAR_EXPRESSION, false, false);
+            case SearchParser.CREEQUAL ->
+                    new OperatorFlags(SearchFlags.REGULAR_EXPRESSION, true, false);
+            case SearchParser.NEQUAL ->
+                    new OperatorFlags(SearchFlags.INEXACT_MATCH, false, true);
+            case SearchParser.NCEQUAL ->
+                    new OperatorFlags(SearchFlags.INEXACT_MATCH, true, true);
+            case SearchParser.NEEQUAL ->
+                    new OperatorFlags(SearchFlags.EXACT_MATCH, false, true);
+            case SearchParser.NCEEQUAL ->
+                    new OperatorFlags(SearchFlags.EXACT_MATCH, true, true);
+            case SearchParser.NREQUAL ->
+                    new OperatorFlags(SearchFlags.REGULAR_EXPRESSION, false, true);
+            case SearchParser.NCREEQUAL ->
+                    new OperatorFlags(SearchFlags.REGULAR_EXPRESSION, true, true);
+            default ->
+                    new OperatorFlags(SearchFlags.INEXACT_MATCH, false, false);
+        };
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLibrarySearcher.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLibrarySearcher.java
@@ -2,6 +2,8 @@ package org.jabref.logic.search.inmemory;
 
 import java.util.List;
 
+import javafx.util.Pair;
+
 import org.jabref.logic.search.LibrarySearcher;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -33,15 +35,21 @@ public class InMemoryLibrarySearcher implements LibrarySearcher {
 
     @Override
     public List<BibEntry> getMatches(SearchQuery query) {
-        if (!query.isValid()) {
-            LOGGER.warn("Search failed: invalid search expression '{}'", query.getSearchExpression());
+        if (!validate(query)) {
             return List.of();
-        }
-        if (query.getSearchFlags().contains(SearchFlags.FULLTEXT)) {
-            LOGGER.warn("In-memory searcher does not support FULLTEXT search; matching against metadata only");
         }
         return databaseContext.getDatabase().getEntries().stream()
                               .filter(entry -> matchesParsedQuery(entry, query))
+                              .toList();
+    }
+
+    public List<Pair<BibEntry, MatchInformation>> getDetailedMatches(SearchQuery query) {
+        if (!validate(query)) {
+            return List.of();
+        }
+        return databaseContext.getDatabase().getEntries().stream()
+                              .map(entry -> new Pair<>(entry, getMatchInformation(entry, query)))
+                              .filter(pair -> pair.getValue().getResult())
                               .toList();
     }
 
@@ -57,5 +65,20 @@ public class InMemoryLibrarySearcher implements LibrarySearcher {
     private boolean matchesParsedQuery(BibEntry entry, SearchQuery query) {
         return Boolean.TRUE.equals(
                 new BibEntryMatchVisitor(entry, query.getSearchFlags(), keywordSeparator).visit(query.getContext()));
+    }
+
+    private MatchInformation getMatchInformation(BibEntry entry, SearchQuery query) {
+        return new BibEntryDetailedMatchVisitor(entry, query.getSearchFlags(), keywordSeparator).visit(query.getContext());
+    }
+
+    private boolean validate(SearchQuery query) {
+        if (!query.isValid()) {
+            LOGGER.warn("Search failed: invalid search expression '{}'", query.getSearchExpression());
+            return false;
+        }
+        if (query.getSearchFlags().contains(SearchFlags.FULLTEXT)) {
+            LOGGER.warn("In-memory searcher does not support FULLTEXT search; matching against metadata only");
+        }
+        return true;
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLibrarySearcher.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLibrarySearcher.java
@@ -1,6 +1,8 @@
 package org.jabref.logic.search.inmemory;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javafx.util.Pair;
 
@@ -43,23 +45,20 @@ public class InMemoryLibrarySearcher implements LibrarySearcher {
                               .toList();
     }
 
-    public List<Pair<BibEntry, MatchInformation>> getDetailedMatches(SearchQuery query) {
+    public Map<BibEntry, MatchInformation> getDetailedMatches(SearchQuery query) {
         if (!validate(query)) {
-            return List.of();
+            return Map.of();
         }
         return databaseContext.getDatabase().getEntries().stream()
                               .map(entry -> new Pair<>(entry, getMatchInformation(entry, query)))
                               .filter(pair -> pair.getValue().getResult())
-                              .toList();
+                              .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
     }
 
     /// Test a single entry against a query without iterating the library.
     /// Returns `false` for invalid queries.
     public boolean matches(BibEntry entry, SearchQuery query) {
-        if (!query.isValid()) {
-            return false;
-        }
-        return matchesParsedQuery(entry, query);
+        return query.isValid() && matchesParsedQuery(entry, query);
     }
 
     private boolean matchesParsedQuery(BibEntry entry, SearchQuery query) {

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemorySearchBackend.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemorySearchBackend.java
@@ -1,8 +1,7 @@
 package org.jabref.logic.search.inmemory;
 
 import java.util.List;
-
-import javafx.util.Pair;
+import java.util.Map.Entry;
 
 import org.jabref.logic.search.SearchBackend;
 import org.jabref.model.database.BibDatabaseContext;
@@ -31,7 +30,7 @@ public class InMemorySearchBackend implements SearchBackend {
         query.getMatchInformation().clear();
         SearchResults results = new SearchResults();
         SearchResult marker = new SearchResult();
-        for (Pair<BibEntry, MatchInformation> entry : searcher.getDetailedMatches(query)) {
+        for (Entry<BibEntry, MatchInformation> entry : searcher.getDetailedMatches(query).entrySet()) {
             results.addSearchResult(entry.getKey().getId(), marker);
             query.getMatchInformation().put(entry.getKey().getId(), entry.getValue());
         }

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemorySearchBackend.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemorySearchBackend.java
@@ -2,6 +2,8 @@ package org.jabref.logic.search.inmemory;
 
 import java.util.List;
 
+import javafx.util.Pair;
+
 import org.jabref.logic.search.SearchBackend;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -26,10 +28,12 @@ public class InMemorySearchBackend implements SearchBackend {
 
     @Override
     public SearchResults search(SearchQuery query) {
+        query.getMatchInformation().clear();
         SearchResults results = new SearchResults();
         SearchResult marker = new SearchResult();
-        for (BibEntry entry : searcher.getMatches(query)) {
-            results.addSearchResult(entry.getId(), marker);
+        for (Pair<BibEntry, MatchInformation> entry : searcher.getDetailedMatches(query)) {
+            results.addSearchResult(entry.getKey().getId(), marker);
+            query.getMatchInformation().put(entry.getKey().getId(), entry.getValue());
         }
         query.setSearchResults(results);
         return results;

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/MatchInformation.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/MatchInformation.java
@@ -1,0 +1,78 @@
+package org.jabref.logic.search.inmemory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public class MatchInformation {
+
+    private Boolean result;
+    private Set<PartialResult> partialResults = new HashSet<>();
+
+    public MatchInformation(Boolean result) {
+        this.result = result;
+    }
+
+    public MatchInformation(Boolean result, PartialResult... partialResults) {
+        this.result = result;
+        Collections.addAll(this.partialResults, partialResults);
+    }
+
+    public Boolean getResult() {
+        return result;
+    }
+
+    public void setResult(Boolean result) {
+        this.result = result;
+    }
+
+    public Set<PartialResult> getPartialResults() {
+        return partialResults;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MatchInformation that = (MatchInformation) o;
+        return Objects.equals(result, that.result) && Objects.equals(partialResults, that.partialResults);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(result, partialResults);
+    }
+
+    @Override
+    public String toString() {
+        return "MatchInformation{" +
+                "result=" + result +
+                ", partialResults=" + partialResults +
+                '}';
+    }
+
+    public record PartialResult(boolean isTrue, String subquery) {
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass())
+                return false;
+            PartialResult that = (PartialResult) o;
+            return isTrue == that.isTrue && Objects.equals(subquery, that.subquery);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(isTrue, subquery);
+        }
+
+        @Override
+        public String toString() {
+            return "PartialResult{" +
+                    "isTrue=" + isTrue +
+                    ", subquery='" + subquery + '\'' +
+                    '}';
+        }
+    }
+}
+

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/MatchInformation.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/MatchInformation.java
@@ -10,6 +10,9 @@ public class MatchInformation {
     private Boolean result;
     private Set<PartialResult> partialResults = new HashSet<>();
 
+    public MatchInformation() {
+    }
+
     public MatchInformation(Boolean result) {
         this.result = result;
     }
@@ -33,8 +36,9 @@ public class MatchInformation {
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass())
+        if (o == null || getClass() != o.getClass()) {
             return false;
+        }
         MatchInformation that = (MatchInformation) o;
         return Objects.equals(result, that.result) && Objects.equals(partialResults, that.partialResults);
     }
@@ -55,8 +59,9 @@ public class MatchInformation {
     public record PartialResult(boolean isTrue, String subquery) {
         @Override
         public boolean equals(Object o) {
-            if (o == null || getClass() != o.getClass())
+            if (o == null || getClass() != o.getClass()) {
                 return false;
+            }
             PartialResult that = (PartialResult) o;
             return isTrue == that.isTrue && Objects.equals(subquery, that.subquery);
         }

--- a/jablib/src/main/java/org/jabref/logic/search/query/SearchQueryConversion.java
+++ b/jablib/src/main/java/org/jabref/logic/search/query/SearchQueryConversion.java
@@ -18,6 +18,11 @@ public class SearchQueryConversion {
         return new SearchToSqlVisitor(table, searchQuery.getSearchFlags()).visit(searchQuery.getContext());
     }
 
+    public static SqlQueryNode searchToSqlWithMatchDetails(String table, SearchQuery searchQuery) {
+        LOGGER.debug("Converting search expression to SQL: {}", searchQuery.getSearchExpression());
+        return new SearchToSqlDetailedMatchVisitor(table, searchQuery.getSearchFlags()).visit(searchQuery.getContext());
+    }
+
     public static String flagsToSearchExpression(SearchQuery searchQuery) {
         LOGGER.debug("Converting search flags to search expression: {}, flags {}", searchQuery.getSearchExpression(), searchQuery.getSearchFlags());
         return new SearchFlagsToExpressionVisitor(searchQuery.getSearchFlags()).visit(searchQuery.getContext());

--- a/jablib/src/main/java/org/jabref/logic/search/query/SearchToSqlDetailedMatchVisitor.java
+++ b/jablib/src/main/java/org/jabref/logic/search/query/SearchToSqlDetailedMatchVisitor.java
@@ -568,21 +568,21 @@ public class SearchToSqlDetailedMatchVisitor extends SearchBaseVisitor<SqlQueryN
         StringBuilder result = new StringBuilder();
         result.append("SELECT ");
         for (Map.Entry<String, String> cteToOperation : cteNamesToOperations.entrySet()) {
-            result.append(String.format("(%s.%s IS NOT NULL) as \"%s\", ", cteToOperation.getKey(), ENTRY_ID, cteToOperation.getValue()));
+            result.append("(%s.%s IS NOT NULL) as \"%s\", ".formatted(cteToOperation.getKey(), ENTRY_ID, cteToOperation.getValue()));
         }
-        result.append(String.format("""
+        result.append("""
                 %s.%s as %s
                 from %s
-                """, LAST_CTE, ENTRY_ID, FINAL_MATCH, LAST_CTE));
+                """.formatted(LAST_CTE, ENTRY_ID, FINAL_MATCH, LAST_CTE));
         for (Map.Entry<String, String> cteToOperation : cteNamesToOperations.entrySet()) {
-            result.append(String.format("left join %s on %s.%s = %s.%s\n", cteToOperation.getKey(),
+            result.append("left join %s on %s.%s = %s.%s\n".formatted(cteToOperation.getKey(),
                     cteToOperation.getKey(), ENTRY_ID, LAST_CTE, ENTRY_ID));
         }
         return result.toString();
     }
 
     private String getUniqueCteName() {
-        return String.format("cte%d", cteCounter++);
+        return "cte%d".formatted(cteCounter++);
     }
 
     private static void setFlags(EnumSet<SearchFlags> flags, SearchFlags matchType, boolean caseSensitive, boolean negation) {

--- a/jablib/src/main/java/org/jabref/logic/search/query/SearchToSqlDetailedMatchVisitor.java
+++ b/jablib/src/main/java/org/jabref/logic/search/query/SearchToSqlDetailedMatchVisitor.java
@@ -1,0 +1,609 @@
+package org.jabref.logic.search.query;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.jabref.model.entry.field.InternalField;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.search.PostgresConstants;
+import org.jabref.model.search.SearchFlags;
+import org.jabref.model.search.query.SqlQueryNode;
+import org.jabref.search.SearchBaseVisitor;
+import org.jabref.search.SearchParser;
+
+import static org.jabref.model.search.PostgresConstants.ENTRY_ID;
+import static org.jabref.model.search.PostgresConstants.FIELD_NAME;
+import static org.jabref.model.search.PostgresConstants.FIELD_VALUE_LITERAL;
+import static org.jabref.model.search.PostgresConstants.FIELD_VALUE_TRANSFORMED;
+import static org.jabref.model.search.SearchFlags.CASE_INSENSITIVE;
+import static org.jabref.model.search.SearchFlags.CASE_SENSITIVE;
+import static org.jabref.model.search.SearchFlags.EXACT_MATCH;
+import static org.jabref.model.search.SearchFlags.INEXACT_MATCH;
+import static org.jabref.model.search.SearchFlags.NEGATION;
+import static org.jabref.model.search.SearchFlags.REGULAR_EXPRESSION;
+
+/// Converts to a query processable by the scheme created by [org.jabref.logic.search.indexing.BibFieldsIndexer].
+
+/// Tests are located in `org.jabref.logic.search.query.SearchQuerySQLConversionTest`
+public class SearchToSqlDetailedMatchVisitor extends SearchBaseVisitor<SqlQueryNode> {
+
+    public static final String FINAL_MATCH = "final_match";
+    private static final String MAIN_TABLE = "main_table";
+    private static final String SPLIT_TABLE = "split_table";
+    private static final String INNER_TABLE = "inner_table";
+    private static final String LAST_CTE = "lastcte";
+    private static final String GROUPS_FIELD = StandardField.GROUPS.getName();
+
+    private final EnumSet<SearchFlags> searchBarFlags;
+    private final String mainTableName;
+    private final String splitValuesTableName;
+    private final List<SqlQueryNode> nodes = new ArrayList<>();
+    private final Map<String, String> cteNamesToOperations = new HashMap<>();
+    private int cteCounter = 0;
+
+    public SearchToSqlDetailedMatchVisitor(String table, EnumSet<SearchFlags> searchBarFlags) {
+        this.searchBarFlags = searchBarFlags;
+        this.mainTableName = PostgresConstants.getMainTableSchemaReference(table);
+        this.splitValuesTableName = PostgresConstants.getSplitTableSchemaReference(table);
+    }
+
+    @Override
+    public SqlQueryNode visitStart(SearchParser.StartContext ctx) {
+        SqlQueryNode finalNode = visit(ctx.andExpression());
+
+        StringBuilder sql = new StringBuilder("WITH\n");
+        List<String> params = new ArrayList<>();
+
+        for (SqlQueryNode node : nodes) {
+            sql.append(node.cte()).append(",\n");
+            params.addAll(node.params());
+        }
+        sql.append("""
+                %s AS (
+                    SELECT *
+                    FROM %s
+                    GROUP BY %s
+                )
+                """.formatted(
+                LAST_CTE,
+                finalNode.cte(),
+                ENTRY_ID)).append("\n");
+        sql.append(getFinalQuery());
+        params.addAll(finalNode.params());
+
+        return new SqlQueryNode(sql.toString(), params);
+    }
+
+    @Override
+    public SqlQueryNode visitImplicitAndExpression(SearchParser.ImplicitAndExpressionContext ctx) {
+        List<SqlQueryNode> children = ctx.expression().stream().map(this::visit).toList();
+        String cteName = getUniqueCteName();
+
+        if (children.size() == 1) {
+            return children.getFirst();
+        } else {
+            String cte = """
+                    %s AS (
+                    %s
+                    )
+                    """.formatted(
+                    cteName,
+                    children.stream().map(node -> "    SELECT %s FROM %s".formatted(ENTRY_ID, node.cte())).collect(Collectors.joining("\n    INTERSECT\n")));
+
+            List<String> params = children.stream().flatMap(node -> node.params().stream()).toList();
+            SqlQueryNode node = new SqlQueryNode(cte, params);
+            nodes.add(node);
+            return new SqlQueryNode(cteName);
+        }
+    }
+
+    @Override
+    public SqlQueryNode visitParenExpression(SearchParser.ParenExpressionContext ctx) {
+        return visit(ctx.andExpression());
+    }
+
+    @Override
+    public SqlQueryNode visitNegatedExpression(SearchParser.NegatedExpressionContext ctx) {
+        SqlQueryNode subNode = visit(ctx.expression());
+        String cteName = getUniqueCteName();
+        String cte = """
+                %s AS (
+                    SELECT %s.%s
+                    FROM %s AS %s
+                    WHERE %s.%s NOT IN (
+                       SELECT %s
+                       FROM %s
+                    )
+                )
+                """.formatted(
+                cteName,
+                MAIN_TABLE, ENTRY_ID,
+                mainTableName, MAIN_TABLE,
+                MAIN_TABLE, ENTRY_ID,
+                ENTRY_ID,
+                subNode.cte());
+
+        SqlQueryNode node = new SqlQueryNode(cte, subNode.params());
+        nodes.add(node);
+        return new SqlQueryNode(cteName);
+    }
+
+    @Override
+    public SqlQueryNode visitBinaryExpression(SearchParser.BinaryExpressionContext ctx) {
+        SqlQueryNode left = visit(ctx.left);
+        SqlQueryNode right = visit(ctx.right);
+        String operator = ctx.bin_op.getType() == SearchParser.AND ? "INTERSECT" : "UNION";
+        String cteName = getUniqueCteName();
+
+        String cte = """
+                %s AS (
+                    SELECT %s
+                    FROM %s
+                    %s
+                    SELECT %s
+                    FROM %s
+                )
+                """.formatted(
+                cteName,
+                ENTRY_ID,
+                left.cte(),
+                operator,
+                ENTRY_ID,
+                right.cte());
+
+        List<String> params = new ArrayList<>(left.params());
+        params.addAll(right.params());
+
+        SqlQueryNode node = new SqlQueryNode(cte, params);
+        nodes.add(node);
+        return new SqlQueryNode(cteName);
+    }
+
+    @Override
+    public SqlQueryNode visitComparisonExpression(SearchParser.ComparisonExpressionContext ctx) {
+        return visit(ctx.comparison());
+    }
+
+    @Override
+    public SqlQueryNode visitComparison(SearchParser.ComparisonContext ctx) {
+        EnumSet<SearchFlags> searchFlags = EnumSet.noneOf(SearchFlags.class);
+        String term = SearchQueryConversion.unescapeSearchValue(ctx.searchValue());
+
+        // unfielded expression
+        if (ctx.FIELD() == null) {
+            // apply search bar flags to unfielded expressions
+            boolean isCaseSensitive = searchBarFlags.contains(CASE_SENSITIVE);
+            if (searchBarFlags.contains(REGULAR_EXPRESSION)) {
+                setFlags(searchFlags, REGULAR_EXPRESSION, isCaseSensitive, false);
+            } else {
+                setFlags(searchFlags, INEXACT_MATCH, isCaseSensitive, false);
+            }
+            var result = getFieldQueryNode(SearchFieldConstants.ANY_FIELD, term, searchFlags);
+            cteNamesToOperations.put(result.cte(), ctx.getText());
+            return result;
+        }
+
+        // fielded expression
+        // TODO: Here, there is no unescaping of the term (e.g., field\=thing=value does not work as expected)
+        String field = ctx.FIELD().getText();
+        int operator = ctx.operator().getStart().getType();
+
+        if (operator == SearchParser.EQUAL || operator == SearchParser.CONTAINS) {
+            setFlags(searchFlags, INEXACT_MATCH, false, false);
+        } else if (operator == SearchParser.CEQUAL) {
+            setFlags(searchFlags, INEXACT_MATCH, true, false);
+        } else if (operator == SearchParser.EEQUAL || operator == SearchParser.MATCHES) {
+            setFlags(searchFlags, EXACT_MATCH, false, false);
+        } else if (operator == SearchParser.CEEQUAL) {
+            setFlags(searchFlags, EXACT_MATCH, true, false);
+        } else if (operator == SearchParser.REQUAL) {
+            setFlags(searchFlags, REGULAR_EXPRESSION, false, false);
+        } else if (operator == SearchParser.CREEQUAL) {
+            setFlags(searchFlags, REGULAR_EXPRESSION, true, false);
+        } else if (operator == SearchParser.NEQUAL) {
+            setFlags(searchFlags, INEXACT_MATCH, false, true);
+        } else if (operator == SearchParser.NCEQUAL) {
+            setFlags(searchFlags, INEXACT_MATCH, true, true);
+        } else if (operator == SearchParser.NEEQUAL) {
+            setFlags(searchFlags, EXACT_MATCH, false, true);
+        } else if (operator == SearchParser.NCEEQUAL) {
+            setFlags(searchFlags, EXACT_MATCH, true, true);
+        } else if (operator == SearchParser.NREQUAL) {
+            setFlags(searchFlags, REGULAR_EXPRESSION, false, true);
+        } else if (operator == SearchParser.NCREEQUAL) {
+            setFlags(searchFlags, REGULAR_EXPRESSION, true, true);
+        }
+
+        // field = "" -> should find entries where the field is empty
+        // field != "" -> should find entries where the field is not empty
+        if (term.isEmpty()) {
+            if (searchFlags.contains(NEGATION)) {
+                searchFlags.remove(NEGATION);
+            } else {
+                searchFlags.add(NEGATION);
+            }
+        }
+
+        var result = getFieldQueryNode(field.toLowerCase(Locale.ROOT), term, searchFlags);
+        cteNamesToOperations.put(result.cte(), ctx.getText());
+        return result;
+    }
+
+    private SqlQueryNode getFieldQueryNode(String field, String term, EnumSet<SearchFlags> searchFlags) {
+        String sqlOperator = getSqlOperator(searchFlags);
+        String prefixSuffix = searchFlags.contains(INEXACT_MATCH) ? "%" : "";
+
+        if (!searchFlags.contains(REGULAR_EXPRESSION)) {
+            term = escapeTermForSql(term);
+        }
+
+        // Pseudo-fields
+        field = switch (field) {
+            case SearchFieldConstants.KEY ->
+                    InternalField.KEY_FIELD.getName();
+            case SearchFieldConstants.ANY_KEYWORD ->
+                    StandardField.KEYWORDS.getName();
+            case SearchFieldConstants.ANY_FIELD_ALIAS ->
+                    SearchFieldConstants.ANY_FIELD;
+            default ->
+                    field;
+        };
+
+        if (ENTRY_ID.toString().equals(field)) {
+            return buildEntryIdQuery(term);
+        } else if (SearchFieldConstants.ANY_FIELD.equals(field)) {
+            if (searchFlags.contains(EXACT_MATCH)) {
+                return searchFlags.contains(NEGATION)
+                       ? buildExactNegationAnyFieldQuery(sqlOperator, term)
+                       : buildExactAnyFieldQuery(sqlOperator, term);
+            } else {
+                return searchFlags.contains(NEGATION)
+                       ? buildContainsNegationAnyFieldQuery(sqlOperator, prefixSuffix, term)
+                       : buildContainsAnyFieldQuery(sqlOperator, prefixSuffix, term);
+            }
+        } else {
+            if (searchFlags.contains(EXACT_MATCH)) {
+                return searchFlags.contains(NEGATION)
+                       ? buildExactNegationFieldQuery(field, sqlOperator, term)
+                       : buildExactFieldQuery(field, sqlOperator, term);
+            } else {
+                return searchFlags.contains(NEGATION)
+                       ? buildContainsNegationFieldQuery(field, sqlOperator, prefixSuffix, term)
+                       : buildContainsFieldQuery(field, sqlOperator, prefixSuffix, term);
+            }
+        }
+    }
+
+    private SqlQueryNode buildEntryIdQuery(String entryId) {
+        String cteName = getUniqueCteName();
+        String cte = """
+                %s AS (
+                    SELECT %s
+                    FROM %s
+                    WHERE %s = ?
+                )
+                """.formatted(cteName, ENTRY_ID, mainTableName, ENTRY_ID);
+        SqlQueryNode node = new SqlQueryNode(cte, List.of(entryId));
+        nodes.add(node);
+        return new SqlQueryNode(cteName);
+    }
+
+    private SqlQueryNode buildContainsAnyFieldQuery(String operator, String prefixSuffix, String term) {
+        String cteName = getUniqueCteName();
+        String cte = """
+                %s AS (
+                    SELECT %s.%s
+                    FROM %s AS %s
+                    WHERE (
+                        (%s.%s != '%s') AND ((%s.%s %s ?) OR (%s.%s %s ?))
+                    )
+                )
+                """.formatted(
+                cteName,
+                MAIN_TABLE, ENTRY_ID,
+                mainTableName, MAIN_TABLE,
+                MAIN_TABLE, FIELD_NAME, GROUPS_FIELD, // https://github.com/JabRef/jabref/issues/7996
+                MAIN_TABLE, FIELD_VALUE_LITERAL,
+                operator,
+                MAIN_TABLE, FIELD_VALUE_TRANSFORMED,
+                operator);
+
+        List<String> params = Collections.nCopies(2, prefixSuffix + term + prefixSuffix);
+        SqlQueryNode node = new SqlQueryNode(cte, params);
+        nodes.add(node);
+        return new SqlQueryNode(cteName);
+    }
+
+    private SqlQueryNode buildContainsNegationAnyFieldQuery(String operator, String prefixSuffix, String term) {
+        String cteName = getUniqueCteName();
+        String cte = """
+                %s AS (
+                    SELECT %s.%s
+                    FROM %s AS %s
+                    WHERE %s.%s NOT IN (
+                        SELECT %s.%s
+                        FROM %s AS %s
+                        WHERE (
+                            (%s.%s != '%s') AND ((%s.%s %s ?) OR (%s.%s %s ?))
+                        )
+                    )
+                )
+                """.formatted(
+                cteName,
+                MAIN_TABLE, ENTRY_ID,
+                mainTableName, MAIN_TABLE,
+                MAIN_TABLE, ENTRY_ID,
+                INNER_TABLE, ENTRY_ID,
+                mainTableName, INNER_TABLE,
+                INNER_TABLE, FIELD_NAME, GROUPS_FIELD, // https://github.com/JabRef/jabref/issues/7996
+                INNER_TABLE, FIELD_VALUE_LITERAL,
+                operator,
+                INNER_TABLE, FIELD_VALUE_TRANSFORMED,
+                operator);
+
+        List<String> params = Collections.nCopies(2, prefixSuffix + term + prefixSuffix);
+        SqlQueryNode node = new SqlQueryNode(cte, params);
+        nodes.add(node);
+        return new SqlQueryNode(cteName);
+    }
+
+    private SqlQueryNode buildExactAnyFieldQuery(String operator, String term) {
+        String cteName = getUniqueCteName();
+        String cte = """
+                %s AS (
+                    SELECT %s.%s
+                    FROM %s AS %s
+                    LEFT JOIN %s AS %s
+                    ON (%s.%s = %s.%s AND %s.%s = %s.%s)
+                    WHERE (
+                        (%s.%s != '%s')
+                        AND (
+                            ((%s.%s %s ?) OR (%s.%s %s ?))
+                            OR
+                            ((%s.%s %s ?) OR (%s.%s %s ?))
+                        )
+                    )
+                )
+                """.formatted(
+                cteName,
+                MAIN_TABLE, ENTRY_ID,
+                mainTableName, MAIN_TABLE,
+                splitValuesTableName, SPLIT_TABLE,
+                MAIN_TABLE, ENTRY_ID, SPLIT_TABLE, ENTRY_ID,
+                MAIN_TABLE, FIELD_NAME, SPLIT_TABLE, FIELD_NAME,
+                MAIN_TABLE, FIELD_NAME, GROUPS_FIELD, // https://github.com/JabRef/jabref/issues/7996
+                MAIN_TABLE, FIELD_VALUE_LITERAL, operator,
+                MAIN_TABLE, FIELD_VALUE_TRANSFORMED, operator,
+                SPLIT_TABLE, FIELD_VALUE_LITERAL, operator,
+                SPLIT_TABLE, FIELD_VALUE_TRANSFORMED, operator);
+
+        List<String> params = Collections.nCopies(4, term);
+        SqlQueryNode node = new SqlQueryNode(cte, params);
+        nodes.add(node);
+        return new SqlQueryNode(cteName);
+    }
+
+    private SqlQueryNode buildExactNegationAnyFieldQuery(String operator, String term) {
+        String cteName = getUniqueCteName();
+        String cte = """
+                %s AS (
+                    SELECT %s.%s
+                    FROM %s AS %s
+                    WHERE %s.%s NOT IN (
+                        SELECT %s.%s
+                        FROM %s AS %s
+                        LEFT JOIN %s AS %s
+                        ON (%s.%s = %s.%s AND %s.%s = %s.%s)
+                        WHERE (
+                            (%s.%s != '%s')
+                            AND (
+                                ((%s.%s %s ?) OR (%s.%s %s ?))
+                                OR
+                                ((%s.%s %s ?) OR (%s.%s %s ?))
+                            )
+                        )
+                    )
+                )
+                """.formatted(
+                cteName,
+                MAIN_TABLE, ENTRY_ID,
+                mainTableName, MAIN_TABLE,
+                MAIN_TABLE, ENTRY_ID,
+                INNER_TABLE, ENTRY_ID,
+                mainTableName, INNER_TABLE,
+                splitValuesTableName, SPLIT_TABLE,
+                INNER_TABLE, FIELD_NAME, SPLIT_TABLE, FIELD_NAME,
+                INNER_TABLE, ENTRY_ID, SPLIT_TABLE, ENTRY_ID,
+                INNER_TABLE, FIELD_NAME, GROUPS_FIELD, // https://github.com/JabRef/jabref/issues/7996
+                INNER_TABLE, FIELD_VALUE_LITERAL, operator,
+                INNER_TABLE, FIELD_VALUE_TRANSFORMED, operator,
+                SPLIT_TABLE, FIELD_VALUE_LITERAL, operator,
+                SPLIT_TABLE, FIELD_VALUE_TRANSFORMED, operator);
+
+        List<String> params = Collections.nCopies(4, term);
+        SqlQueryNode node = new SqlQueryNode(cte, params);
+        nodes.add(node);
+        return new SqlQueryNode(cteName);
+    }
+
+    private SqlQueryNode buildContainsFieldQuery(String field, String operator, String prefixSuffix, String term) {
+        String cteName = getUniqueCteName();
+        String cte = """
+                %s AS (
+                    SELECT %s.%s
+                    FROM %s AS %s
+                    WHERE (
+                        (%s.%s = '%s') AND ((%s.%s %s ?) OR (%s.%s %s ?))
+                    )
+                )
+                """.formatted(
+                cteName,
+                MAIN_TABLE, ENTRY_ID,
+                mainTableName, MAIN_TABLE,
+                MAIN_TABLE, FIELD_NAME, field,
+                MAIN_TABLE, FIELD_VALUE_LITERAL, operator,
+                MAIN_TABLE, FIELD_VALUE_TRANSFORMED, operator);
+
+        List<String> params = Collections.nCopies(2, prefixSuffix + term + prefixSuffix);
+        SqlQueryNode node = new SqlQueryNode(cte, params);
+        nodes.add(node);
+        return new SqlQueryNode(cteName);
+    }
+
+    private SqlQueryNode buildContainsNegationFieldQuery(String field, String operator, String prefixSuffix, String term) {
+        String cteName = getUniqueCteName();
+        String cte = """
+                %s AS (
+                    SELECT %s.%s
+                    FROM %s AS %s
+                    WHERE %s.%s NOT IN (
+                        SELECT %s.%s
+                        FROM %s AS %s
+                        WHERE (
+                            (%s.%s = '%s') AND ((%s.%s %s ?) OR (%s.%s %s ?))
+                        )
+                    )
+                )
+                """.formatted(
+                cteName,
+                MAIN_TABLE, ENTRY_ID,
+                mainTableName, MAIN_TABLE,
+                MAIN_TABLE, ENTRY_ID,
+                INNER_TABLE, ENTRY_ID,
+                mainTableName, INNER_TABLE,
+                INNER_TABLE, FIELD_NAME, field,
+                INNER_TABLE, FIELD_VALUE_LITERAL,
+                operator,
+                INNER_TABLE, FIELD_VALUE_TRANSFORMED,
+                operator);
+
+        List<String> params = Collections.nCopies(2, prefixSuffix + term + prefixSuffix);
+        SqlQueryNode node = new SqlQueryNode(cte, params);
+        nodes.add(node);
+        return new SqlQueryNode(cteName);
+    }
+
+    private SqlQueryNode buildExactFieldQuery(String field, String operator, String term) {
+        String cteName = getUniqueCteName();
+        String cte = """
+                %s AS (
+                    SELECT %s.%s
+                    FROM %s AS %s
+                    LEFT JOIN %s AS %s
+                    ON (%s.%s = %s.%s AND %s.%s = %s.%s)
+                    WHERE (
+                        ((%s.%s = '%s') AND ((%s.%s %s ?) OR (%s.%s %s ?)))
+                        OR
+                        ((%s.%s = '%s') AND ((%s.%s %s ?) OR (%s.%s %s ?)))
+                    )
+                )
+                """.formatted(
+                getUniqueCteName(),
+                MAIN_TABLE, ENTRY_ID,
+                mainTableName, MAIN_TABLE,
+                splitValuesTableName, SPLIT_TABLE,
+                MAIN_TABLE, ENTRY_ID, SPLIT_TABLE, ENTRY_ID,
+                MAIN_TABLE, FIELD_NAME, SPLIT_TABLE, FIELD_NAME,
+                MAIN_TABLE, FIELD_NAME, field,
+                MAIN_TABLE, FIELD_VALUE_LITERAL, operator,
+                MAIN_TABLE, FIELD_VALUE_TRANSFORMED, operator,
+                SPLIT_TABLE, FIELD_NAME, field,
+                SPLIT_TABLE, FIELD_VALUE_LITERAL, operator,
+                SPLIT_TABLE, FIELD_VALUE_TRANSFORMED, operator);
+
+        List<String> params = Collections.nCopies(4, term);
+        SqlQueryNode node = new SqlQueryNode(cte, params);
+        nodes.add(node);
+        return new SqlQueryNode(cteName);
+    }
+
+    private SqlQueryNode buildExactNegationFieldQuery(String field, String operator, String term) {
+        String cteName = getUniqueCteName();
+        String cte = """
+                %s AS (
+                    SELECT %s.%s
+                    FROM %s AS %s
+                    WHERE %s.%s NOT IN (
+                        SELECT %s.%s
+                        FROM %s AS %s
+                        LEFT JOIN %s AS %s
+                        ON (%s.%s = %s.%s AND %s.%s = %s.%s)
+                        WHERE (
+                            ((%s.%s = '%s') AND ((%s.%s %s ?) OR (%s.%s %s ?)))
+                            OR
+                            ((%s.%s = '%s') AND ((%s.%s %s ?) OR (%s.%s %s ?)))
+                        )
+                    )
+                )
+                """.formatted(
+                cteName,
+                MAIN_TABLE, ENTRY_ID,
+                mainTableName, MAIN_TABLE,
+                MAIN_TABLE, ENTRY_ID,
+                INNER_TABLE, ENTRY_ID,
+                mainTableName, INNER_TABLE,
+                splitValuesTableName, SPLIT_TABLE,
+                INNER_TABLE, ENTRY_ID, SPLIT_TABLE, ENTRY_ID,
+                INNER_TABLE, FIELD_NAME, SPLIT_TABLE, FIELD_NAME,
+                INNER_TABLE, FIELD_NAME, field,
+                INNER_TABLE, FIELD_VALUE_LITERAL, operator,
+                INNER_TABLE, FIELD_VALUE_TRANSFORMED, operator,
+                SPLIT_TABLE, FIELD_NAME, field,
+                SPLIT_TABLE, FIELD_VALUE_LITERAL, operator,
+                SPLIT_TABLE, FIELD_VALUE_TRANSFORMED, operator);
+
+        List<String> params = Collections.nCopies(4, term);
+        SqlQueryNode node = new SqlQueryNode(cte, params);
+        nodes.add(node);
+        return new SqlQueryNode(cteName);
+    }
+
+    private String getFinalQuery() {
+        StringBuilder result = new StringBuilder();
+        result.append("SELECT ");
+        for (Map.Entry<String, String> cteToOperation : cteNamesToOperations.entrySet()) {
+            result.append(String.format("(%s.%s IS NOT NULL) as \"%s\", ", cteToOperation.getKey(), ENTRY_ID, cteToOperation.getValue()));
+        }
+        result.append(String.format("""
+                %s.%s as %s
+                from %s
+                """, LAST_CTE, ENTRY_ID, FINAL_MATCH, LAST_CTE));
+        for (Map.Entry<String, String> cteToOperation : cteNamesToOperations.entrySet()) {
+            result.append(String.format("left join %s on %s.%s = %s.%s\n", cteToOperation.getKey(),
+                    cteToOperation.getKey(), ENTRY_ID, LAST_CTE, ENTRY_ID));
+        }
+        return result.toString();
+    }
+
+    private String getUniqueCteName() {
+        return String.format("cte%d", cteCounter++);
+    }
+
+    private static void setFlags(EnumSet<SearchFlags> flags, SearchFlags matchType, boolean caseSensitive, boolean negation) {
+        flags.add(matchType);
+
+        flags.add(caseSensitive ? CASE_SENSITIVE : CASE_INSENSITIVE);
+        if (negation) {
+            flags.add(NEGATION);
+        }
+    }
+
+    private static String getSqlOperator(EnumSet<SearchFlags> searchFlags) {
+        return searchFlags.contains(REGULAR_EXPRESSION)
+               ? (searchFlags.contains(CASE_SENSITIVE) ? "~" : "~*")
+               : (searchFlags.contains(CASE_SENSITIVE) ? "LIKE" : "ILIKE");
+    }
+
+    /// Escapes wildcard characters in the search term for SQL queries.
+    ///
+    /// - Escapes `\`, `_`, and `%` for SQL LIKE queries.
+    private static String escapeTermForSql(String term) {
+        return term.replaceAll("[\\\\_%]", "\\\\$0");
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/IndexManager.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/IndexManager.java
@@ -308,7 +308,7 @@ public class IndexManager {
 
     public SearchResults search(SearchQuery query) {
         List<Callable<SearchResults>> tasks = new ArrayList<>();
-        tasks.add(() -> bibFieldsSearcher.search(query));
+        tasks.add(() -> bibFieldsSearcher.searchDetailedMatches(query));
 
         if (query.getSearchFlags().contains(SearchFlags.FULLTEXT)) {
             tasks.add(() -> linkedFilesSearcher.search(query));

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/SqlBasedLibrarySearcher.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/SqlBasedLibrarySearcher.java
@@ -1,11 +1,17 @@
 package org.jabref.logic.search.sqlbased;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javafx.util.Pair;
 
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.search.LibrarySearcher;
+import org.jabref.logic.search.inmemory.MatchInformation;
 import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.BibDatabases;
@@ -48,5 +54,26 @@ public class SqlBasedLibrarySearcher implements LibrarySearcher {
                                                   .toList();
         indexManager.closeAndWait();
         return BibDatabases.purgeEmptyEntries(matchEntries);
+    }
+
+    public Map<BibEntry, Optional<MatchInformation>> getDetailedMatches(SearchQuery query) {
+        LOGGER.debug("Search term: {}", query);
+
+        if (!query.isValid()) {
+            LOGGER.warn("Search failed: invalid search expression");
+            indexManager.closeAndWait();
+            return new HashMap<>();
+        }
+        Map<BibEntry, Optional<MatchInformation>> matchEntries = indexManager.search(query)
+                                                                             .getDetailedMatchedEntries()
+                                                                             .entrySet()
+                                                                             .stream()
+                                                                             .map(entry ->
+                                                                                     new Pair<>(databaseContext.getDatabase().getEntryById(entry.getKey()), entry.getValue()))
+                                                                             .filter(pair -> pair.getKey().isPresent())
+                                                                             .collect(Collectors.toMap(entry ->
+                                                                                     entry.getKey().get(), Pair::getValue));
+        indexManager.closeAndWait();
+        return matchEntries;
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/SqlSearchBackend.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/SqlSearchBackend.java
@@ -1,8 +1,11 @@
 package org.jabref.logic.search.sqlbased;
 
 import java.util.List;
+import java.util.Map.Entry;
+import java.util.Optional;
 
 import org.jabref.logic.search.SearchBackend;
+import org.jabref.logic.search.inmemory.MatchInformation;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.event.FieldChangedEvent;
 import org.jabref.model.search.query.SearchQuery;
@@ -20,7 +23,14 @@ public class SqlSearchBackend implements SearchBackend {
 
     @Override
     public SearchResults search(SearchQuery query) {
-        return indexManager.search(query);
+        query.getMatchInformation().clear();
+        SearchResults results = indexManager.search(query);
+        for (Entry<String, Optional<MatchInformation>> mi : results.getDetailedMatchedEntries().entrySet()) {
+            if (mi.getValue().isPresent()) {
+                query.getMatchInformation().put(mi.getKey(), mi.getValue().get());
+            }
+        }
+        return results;
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/retrieval/BibFieldsSearcher.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/retrieval/BibFieldsSearcher.java
@@ -3,8 +3,11 @@ package org.jabref.logic.search.sqlbased.retrieval;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.Objects;
 
+import org.jabref.logic.search.inmemory.MatchInformation;
 import org.jabref.logic.search.query.SearchQueryConversion;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.search.query.SearchQuery;
@@ -15,6 +18,7 @@ import org.jabref.model.search.query.SqlQueryNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.jabref.logic.search.query.SearchToSqlDetailedMatchVisitor.FINAL_MATCH;
 import static org.jabref.model.search.PostgresConstants.ENTRY_ID;
 
 public class BibFieldsSearcher {
@@ -59,4 +63,41 @@ public class BibFieldsSearcher {
         }
         return searchResults;
     }
+
+    public SearchResults searchDetailedMatches(SearchQuery searchQuery) {
+        if (!searchQuery.isValid()) {
+            return new SearchResults();
+        }
+        SqlQueryNode sqlQueryNode = SearchQueryConversion.searchToSqlWithMatchDetails(tableName, searchQuery);
+        SearchResults searchResults = new SearchResults();
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sqlQueryNode.cte())) {
+            for (int i = 0; i < sqlQueryNode.params().size(); i++) {
+                preparedStatement.setString(i + 1, sqlQueryNode.params().get(i));
+            }
+            LOGGER.debug("Executing search query: {}", preparedStatement);
+            ResultSet resultSet = preparedStatement.executeQuery();
+            ResultSetMetaData resultMdata = resultSet.getMetaData();
+            int columnCount = resultMdata.getColumnCount();
+            while (resultSet.next()) {
+                SearchResult result = new SearchResult();
+                MatchInformation mi = new MatchInformation(true);
+                result.setMatchInformation(mi);
+                for (int i = 1; i <= columnCount; i++) {
+                    String cname = resultMdata.getColumnName(i);
+                    if (Objects.equals(cname, FINAL_MATCH)) {
+                        String entryId = resultSet.getString(FINAL_MATCH);
+                        searchResults.addSearchResult(entryId, result);
+                    } else {
+                        mi.getPartialResults().add(
+                                new MatchInformation.PartialResult(resultSet.getBoolean(resultMdata.getColumnLabel(i)), cname)
+                        );
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Error during bib fields search execution", e);
+        }
+        return searchResults;
+    }
 }
+

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/retrieval/LinkedFilesClausesSearcher.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/retrieval/LinkedFilesClausesSearcher.java
@@ -1,0 +1,72 @@
+package org.jabref.logic.search.sqlbased.retrieval;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+
+import javafx.util.Pair;
+
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+
+public final class LinkedFilesClausesSearcher {
+
+    public static Map<String, TopDocs> getClausesResults(IndexSearcher indexSearcher, Query searchQuery) throws IOException {
+        Map<String, TopDocs> result = new HashMap<>();
+        Map<String, Set<Query>> termQueries = getQueries(searchQuery);
+
+        for (Entry<String, Set<Query>> fieldToQueries : termQueries.entrySet()) {
+            BooleanQuery.Builder queryBuilder = new BooleanQuery.Builder();
+            fieldToQueries.getValue().forEach(term -> queryBuilder.add(
+                    new BooleanQuery.Builder().add(term, BooleanClause.Occur.FILTER).build(), BooleanClause.Occur.SHOULD)
+            );
+            result.put(fieldToQueries.getKey(), indexSearcher.search(queryBuilder.build(), Integer.MAX_VALUE));
+        }
+        return result;
+    }
+
+    private static Map<String, Set<Query>> getQueries(Query searchQuery) {
+        return getQueries(searchQuery, new HashMap<>());
+    }
+
+    private static Map<String, Set<Query>> getQueries(Query searchQuery, Map<String, Set<Query>> result) {
+        Optional<Pair<String, Query>> newQuery = Optional.empty();
+        if (searchQuery instanceof TermQuery termQuery) {
+            newQuery = Optional.of(new Pair<>(getTermQueryValue(termQuery), termQuery));
+        } else if (searchQuery instanceof PhraseQuery phraseQuery) {
+            newQuery = Optional.of(new Pair<>(getPhraseQueryValue(phraseQuery), phraseQuery));
+        } else if (searchQuery instanceof BooleanQuery booleanQuery) {
+            for (BooleanClause clause : booleanQuery.clauses()) {
+                getQueries(clause.query(), result);
+            }
+        }
+        if (newQuery.isPresent()) {
+            String key = newQuery.get().getKey();
+            Query query = newQuery.get().getValue();
+            if (result.containsKey(key)) {
+                result.get(key).add(query);
+            } else {
+                result.put(key, new HashSet<>(List.of(query)));
+            }
+        }
+        return result;
+    }
+
+    private static String getTermQueryValue(TermQuery termQuery) {
+        return termQuery.toString(termQuery.getTerm().field());
+    }
+
+    private static String getPhraseQueryValue(PhraseQuery phraseQuery) {
+        return phraseQuery.toString(phraseQuery.getField());
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/retrieval/LinkedFilesSearcher.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/retrieval/LinkedFilesSearcher.java
@@ -2,13 +2,16 @@ package org.jabref.logic.search.sqlbased.retrieval;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 import org.jabref.logic.FilePreferences;
+import org.jabref.logic.search.inmemory.MatchInformation;
 import org.jabref.logic.search.query.SearchQueryConversion;
 import org.jabref.logic.search.sqlbased.LuceneIndexer;
 import org.jabref.model.database.BibDatabaseContext;
@@ -35,6 +38,8 @@ import org.apache.lucene.search.highlight.QueryScorer;
 import org.apache.lucene.search.highlight.SimpleHTMLFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.jabref.logic.search.sqlbased.retrieval.LinkedFilesClausesSearcher.getClausesResults;
 
 public final class LinkedFilesSearcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(LinkedFilesSearcher.class);
@@ -93,12 +98,13 @@ public final class LinkedFilesSearcher {
 
     private SearchResults search(IndexSearcher indexSearcher, Query searchQuery) throws IOException {
         TopDocs topDocs = indexSearcher.search(searchQuery, Integer.MAX_VALUE);
+        Map<String, TopDocs> clauseResult = getClausesResults(indexSearcher, searchQuery);
         StoredFields storedFields = indexSearcher.storedFields();
         LOGGER.debug("Found {} matching documents", topDocs.totalHits.value());
-        return getSearchResults(topDocs, storedFields, searchQuery);
+        return getSearchResults(topDocs, storedFields, searchQuery, clauseResult);
     }
 
-    private SearchResults getSearchResults(TopDocs topDocs, StoredFields storedFields, Query searchQuery) throws IOException {
+    private SearchResults getSearchResults(TopDocs topDocs, StoredFields storedFields, Query searchQuery, Map<String, TopDocs> clauseResults) throws IOException {
         SearchResults searchResults = new SearchResults();
         long startTime = System.currentTimeMillis();
 
@@ -118,6 +124,14 @@ public final class LinkedFilesSearcher {
                             getFieldContents(document, LinkedFilesConstants.ANNOTATIONS),
                             Integer.parseInt(getFieldContents(document, LinkedFilesConstants.PAGE_NUMBER)),
                             highlighter);
+                    if (!clauseResults.isEmpty()) {
+                        MatchInformation matchInformation = new MatchInformation(true);
+                        for (Entry<String, TopDocs> clauseResult : clauseResults.entrySet()) {
+                            List<Integer> resultDocs = Arrays.stream(clauseResult.getValue().scoreDocs).map(scoredoc -> scoredoc.doc).toList();
+                            matchInformation.getPartialResults().add(new MatchInformation.PartialResult(resultDocs.contains(scoreDoc.doc), clauseResult.getKey()));
+                        }
+                        searchResult.setMatchInformation(matchInformation);
+                    }
                     searchResults.addSearchResult(entriesWithFile, searchResult);
                 }
             }

--- a/jablib/src/main/java/org/jabref/model/search/query/SearchQuery.java
+++ b/jablib/src/main/java/org/jabref/model/search/query/SearchQuery.java
@@ -1,8 +1,11 @@
 package org.jabref.model.search.query;
 
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
+import org.jabref.logic.search.inmemory.MatchInformation;
 import org.jabref.model.search.SearchFlags;
 import org.jabref.model.search.ThrowingErrorListener;
 import org.jabref.search.SearchLexer;
@@ -25,6 +28,7 @@ public class SearchQuery {
     private SearchParser.StartContext context;
     private boolean isValidExpression;
     private SearchResults searchResults;
+    private final Map<String, MatchInformation> matchInformation = new HashMap<>();
 
     public SearchQuery(String searchExpression) {
         this(searchExpression, EnumSet.noneOf(SearchFlags.class));
@@ -66,6 +70,10 @@ public class SearchQuery {
 
     public SearchParser.StartContext getContext() {
         return context;
+    }
+
+    public Map<String, MatchInformation> getMatchInformation() {
+        return matchInformation;
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/model/search/query/SearchResult.java
+++ b/jablib/src/main/java/org/jabref/model/search/query/SearchResult.java
@@ -3,7 +3,9 @@ package org.jabref.model.search.query;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
+import org.jabref.logic.search.inmemory.MatchInformation;
 import org.jabref.model.search.LinkedFilesConstants;
 
 import org.apache.lucene.analysis.TokenStream;
@@ -21,6 +23,7 @@ public final class SearchResult {
     private final Highlighter highlighter;
     private List<String> contentResultStringsHtml;
     private List<String> annotationsResultStringsHtml;
+    private MatchInformation matchInformation;
 
     private SearchResult(boolean hasFulltextResults,
                          String path,
@@ -68,6 +71,14 @@ public final class SearchResult {
 
     public int getPageNumber() {
         return pageNumber;
+    }
+
+    public Optional<MatchInformation> getMatchInformation() {
+        return matchInformation != null ? Optional.of(matchInformation) : Optional.empty();
+    }
+
+    public void setMatchInformation(MatchInformation matchInformation) {
+        this.matchInformation = matchInformation;
     }
 
     private static List<String> getHighlighterFragments(Highlighter highlighter, LinkedFilesConstants field, String content) {

--- a/jablib/src/main/java/org/jabref/model/search/query/SearchResults.java
+++ b/jablib/src/main/java/org/jabref/model/search/query/SearchResults.java
@@ -5,9 +5,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.jabref.logic.search.inmemory.MatchInformation;
 import org.jabref.model.entry.BibEntry;
 
 public class SearchResults {
@@ -53,5 +56,19 @@ public class SearchResults {
 
     public Set<String> getMatchedEntries() {
         return searchResults.keySet();
+    }
+
+    public Map<String, Optional<MatchInformation>> getDetailedMatchedEntries() {
+        Map<String, Optional<MatchInformation>> matchedEntries = new HashMap<>();
+        for (Entry<String, List<SearchResult>> entry : searchResults.entrySet()) {
+            matchedEntries.put(entry.getKey(), Optional.empty());
+            for (SearchResult result : entry.getValue()) {
+                if (result.getMatchInformation().isPresent()) {
+                    matchedEntries.put(entry.getKey(), result.getMatchInformation());
+                    break;
+                }
+            }
+        }
+        return matchedEntries;
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/search/LibrarySearcherTestCases.java
+++ b/jablib/src/test/java/org/jabref/logic/search/LibrarySearcherTestCases.java
@@ -1,9 +1,8 @@
 package org.jabref.logic.search;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
-
-import javafx.util.Pair;
 
 import org.jabref.logic.search.inmemory.MatchInformation;
 import org.jabref.logic.search.inmemory.MatchInformation.PartialResult;
@@ -21,39 +20,34 @@ import org.junit.jupiter.params.provider.Arguments;
 /// belong in the per-implementation test class.
 public final class LibrarySearcherTestCases {
 
-    public static final BibEntry ARTICLE_HARRER = new BibEntry(StandardEntryType.Article)
+    private static final String TITLE_SENTENCE_CASED_AUTHOR = "JamesSensible";
+    private static final String TITLE_MIXED_CASED_AUTHOR = "TomTheHusky";
+    private static final String TITLE_UPPER_CASED_AUTHOR = "ArnoldtheLoud";
+
+    private static final BibEntry ARTICLE_HARRER = new BibEntry(StandardEntryType.Article)
             .withCitationKey("harrer")
             .withField(StandardField.AUTHOR, "harrer");
 
-    public static final BibEntry INCOLLECTION_TONHO = new BibEntry(StandardEntryType.InCollection)
+    private static final BibEntry INCOLLECTION_TONHO = new BibEntry(StandardEntryType.InCollection)
             .withCitationKey("tonho")
             .withField(StandardField.AUTHOR, "tonho");
 
-    public static final BibEntry EMPTY_ENTRY = new BibEntry();
+    private static final BibEntry EMPTY_ENTRY = new BibEntry();
 
-    public static final BibEntry TITLE_SENTENCE_CASED = new BibEntry(StandardEntryType.Misc)
+    private static final BibEntry TITLE_SENTENCE_CASED = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("title-sentence-cased")
             .withField(StandardField.TITLE, "Title Sentence Cased")
             .withField(StandardField.AUTHOR, TITLE_SENTENCE_CASED_AUTHOR);
 
-    public static final BibEntry TITLE_MIXED_CASED = new BibEntry(StandardEntryType.Misc)
+    private static final BibEntry TITLE_MIXED_CASED = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("title-mixed-cased")
             .withField(StandardField.TITLE, "TiTle MiXed CaSed")
             .withField(StandardField.AUTHOR, TITLE_MIXED_CASED_AUTHOR);
 
-    public static final BibEntry TITLE_UPPER_CASED = new BibEntry(StandardEntryType.Misc)
+    private static final BibEntry TITLE_UPPER_CASED = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("title-upper-cased")
             .withField(StandardField.TITLE, "TITLE UPPER CASED")
             .withField(StandardField.AUTHOR, TITLE_UPPER_CASED_AUTHOR);
-
-    public static final BibEntry AUTHOR_WITH_COMMENT_CHARACTERS = new BibEntry(StandardEntryType.Misc)
-            .withField(StandardField.TITLE, "A life with a stupid name - my story")
-            .withField(StandardField.AUTHOR, AUTHOR_WITH_COMMENT_CHARACTERS_NAME);
-
-    private static final String TITLE_SENTENCE_CASED_AUTHOR = "JamesSensible";
-    private static final String TITLE_MIXED_CASED_AUTHOR = "TomTheHusky";
-    private static final String TITLE_UPPER_CASED_AUTHOR = "ArnoldtheLoud";
-    private static final String AUTHOR_WITH_COMMENT_CHARACTERS_NAME = "Commen/*tiusPavloczyns*/ky";
 
     private LibrarySearcherTestCases() {
     }
@@ -80,8 +74,8 @@ public final class LibrarySearcherTestCases {
                 Arguments.of(List.of(ARTICLE_HARRER), new SearchQuery("author= harrer"), List.of(ARTICLE_HARRER)),
 
                 // case-insensitive vs case-sensitive contains (=, =!)
-                Arguments.of(List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED),
-                        new SearchQuery("title = Title"),
+                Arguments.of(List.of(TITLE_MIXED_CASED),
+                        new SearchQuery(String.format("title=title AND author=%s", TITLE_MIXED_CASED_AUTHOR)),
                         List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
                 Arguments.of(List.of(TITLE_SENTENCE_CASED),
                         new SearchQuery("title =! Title"),
@@ -108,151 +102,112 @@ public final class LibrarySearcherTestCases {
     public static Stream<Arguments> detailedSearchCases() {
         return Stream.of(
                 // empty library
-                Arguments.of(List.of(), new SearchQuery("whatever"), List.of()),
-                Arguments.of(List.of(), new SearchQuery("whatever"), List.of(EMPTY_ENTRY)),
-                Arguments.of(List.of(), new SearchQuery("whatever"), List.of(EMPTY_ENTRY, ARTICLE_HARRER, INCOLLECTION_TONHO)),
+                Arguments.of(Map.of(), new SearchQuery("whatever"), List.of()),
+                Arguments.of(Map.of(), new SearchQuery("whatever"), List.of(EMPTY_ENTRY)),
+                Arguments.of(Map.of(), new SearchQuery("whatever"), List.of(EMPTY_ENTRY, ARTICLE_HARRER, INCOLLECTION_TONHO)),
 
                 // invalid search syntax → no matches
-                Arguments.of(List.of(), new SearchQuery("author="), List.of(ARTICLE_HARRER)),
+                Arguments.of(Map.of(), new SearchQuery("author="), List.of(ARTICLE_HARRER)),
 
                 // unfielded bareword (case-insensitive substring on any field);
-                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                Arguments.of(Map.of(
                                 ARTICLE_HARRER,
-                                new MatchInformation(true, new PartialResult(true, "harrer")))
+                                new MatchInformation(true, new PartialResult(true, "harrer"))
                         ),
                         new SearchQuery("harrer"), List.of(ARTICLE_HARRER)
                 ),
 
-                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                Arguments.of(Map.of(
                                 INCOLLECTION_TONHO,
-                                new MatchInformation(true, new PartialResult(true, "tonho")))
+                                new MatchInformation(true, new PartialResult(true, "tonho"))
                         ),
                         new SearchQuery("tonho"), List.of(INCOLLECTION_TONHO)
                 ),
 
-                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                Arguments.of(Map.of(
                                 INCOLLECTION_TONHO,
-                                new MatchInformation(true, new PartialResult(true, "tonho")))
+                                new MatchInformation(true, new PartialResult(true, "tonho"))
                         ),
                         new SearchQuery("tonho"), List.of(ARTICLE_HARRER, INCOLLECTION_TONHO)
                 ),
 
                 // fielded queries
-                Arguments.of(List.of(), new SearchQuery("title= harrer"), List.of(ARTICLE_HARRER)),
-                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                Arguments.of(Map.of(), new SearchQuery("title= harrer"), List.of(ARTICLE_HARRER)),
+                Arguments.of(Map.of(
                                 ARTICLE_HARRER,
-                                new MatchInformation(true, new PartialResult(true, "author=harrer")))
+                                new MatchInformation(true, new PartialResult(true, "author=harrer"))
                         ),
                         new SearchQuery("author=harrer"), List.of(ARTICLE_HARRER)
                 ),
 
                 // case-insensitive vs case-sensitive contains (=, =!)
-                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
-                                        TITLE_SENTENCE_CASED,
-                                        new MatchInformation(true, new PartialResult(true, "title=Title"))),
-                                new Pair<BibEntry, MatchInformation>(
-                                        TITLE_MIXED_CASED,
-                                        new MatchInformation(true, new PartialResult(true, "title=Title"))),
-                                new Pair<BibEntry, MatchInformation>(
-                                        TITLE_UPPER_CASED,
-                                        new MatchInformation(true, new PartialResult(true, "title=Title")))
+                Arguments.of(Map.of(
+                                TITLE_SENTENCE_CASED,
+                                new MatchInformation(true, new PartialResult(true, "title=Title")),
+                                TITLE_MIXED_CASED,
+                                new MatchInformation(true, new PartialResult(true, "title=Title")),
+                                TITLE_UPPER_CASED,
+                                new MatchInformation(true, new PartialResult(true, "title=Title"))
 
                         ),
                         new SearchQuery("title=Title"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
                 ),
 
-                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                Arguments.of(Map.of(
                                 TITLE_SENTENCE_CASED,
-                                new MatchInformation(true, new PartialResult(true, "title=!Title")))
+                                new MatchInformation(true, new PartialResult(true, "title=!Title"))
                         ),
                         new SearchQuery("title=!Title"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
                 ),
 
-                Arguments.of(List.of(), new SearchQuery("title =! TiTLE"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
+                Arguments.of(Map.of(), new SearchQuery("title =! TiTLE"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
 
                 // any-field with case-sensitive contains (any =!)
-                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                Arguments.of(Map.of(
                                 TITLE_MIXED_CASED,
-                                new MatchInformation(true, new PartialResult(true, "any=!TiTle")))
+                                new MatchInformation(true, new PartialResult(true, "any=!TiTle"))
                         ),
                         new SearchQuery("any=!TiTle"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
                 ),
-                Arguments.of(List.of(), new SearchQuery("any=!TiTLe"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
+                Arguments.of(Map.of(), new SearchQuery("any=!TiTLe"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
 
                 // regex on any field
-                Arguments.of(List.of(), new SearchQuery("any =~ [Z]"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
+                Arguments.of(Map.of(), new SearchQuery("any =~ [Z]"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
 
                 // testing partial results
-                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
-                                        TITLE_SENTENCE_CASED,
-                                        new MatchInformation(true,
-                                                new PartialResult(false, "any=~husky"),
-                                                new PartialResult(true, "any=~james")
-                                        )
+                Arguments.of(Map.of(
+                                TITLE_SENTENCE_CASED,
+                                new MatchInformation(true,
+                                        new PartialResult(false, "any=~husky"),
+                                        new PartialResult(true, "any=~james")
                                 ),
-                                new Pair<BibEntry, MatchInformation>(
-                                        TITLE_MIXED_CASED,
-                                        new MatchInformation(true,
-                                                new PartialResult(true, "any=~husky"),
-                                                new PartialResult(false, "any=~james")
-                                        )
+                                TITLE_MIXED_CASED,
+                                new MatchInformation(true,
+                                        new PartialResult(true, "any=~husky"),
+                                        new PartialResult(false, "any=~james")
                                 )
                         ),
                         new SearchQuery("any=~husky or any=~james"),
                         List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
                 ),
 
-                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
-                                        TITLE_UPPER_CASED,
-                                        new MatchInformation(true,
-                                                new PartialResult(true, "title=title"),
-                                                new PartialResult(true, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
-                                                new PartialResult(false, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
-                                        )
+                Arguments.of(Map.of(
+                                TITLE_UPPER_CASED,
+                                new MatchInformation(true,
+                                        new PartialResult(true, "title=title"),
+                                        new PartialResult(true, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
+                                        new PartialResult(false, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
                                 ),
-                                new Pair<BibEntry, MatchInformation>(
-                                        TITLE_MIXED_CASED,
-                                        new MatchInformation(true,
-                                                new PartialResult(true, "title=title"),
-                                                new PartialResult(false, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
-                                                new PartialResult(true, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
-                                        )
+                                TITLE_MIXED_CASED,
+                                new MatchInformation(true,
+                                        new PartialResult(true, "title=title"),
+                                        new PartialResult(false, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
+                                        new PartialResult(true, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
                                 )
                         ),
                         new SearchQuery(String.format("title=title AND (author=%s OR author=%s)", TITLE_UPPER_CASED_AUTHOR, TITLE_MIXED_CASED_AUTHOR)),
                         List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
-                ),
-
-                // comments do not modify the query
-                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
-                                        TITLE_UPPER_CASED,
-                                        new MatchInformation(true,
-                                                new PartialResult(true, "title=title"),
-                                                new PartialResult(true, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
-                                                new PartialResult(false, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
-                                        )
-                                ),
-                                new Pair<BibEntry, MatchInformation>(
-                                        TITLE_MIXED_CASED,
-                                        new MatchInformation(true,
-                                                new PartialResult(true, "title=title"),
-                                                new PartialResult(false, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
-                                                new PartialResult(true, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
-                                        )
-                                )
-                        ),
-                        new SearchQuery(String.format("title=title /*Old Tom Bombadil is a merry fellow*/ AND (author=%s /*Bright blue his jacket is*/ OR author=%s)", TITLE_UPPER_CASED_AUTHOR, TITLE_MIXED_CASED_AUTHOR)),
-                        List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
-                ),
-
-                // comment delimiters inside a string literal are treated as a part of this string literal
-                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
-                                AUTHOR_WITH_COMMENT_CHARACTERS,
-                                new MatchInformation(true, new PartialResult(true, String.format("author=%s", AUTHOR_WITH_COMMENT_CHARACTERS_NAME))))
-                        ),
-                        new SearchQuery(String.format("author=%s", AUTHOR_WITH_COMMENT_CHARACTERS_NAME)), List.of(AUTHOR_WITH_COMMENT_CHARACTERS)
                 )
-
         );
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/search/LibrarySearcherTestCases.java
+++ b/jablib/src/test/java/org/jabref/logic/search/LibrarySearcherTestCases.java
@@ -75,7 +75,7 @@ public final class LibrarySearcherTestCases {
 
                 // case-insensitive vs case-sensitive contains (=, =!)
                 Arguments.of(List.of(TITLE_MIXED_CASED),
-                        new SearchQuery(String.format("title=title AND author=%s", TITLE_MIXED_CASED_AUTHOR)),
+                        new SearchQuery("title=title AND author=%s".formatted(TITLE_MIXED_CASED_AUTHOR)),
                         List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
                 Arguments.of(List.of(TITLE_SENTENCE_CASED),
                         new SearchQuery("title =! Title"),
@@ -195,17 +195,17 @@ public final class LibrarySearcherTestCases {
                                 TITLE_UPPER_CASED,
                                 new MatchInformation(true,
                                         new PartialResult(true, "title=title"),
-                                        new PartialResult(true, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
-                                        new PartialResult(false, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
+                                        new PartialResult(true, "author=%s".formatted(TITLE_UPPER_CASED_AUTHOR)),
+                                        new PartialResult(false, "author=%s".formatted(TITLE_MIXED_CASED_AUTHOR))
                                 ),
                                 TITLE_MIXED_CASED,
                                 new MatchInformation(true,
                                         new PartialResult(true, "title=title"),
-                                        new PartialResult(false, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
-                                        new PartialResult(true, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
+                                        new PartialResult(false, "author=%s".formatted(TITLE_UPPER_CASED_AUTHOR)),
+                                        new PartialResult(true, "author=%s".formatted(TITLE_MIXED_CASED_AUTHOR))
                                 )
                         ),
-                        new SearchQuery(String.format("title=title AND (author=%s OR author=%s)", TITLE_UPPER_CASED_AUTHOR, TITLE_MIXED_CASED_AUTHOR)),
+                        new SearchQuery("title=title AND (author=%s OR author=%s)".formatted(TITLE_UPPER_CASED_AUTHOR, TITLE_MIXED_CASED_AUTHOR)),
                         List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
                 )
         );

--- a/jablib/src/test/java/org/jabref/logic/search/LibrarySearcherTestCases.java
+++ b/jablib/src/test/java/org/jabref/logic/search/LibrarySearcherTestCases.java
@@ -3,6 +3,10 @@ package org.jabref.logic.search;
 import java.util.List;
 import java.util.stream.Stream;
 
+import javafx.util.Pair;
+
+import org.jabref.logic.search.inmemory.MatchInformation;
+import org.jabref.logic.search.inmemory.MatchInformation.PartialResult;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
@@ -17,8 +21,6 @@ import org.junit.jupiter.params.provider.Arguments;
 /// belong in the per-implementation test class.
 public final class LibrarySearcherTestCases {
 
-    public static final BibEntry EMPTY_ENTRY = new BibEntry();
-
     public static final BibEntry ARTICLE_HARRER = new BibEntry(StandardEntryType.Article)
             .withCitationKey("harrer")
             .withField(StandardField.AUTHOR, "harrer");
@@ -27,17 +29,31 @@ public final class LibrarySearcherTestCases {
             .withCitationKey("tonho")
             .withField(StandardField.AUTHOR, "tonho");
 
+    public static final BibEntry EMPTY_ENTRY = new BibEntry();
+
     public static final BibEntry TITLE_SENTENCE_CASED = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("title-sentence-cased")
-            .withField(StandardField.TITLE, "Title Sentence Cased");
+            .withField(StandardField.TITLE, "Title Sentence Cased")
+            .withField(StandardField.AUTHOR, TITLE_SENTENCE_CASED_AUTHOR);
 
     public static final BibEntry TITLE_MIXED_CASED = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("title-mixed-cased")
-            .withField(StandardField.TITLE, "TiTle MiXed CaSed");
+            .withField(StandardField.TITLE, "TiTle MiXed CaSed")
+            .withField(StandardField.AUTHOR, TITLE_MIXED_CASED_AUTHOR);
 
     public static final BibEntry TITLE_UPPER_CASED = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("title-upper-cased")
-            .withField(StandardField.TITLE, "TITLE UPPER CASED");
+            .withField(StandardField.TITLE, "TITLE UPPER CASED")
+            .withField(StandardField.AUTHOR, TITLE_UPPER_CASED_AUTHOR);
+
+    public static final BibEntry AUTHOR_WITH_COMMENT_CHARACTERS = new BibEntry(StandardEntryType.Misc)
+            .withField(StandardField.TITLE, "A life with a stupid name - my story")
+            .withField(StandardField.AUTHOR, AUTHOR_WITH_COMMENT_CHARACTERS_NAME);
+
+    private static final String TITLE_SENTENCE_CASED_AUTHOR = "JamesSensible";
+    private static final String TITLE_MIXED_CASED_AUTHOR = "TomTheHusky";
+    private static final String TITLE_UPPER_CASED_AUTHOR = "ArnoldtheLoud";
+    private static final String AUTHOR_WITH_COMMENT_CHARACTERS_NAME = "Commen/*tiusPavloczyns*/ky";
 
     private LibrarySearcherTestCases() {
     }
@@ -84,8 +100,159 @@ public final class LibrarySearcherTestCases {
 
                 // regex on any field
                 Arguments.of(List.of(),
-                        new SearchQuery("any =~ [Y]"),
+                        new SearchQuery("any =~ [Z]"),
                         List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED))
+        );
+    }
+
+    public static Stream<Arguments> detailedSearchCases() {
+        return Stream.of(
+                // empty library
+                Arguments.of(List.of(), new SearchQuery("whatever"), List.of()),
+                Arguments.of(List.of(), new SearchQuery("whatever"), List.of(EMPTY_ENTRY)),
+                Arguments.of(List.of(), new SearchQuery("whatever"), List.of(EMPTY_ENTRY, ARTICLE_HARRER, INCOLLECTION_TONHO)),
+
+                // invalid search syntax → no matches
+                Arguments.of(List.of(), new SearchQuery("author="), List.of(ARTICLE_HARRER)),
+
+                // unfielded bareword (case-insensitive substring on any field);
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                ARTICLE_HARRER,
+                                new MatchInformation(true, new PartialResult(true, "harrer")))
+                        ),
+                        new SearchQuery("harrer"), List.of(ARTICLE_HARRER)
+                ),
+
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                INCOLLECTION_TONHO,
+                                new MatchInformation(true, new PartialResult(true, "tonho")))
+                        ),
+                        new SearchQuery("tonho"), List.of(INCOLLECTION_TONHO)
+                ),
+
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                INCOLLECTION_TONHO,
+                                new MatchInformation(true, new PartialResult(true, "tonho")))
+                        ),
+                        new SearchQuery("tonho"), List.of(ARTICLE_HARRER, INCOLLECTION_TONHO)
+                ),
+
+                // fielded queries
+                Arguments.of(List.of(), new SearchQuery("title= harrer"), List.of(ARTICLE_HARRER)),
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                ARTICLE_HARRER,
+                                new MatchInformation(true, new PartialResult(true, "author=harrer")))
+                        ),
+                        new SearchQuery("author=harrer"), List.of(ARTICLE_HARRER)
+                ),
+
+                // case-insensitive vs case-sensitive contains (=, =!)
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                        TITLE_SENTENCE_CASED,
+                                        new MatchInformation(true, new PartialResult(true, "title=Title"))),
+                                new Pair<BibEntry, MatchInformation>(
+                                        TITLE_MIXED_CASED,
+                                        new MatchInformation(true, new PartialResult(true, "title=Title"))),
+                                new Pair<BibEntry, MatchInformation>(
+                                        TITLE_UPPER_CASED,
+                                        new MatchInformation(true, new PartialResult(true, "title=Title")))
+
+                        ),
+                        new SearchQuery("title=Title"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
+                ),
+
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                TITLE_SENTENCE_CASED,
+                                new MatchInformation(true, new PartialResult(true, "title=!Title")))
+                        ),
+                        new SearchQuery("title=!Title"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
+                ),
+
+                Arguments.of(List.of(), new SearchQuery("title =! TiTLE"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
+
+                // any-field with case-sensitive contains (any =!)
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                TITLE_MIXED_CASED,
+                                new MatchInformation(true, new PartialResult(true, "any=!TiTle")))
+                        ),
+                        new SearchQuery("any=!TiTle"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
+                ),
+                Arguments.of(List.of(), new SearchQuery("any=!TiTLe"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
+
+                // regex on any field
+                Arguments.of(List.of(), new SearchQuery("any =~ [Z]"), List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)),
+
+                // testing partial results
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                        TITLE_SENTENCE_CASED,
+                                        new MatchInformation(true,
+                                                new PartialResult(false, "any=~husky"),
+                                                new PartialResult(true, "any=~james")
+                                        )
+                                ),
+                                new Pair<BibEntry, MatchInformation>(
+                                        TITLE_MIXED_CASED,
+                                        new MatchInformation(true,
+                                                new PartialResult(true, "any=~husky"),
+                                                new PartialResult(false, "any=~james")
+                                        )
+                                )
+                        ),
+                        new SearchQuery("any=~husky or any=~james"),
+                        List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
+                ),
+
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                        TITLE_UPPER_CASED,
+                                        new MatchInformation(true,
+                                                new PartialResult(true, "title=title"),
+                                                new PartialResult(true, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
+                                                new PartialResult(false, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
+                                        )
+                                ),
+                                new Pair<BibEntry, MatchInformation>(
+                                        TITLE_MIXED_CASED,
+                                        new MatchInformation(true,
+                                                new PartialResult(true, "title=title"),
+                                                new PartialResult(false, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
+                                                new PartialResult(true, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
+                                        )
+                                )
+                        ),
+                        new SearchQuery(String.format("title=title AND (author=%s OR author=%s)", TITLE_UPPER_CASED_AUTHOR, TITLE_MIXED_CASED_AUTHOR)),
+                        List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
+                ),
+
+                // comments do not modify the query
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                        TITLE_UPPER_CASED,
+                                        new MatchInformation(true,
+                                                new PartialResult(true, "title=title"),
+                                                new PartialResult(true, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
+                                                new PartialResult(false, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
+                                        )
+                                ),
+                                new Pair<BibEntry, MatchInformation>(
+                                        TITLE_MIXED_CASED,
+                                        new MatchInformation(true,
+                                                new PartialResult(true, "title=title"),
+                                                new PartialResult(false, String.format("author=%s", TITLE_UPPER_CASED_AUTHOR)),
+                                                new PartialResult(true, String.format("author=%s", TITLE_MIXED_CASED_AUTHOR))
+                                        )
+                                )
+                        ),
+                        new SearchQuery(String.format("title=title /*Old Tom Bombadil is a merry fellow*/ AND (author=%s /*Bright blue his jacket is*/ OR author=%s)", TITLE_UPPER_CASED_AUTHOR, TITLE_MIXED_CASED_AUTHOR)),
+                        List.of(TITLE_SENTENCE_CASED, TITLE_MIXED_CASED, TITLE_UPPER_CASED)
+                ),
+
+                // comment delimiters inside a string literal are treated as a part of this string literal
+                Arguments.of(List.of(new Pair<BibEntry, MatchInformation>(
+                                AUTHOR_WITH_COMMENT_CHARACTERS,
+                                new MatchInformation(true, new PartialResult(true, String.format("author=%s", AUTHOR_WITH_COMMENT_CHARACTERS_NAME))))
+                        ),
+                        new SearchQuery(String.format("author=%s", AUTHOR_WITH_COMMENT_CHARACTERS_NAME)), List.of(AUTHOR_WITH_COMMENT_CHARACTERS)
+                )
+
         );
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLibrarySearcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLibrarySearcherTest.java
@@ -1,7 +1,10 @@
 package org.jabref.logic.search.inmemory;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import javafx.util.Pair;
 
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -35,5 +38,15 @@ class InMemoryLibrarySearcherTest {
         }
         List<BibEntry> matches = new InMemoryLibrarySearcher(databaseContext, bibEntryPreferences).getMatches(query);
         assertEquals(Set.copyOf(expectedMatches), Set.copyOf(matches));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.jabref.logic.search.LibrarySearcherTestCases#detailedSearchCases")
+    void commonDetailedSearchCases(List<Pair<BibEntry, MatchInformation>> expectedMatches, SearchQuery query, List<BibEntry> entries) {
+        for (BibEntry entry : entries) {
+            databaseContext.getDatabase().insertEntry(entry);
+        }
+        List<Pair<BibEntry, MatchInformation>> matches = new InMemoryLibrarySearcher(databaseContext, bibEntryPreferences).getDetailedMatches(query);
+        assertEquals(new HashSet<>(expectedMatches), new HashSet<>(matches));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLibrarySearcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLibrarySearcherTest.java
@@ -1,20 +1,20 @@
 package org.jabref.logic.search.inmemory;
 
-import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-
-import javafx.util.Pair;
 
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryPreferences;
 import org.jabref.model.search.query.SearchQuery;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -42,11 +42,11 @@ class InMemoryLibrarySearcherTest {
 
     @ParameterizedTest
     @MethodSource("org.jabref.logic.search.LibrarySearcherTestCases#detailedSearchCases")
-    void commonDetailedSearchCases(List<Pair<BibEntry, MatchInformation>> expectedMatches, SearchQuery query, List<BibEntry> entries) {
+    void commonDetailedSearchCases(Map<BibEntry, MatchInformation> expectedMatches, SearchQuery query, List<BibEntry> entries) {
         for (BibEntry entry : entries) {
             databaseContext.getDatabase().insertEntry(entry);
         }
-        List<Pair<BibEntry, MatchInformation>> matches = new InMemoryLibrarySearcher(databaseContext, bibEntryPreferences).getDetailedMatches(query);
-        assertEquals(new HashSet<>(expectedMatches), new HashSet<>(matches));
+        Map<BibEntry, MatchInformation> matches = new InMemoryLibrarySearcher(databaseContext, bibEntryPreferences).getDetailedMatches(query);
+        assertThat(expectedMatches.entrySet(), Matchers.everyItem(Matchers.in(matches.entrySet())));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/search/sqlbased/SqlBasedLibrarySearcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/sqlbased/SqlBasedLibrarySearcherTest.java
@@ -3,12 +3,15 @@ package org.jabref.logic.search.sqlbased;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javafx.beans.property.BooleanProperty;
 
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.preferences.CliPreferences;
+import org.jabref.logic.search.inmemory.MatchInformation;
 import org.jabref.logic.util.CurrentThreadTaskExecutor;
 import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseContext;
@@ -16,6 +19,7 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryPreferences;
 import org.jabref.model.search.query.SearchQuery;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
@@ -25,6 +29,7 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -69,8 +74,24 @@ public class SqlBasedLibrarySearcherTest {
         for (BibEntry entry : entries) {
             databaseContext.getDatabase().insertEntry(entry);
         }
+        System.out.println("query: " + query);
         List<BibEntry> matches = new SqlBasedLibrarySearcher(databaseContext, TASK_EXECUTOR, preferences, postgresServer).getMatches(query);
         // Order-insensitive comparison: SQL-backed searcher does not guarantee result ordering.
         assertEquals(Set.copyOf(expectedMatches), Set.copyOf(matches));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.jabref.logic.search.LibrarySearcherTestCases#detailedSearchCases")
+    void detailedSearchCases(Map<BibEntry, MatchInformation> expectedMatches, SearchQuery query, List<BibEntry> entries) throws IOException {
+        for (BibEntry entry : entries) {
+            databaseContext.getDatabase().insertEntry(entry);
+        }
+        Map<BibEntry, MatchInformation> matches =
+                new SqlBasedLibrarySearcher(databaseContext, TASK_EXECUTOR, preferences, postgresServer)
+                        .getDetailedMatches(query).entrySet()
+                        .stream()
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get())); // SqlBasedLibraryTest should not return empty optionals for MatchInformation
+        // Order-insensitive comparison: SQL-backed searcher does not guarantee result ordering.
+        assertThat(expectedMatches.entrySet(), Matchers.everyItem(Matchers.in(matches.entrySet())));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/search/sqlbased/SqlBasedLibrarySearcherWithBibFilesTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/sqlbased/SqlBasedLibrarySearcherWithBibFilesTest.java
@@ -5,7 +5,10 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import javafx.beans.property.SimpleBooleanProperty;
@@ -15,6 +18,7 @@ import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.importer.fileformat.BibtexImporter;
 import org.jabref.logic.preferences.CliPreferences;
+import org.jabref.logic.search.inmemory.MatchInformation;
 import org.jabref.logic.util.CurrentThreadTaskExecutor;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.logic.util.TaskExecutor;
@@ -78,11 +82,12 @@ class SqlBasedLibrarySearcherWithBibFilesTest {
     private static final BibEntry MINIMAL_NOTE_MIXED_CASE = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("minimal-note-mixed-case")
             .withFiles(List.of(new LinkedFile("", "minimal-note-mixed-case.pdf", StandardFileType.PDF.getName())));
+    private static final String FULLTEXT_QUERY = "\"This is a short sentence, comma included.\"";
+    private static final String PARSED_FULLTEXT_QUERY = "\"? ? ? short sentenc comma includ\"";
 
     private final CliPreferences preferences = mock(CliPreferences.class);
     private final FilePreferences filePreferences = mock(FilePreferences.class);
     private final BibEntryPreferences bibEntryPreferences = mock(BibEntryPreferences.class);
-
     private PostgresServer postgresServer;
 
     @TempDir
@@ -144,12 +149,54 @@ class SqlBasedLibrarySearcherWithBibFilesTest {
 
                 // test-library-with-attached-files
                 Arguments.of(List.of(), "test-library-with-attached-files.bib", "NotExisting.", true),
-                Arguments.of(List.of(MINIMAL_SENTENCE_CASE, MINIMAL_ALL_UPPER_CASE, MINIMAL_MIXED_CASE), "test-library-with-attached-files.bib", "\"This is a short sentence, comma included.\"", true),
+                Arguments.of(List.of(MINIMAL_SENTENCE_CASE, MINIMAL_ALL_UPPER_CASE, MINIMAL_MIXED_CASE), "test-library-with-attached-files.bib", FULLTEXT_QUERY, true),
                 Arguments.of(List.of(MINIMAL_SENTENCE_CASE, MINIMAL_ALL_UPPER_CASE, MINIMAL_MIXED_CASE), "test-library-with-attached-files.bib", "comma", true),
 
                 Arguments.of(List.of(), "test-library-with-attached-files.bib", "NotExisting", true),
                 Arguments.of(List.of(MINIMAL_NOTE_SENTENCE_CASE, MINIMAL_NOTE_ALL_UPPER_CASE, MINIMAL_NOTE_MIXED_CASE), "test-library-with-attached-files.bib", "world", true),
                 Arguments.of(List.of(MINIMAL_NOTE_SENTENCE_CASE, MINIMAL_NOTE_ALL_UPPER_CASE, MINIMAL_NOTE_MIXED_CASE), "test-library-with-attached-files.bib", "\"Hello World\"", true)
+        );
+    }
+
+    private static Stream<Arguments> detailedLibrarySearch() {
+        BiFunction<List<String>, List<Boolean>, Optional<MatchInformation>> createMI = (List<String> clauses, List<Boolean> partialResults) -> {
+            var result = new MatchInformation(true);
+            for (int i = 0; i < clauses.size(); i++) {
+                result.getPartialResults().add(new MatchInformation.PartialResult(partialResults.get(i), clauses.get(i)));
+            }
+            return Optional.of(result);
+        };
+        return Stream.of(
+                //                                 test-library-with-attached-files
+                Arguments.of(Map.of(), "test-library-with-attached-files.bib", "NotExisting.", true),
+                Arguments.of(Map.of(
+                                MINIMAL_SENTENCE_CASE, createMI.apply(List.of(PARSED_FULLTEXT_QUERY), List.of(true)),
+                                MINIMAL_ALL_UPPER_CASE, createMI.apply(List.of(PARSED_FULLTEXT_QUERY), List.of(true)),
+                                MINIMAL_MIXED_CASE, createMI.apply(List.of(PARSED_FULLTEXT_QUERY), List.of(true))),
+                        "test-library-with-attached-files.bib", FULLTEXT_QUERY, true),
+                Arguments.of(Map.of(
+                                MINIMAL_SENTENCE_CASE, createMI.apply(List.of("comma"), List.of(true)),
+                                MINIMAL_ALL_UPPER_CASE, createMI.apply(List.of("comma"), List.of(true)),
+                                MINIMAL_MIXED_CASE, createMI.apply(List.of("comma"), List.of(true))),
+                        "test-library-with-attached-files.bib", "comma", true),
+
+                Arguments.of(Map.of(), "test-library-with-attached-files.bib", "NotExisting", true),
+                Arguments.of(Map.of(
+                        MINIMAL_NOTE_SENTENCE_CASE, createMI.apply(List.of("world"), List.of(true)),
+                        MINIMAL_NOTE_ALL_UPPER_CASE, createMI.apply(List.of("world"), List.of(true)),
+                        MINIMAL_NOTE_MIXED_CASE, createMI.apply(List.of("world"), List.of(true))), "test-library-with-attached-files.bib", "world", true),
+                Arguments.of(Map.of(
+                        MINIMAL_NOTE_SENTENCE_CASE, createMI.apply(List.of("\"hello world\""), List.of(true)),
+                        MINIMAL_NOTE_ALL_UPPER_CASE, createMI.apply(List.of("\"hello world\""), List.of(true)),
+                        MINIMAL_NOTE_MIXED_CASE, createMI.apply(List.of("\"hello world\""), List.of(true))), "test-library-with-attached-files.bib", "\"Hello World\"", true),
+                Arguments.of(Map.of(
+                                MINIMAL_NOTE_SENTENCE_CASE, createMI.apply(List.of("world", PARSED_FULLTEXT_QUERY), List.of(true, false)),
+                                MINIMAL_NOTE_ALL_UPPER_CASE, createMI.apply(List.of("world", PARSED_FULLTEXT_QUERY), List.of(true, false)),
+                                MINIMAL_NOTE_MIXED_CASE, createMI.apply(List.of("world", PARSED_FULLTEXT_QUERY), List.of(true, false)),
+                                MINIMAL_SENTENCE_CASE, createMI.apply(List.of("world", PARSED_FULLTEXT_QUERY), List.of(false, true)),
+                                MINIMAL_ALL_UPPER_CASE, createMI.apply(List.of("world", PARSED_FULLTEXT_QUERY), List.of(false, true)),
+                                MINIMAL_MIXED_CASE, createMI.apply(List.of("world", PARSED_FULLTEXT_QUERY), List.of(false, true))),
+                        "test-library-with-attached-files.bib", "world or \"This is a short sentence, comma included.\"", true)
         );
     }
 
@@ -160,5 +207,14 @@ class SqlBasedLibrarySearcherWithBibFilesTest {
         EnumSet<SearchFlags> flags = isFullText ? EnumSet.of(SearchFlags.FULLTEXT) : EnumSet.noneOf(SearchFlags.class);
         List<BibEntry> matches = new SqlBasedLibrarySearcher(databaseContext, TASK_EXECUTOR, preferences, postgresServer).getMatches(new SearchQuery(query, flags));
         assertThat(expected, Matchers.containsInAnyOrder(matches.toArray()));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void detailedLibrarySearch(Map<BibEntry, Optional<MatchInformation>> expected, String testFile, String query, boolean isFullText) throws URISyntaxException, IOException {
+        BibDatabaseContext databaseContext = initializeDatabaseFromPath(testFile);
+        EnumSet<SearchFlags> flags = isFullText ? EnumSet.of(SearchFlags.FULLTEXT) : EnumSet.noneOf(SearchFlags.class);
+        Map<BibEntry, Optional<MatchInformation>> matches = new SqlBasedLibrarySearcher(databaseContext, TASK_EXECUTOR, preferences, postgresServer).getDetailedMatches(new SearchQuery(query, flags));
+        assertThat(expected.entrySet(), Matchers.everyItem(Matchers.in(matches.entrySet())));
     }
 }


### PR DESCRIPTION
### Related issues and pull requests
Closes #15631

### PR Description
Description:
Displays in the tooltip of the global search bar all partial comparisons and whether they are true or false.

The draft includes full and tested implementation of the above-mentioned feature for in-memory-search.
Beside that, I've finished a similar implementation of LibrarySearcher for sql queries (not included in the draft for now).
I still need to finish this feature for lucene searches and test them manually.
Question: how to set up local gui application to use SqlBasedLibrarySearcher instead of InMemoryLibrarySearcher? I set up a shared database but the application imports data from the database and uses in-memory-search.
(Edit: don´t bother, I have figured it out).

jabref-contrib-policy:4.2:reviewed​:ok

This pull request is sweet like a chocolate, round like a moon and confused like honey produced by very confused bees.

### Steps to test

Enter a global search with an "or" operator, select a bib entry and hover the cursor over global search bar. The tooltip should contain informations about comparisons.

https://github.com/user-attachments/assets/55258257-3b7d-4034-9ce7-55695114858e

### AI usage

No Ai Tool was used.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in CHANGELOG.md in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the user documentation for up to dateness and submitted a pull request to our user documentation repository
Additional notes:
BibEntryDetailedMatchVisitor is in the most part a copy of BibEntryMatchVisitor except for a couple of changes that make it preserve the result of every comparison. There is something to say for removing BibEntryMatchVisitor altogether, but since I am not sure how performance-critical it is and since BEDMV incurs a (very) small performance hit I opted for duplicating the class. At least for now.
The similar story repeated with sql search, btw.

<img width="1849" height="1041" alt="Screenshot From 2026-08-08 16-08-32" src="https://github.com/user-attachments/assets/77c035bb-f36c-44dc-8d1e-4ec38a2db203" />
