### PR TITLE
Add workflow to wait for second review

### DIFF
--- a/.github/workflows/on-pr-awaiting-second-review-check.yml
+++ b/.github/workflows/on-pr-awaiting-second-review-check.yml
@@ -1,0 +1,97 @@
+name: Await second review
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+  pull_request_review:
+    types:
+      - submitted
+      - dismissed
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  require-second-approval:
+    name: Require second approval
+    if: github.repository == 'JabRef/jabref'
+    runs-on: ubuntu-slim
+    steps:
+      - name: Check whether a second approval is required
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullNumber = context.payload.pull_request?.number;
+            const requiredLabel = 'status: awaiting-second-review';
+
+            if (!pullNumber) {
+              core.setFailed('This workflow requires a pull request context.');
+              return;
+            }
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+
+            const labelNames = pullRequest.labels.map((label) => label.name);
+            const hasAwaitingSecondReviewLabel = labelNames.includes(requiredLabel);
+
+            if (!hasAwaitingSecondReviewLabel) {
+              await core.summary
+                .addHeading('Await second review')
+                .addRaw(`Label \`${requiredLabel}\` is not present.\n`)
+                .write();
+              return;
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+
+            const latestOpinionatedReviewStateByUser = new Map();
+            for (const review of reviews) {
+              const login = review.user?.login;
+              if (!login || login === pullRequest.user.login) {
+                continue;
+              }
+
+              if (review.state === 'APPROVED' || review.state === 'CHANGES_REQUESTED' || review.state === 'DISMISSED') {
+                latestOpinionatedReviewStateByUser.set(login, review.state);
+              }
+            }
+
+            const approvers = [...latestOpinionatedReviewStateByUser.entries()]
+              .filter(([, state]) => state === 'APPROVED')
+              .map(([login]) => login);
+
+            core.summary
+              .addHeading('Await second review')
+              .addRaw(`Label present: \`${requiredLabel}\`\n\n`)
+              .addRaw(`Current approvers: ${approvers.length > 0 ? approvers.map((login) => `\`${login}\``).join(', ') : 'none'}\n`);
+
+            if (approvers.length >= 2) {
+              await core.summary
+                .addRaw('\nSecond approval requirement satisfied.\n')
+                .write();
+              return;
+            }
+
+            await core.summary
+              .addRaw('\nSecond approval requirement not satisfied.\n')
+              .write();
+
+            core.setFailed(`PR has label "${requiredLabel}" and needs approval from a second reviewer before it can enter the merge queue.`);


### PR DESCRIPTION
### Related issues and pull requests

Closes NA

### PR Description

Now that 6.0 beta is being worked on, we need to make sure less and less changes are breaking.

Thought process - a reviewer adds an "awaiting-second-review" label if they feel it deserves an extra pair of eyes.
However, if merge queue is enabled and they "approve", the PR is queued even if this label is present.
Since the merge queue couldn't be configured with respect to active labels, this is sort of a workaround so that critical PRs really go through two reviews before merge.

#### Workflow:
```
if label "status: awaiting-second-review" is absent:
    pass

if label is present and approvals < 2:
    fail

if label is present and approvals >= 2:
    pass
```

Pending: Merge this and mark the workflow `required`.

### Steps to test

   Add the label and check CI.

### AI usage

_____

   Manually driven Zed + GPT 5.4

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
