### PR TITLE
Add Qodo acknowledgement action

### DIFF
--- a/.github/workflows/on-pr-qodo-review-thread-check.yml
+++ b/.github/workflows/on-pr-qodo-review-thread-check.yml
@@ -153,7 +153,7 @@ jobs:
               core.setFailed([
                 'Some active Qodo review threads still need acknowledgment from the PR author.',
                 '',
-                'Each Qodo-started review thread must either be outdated, or have have been responded to by the PR author.',
+                'Each Qodo-started review thread must either be outdated or have have been responded to by the PR author.',
                 '',
                 ...failingThreads,
               ].join('\n'));

--- a/.github/workflows/on-pr-qodo-review-thread-check.yml
+++ b/.github/workflows/on-pr-qodo-review-thread-check.yml
@@ -139,21 +139,12 @@ jobs:
                 continue;
               }
 
-              const latestQodoComment = [...comments]
-                .reverse()
-                .find(comment => comment.author.login === qodoLogin);
-
-              if (!latestQodoComment) {
-                continue;
-              }
-
-              const hasReplyFromPrAuthor = comments.some(comment =>
+              const hasReplyFromPrAuthor = comments.slice(1).some(comment =>
                 comment.author.login === prAuthorLogin
-                && new Date(comment.createdAt) > new Date(latestQodoComment.createdAt)
               );
 
               if (!hasReplyFromPrAuthor) {
-                const threadUrl = latestQodoComment.url || firstComment.url;
+                const threadUrl = firstComment.url;
                 failingThreads.push(`- ${threadUrl}`);
               }
             }
@@ -162,7 +153,7 @@ jobs:
               core.setFailed([
                 'Some active Qodo review threads still need acknowledgment from the PR author.',
                 '',
-                'Each Qodo-started review thread must be resolved, outdated, or have a PR-author reply after the latest Qodo comment.',
+                'Each Qodo-started review thread must be resolved, outdated, or have at least one reply from the PR author.',
                 '',
                 ...failingThreads,
               ].join('\n'));

--- a/.github/workflows/on-pr-qodo-review-thread-check.yml
+++ b/.github/workflows/on-pr-qodo-review-thread-check.yml
@@ -1,0 +1,109 @@
+name: Qodo review threads acknowledged
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+
+
+jobs:
+  check-qodo-review-threads:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check Qodo review threads
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullRequestNumber = context.payload.pull_request.number;
+            const prAuthorLogin = context.payload.pull_request.user.login;
+            const qodoLogin = 'qodo-free-for-open-source-projects';
+
+            const query = `
+              query($owner: String!, $repo: String!, $pullRequestNumber: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pullRequestNumber) {
+                    reviewThreads(first: 100) {
+                      nodes {
+                        isResolved
+                        isOutdated
+                        comments(first: 100) {
+                          nodes {
+                            author {
+                              login
+                            }
+                            url
+                            createdAt
+                            body
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const result = await github.graphql(query, {
+              owner,
+              repo,
+              pullRequestNumber,
+            });
+
+            const threads = result.repository.pullRequest.reviewThreads.nodes;
+            const failingThreads = [];
+
+            for (const thread of threads) {
+              if (thread.isResolved || thread.isOutdated) {
+                continue;
+              }
+
+              const comments = [...thread.comments.nodes]
+                .filter(comment => comment.author && comment.author.login)
+                .sort((left, right) => new Date(left.createdAt) - new Date(right.createdAt));
+
+              if (comments.length === 0) {
+                continue;
+              }
+
+              const firstComment = comments[0];
+              if (firstComment.author.login !== qodoLogin) {
+                continue;
+              }
+
+              const latestQodoComment = [...comments]
+                .reverse()
+                .find(comment => comment.author.login === qodoLogin);
+
+              if (!latestQodoComment) {
+                continue;
+              }
+
+              const hasReplyFromPrAuthor = comments.some(comment =>
+                comment.author.login === prAuthorLogin
+                && new Date(comment.createdAt) > new Date(latestQodoComment.createdAt)
+              );
+
+              if (!hasReplyFromPrAuthor) {
+                const threadUrl = latestQodoComment.url || firstComment.url;
+                failingThreads.push(`- ${threadUrl}`);
+              }
+            }
+
+            if (failingThreads.length > 0) {
+              core.setFailed([
+                'Some active Qodo review threads still need acknowledgment from the PR author.',
+                '',
+                'Each Qodo-started review thread must be resolved, outdated, or have a PR-author reply after the latest Qodo comment.',
+                '',
+                ...failingThreads,
+              ].join('\n'));
+            }

--- a/.github/workflows/on-pr-qodo-review-thread-check.yml
+++ b/.github/workflows/on-pr-qodo-review-thread-check.yml
@@ -8,7 +8,6 @@ on:
   pull_request_review_comment:
     types: [created, edited, deleted]
 
-
 jobs:
   check-qodo-review-threads:
     if: github.event.pull_request.draft == false
@@ -27,38 +26,102 @@ jobs:
             const prAuthorLogin = context.payload.pull_request.user.login;
             const qodoLogin = 'qodo-free-for-open-source-projects';
 
-            const query = `
-              query($owner: String!, $repo: String!, $pullRequestNumber: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  pullRequest(number: $pullRequestNumber) {
-                    reviewThreads(first: 100) {
-                      nodes {
-                        isResolved
-                        isOutdated
-                        comments(first: 100) {
+            async function fetchAllReviewThreads() {
+              const threads = [];
+              let reviewThreadsCursor = null;
+
+              do {
+                const query = `
+                  query($owner: String!, $repo: String!, $pullRequestNumber: Int!, $reviewThreadsCursor: String) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $pullRequestNumber) {
+                        reviewThreads(first: 100, after: $reviewThreadsCursor) {
+                          nodes {
+                            id
+                            isResolved
+                            isOutdated
+                            comments(first: 100) {
+                              nodes {
+                                author {
+                                  login
+                                }
+                                url
+                                createdAt
+                              }
+                              pageInfo {
+                                hasNextPage
+                                endCursor
+                              }
+                            }
+                          }
+                          pageInfo {
+                            hasNextPage
+                            endCursor
+                          }
+                        }
+                      }
+                    }
+                  }
+                `;
+
+                const result = await github.graphql(query, {
+                  owner,
+                  repo,
+                  pullRequestNumber,
+                  reviewThreadsCursor,
+                });
+
+                const reviewThreads = result.repository.pullRequest.reviewThreads;
+                threads.push(...reviewThreads.nodes);
+                reviewThreadsCursor = reviewThreads.pageInfo.hasNextPage ? reviewThreads.pageInfo.endCursor : null;
+              } while (reviewThreadsCursor);
+
+              return threads;
+            }
+
+            async function fetchAllThreadComments(thread) {
+              const comments = [...thread.comments.nodes];
+              let commentsCursor = thread.comments.pageInfo.hasNextPage ? thread.comments.pageInfo.endCursor : null;
+
+              while (commentsCursor) {
+                const query = `
+                  query($threadId: ID!, $commentsCursor: String) {
+                    node(id: $threadId) {
+                      ... on PullRequestReviewThread {
+                        comments(first: 100, after: $commentsCursor) {
                           nodes {
                             author {
                               login
                             }
                             url
                             createdAt
-                            body
+                          }
+                          pageInfo {
+                            hasNextPage
+                            endCursor
                           }
                         }
                       }
                     }
                   }
-                }
+                `;
+
+                const result = await github.graphql(query, {
+                  threadId: thread.id,
+                  commentsCursor,
+                });
+
+                const threadComments = result.node.comments;
+                comments.push(...threadComments.nodes);
+                commentsCursor = threadComments.pageInfo.hasNextPage ? threadComments.pageInfo.endCursor : null;
               }
-            `;
 
-            const result = await github.graphql(query, {
-              owner,
-              repo,
-              pullRequestNumber,
-            });
+              return comments
+                .filter(comment => comment.author && comment.author.login)
+                .sort((left, right) => new Date(left.createdAt) - new Date(right.createdAt));
+            }
 
-            const threads = result.repository.pullRequest.reviewThreads.nodes;
+            const threads = await fetchAllReviewThreads();
             const failingThreads = [];
 
             for (const thread of threads) {
@@ -66,10 +129,7 @@ jobs:
                 continue;
               }
 
-              const comments = [...thread.comments.nodes]
-                .filter(comment => comment.author && comment.author.login)
-                .sort((left, right) => new Date(left.createdAt) - new Date(right.createdAt));
-
+              const comments = await fetchAllThreadComments(thread);
               if (comments.length === 0) {
                 continue;
               }

--- a/.github/workflows/on-pr-qodo-review-thread-check.yml
+++ b/.github/workflows/on-pr-qodo-review-thread-check.yml
@@ -153,7 +153,7 @@ jobs:
               core.setFailed([
                 'Some active Qodo review threads still need acknowledgment from the PR author.',
                 '',
-                'Each Qodo-started review thread must either be outdated, or have have been responded to the PR author.',
+                'Each Qodo-started review thread must either be outdated, or have have been responded to by the PR author.',
                 '',
                 ...failingThreads,
               ].join('\n'));

--- a/.github/workflows/on-pr-qodo-review-thread-check.yml
+++ b/.github/workflows/on-pr-qodo-review-thread-check.yml
@@ -153,7 +153,7 @@ jobs:
               core.setFailed([
                 'Some active Qodo review threads still need acknowledgment from the PR author.',
                 '',
-                'Each Qodo-started review thread must be resolved, outdated, or have at least one reply from the PR author.',
+                'Each Qodo-started review thread must either be outdated, or have have been responded to the PR author.',
                 '',
                 ...failingThreads,
               ].join('\n'));


### PR DESCRIPTION
### Related issues and pull requests

Closes NA

### PR Description

Part of the series to improve JabRef's stability with respect to newer generation (AI-assisted) PRs, 6.0 beta being in sight.
 
Over time, Qodo has proved to be useful in catching things that would've otherwise been overlooked. Often, maintainers have to write "address this qodo comment" when the PR author forgets to look at it. 
Add an action which passes when all review comments by Qodo are either marked "outdated" after pushes or replied to by the original author. If there are multiple comments with qodo tagged and conversed with, there should be at least one response by the PR author on that review comment thread.
**In other words, Qodo comments have to be at least acknowledged, if not acted on, and ideally acted on (if they make sense)**.

## Pass cases

### 1. PR author replies once
```text
qodo: Please change this
author: fixed
```
**Result:** pass

---

### 2. PR author replies, then Qodo replies again
```text
qodo: Please change this
author: can you clarify?
qodo: more detail
```
**Result:** pass

Reason: under the relaxed rule, one PR-author reply anywhere in the thread is enough.

---

### 3. PR author replies after someone else
```text
qodo: Please change this
reviewer: I agree
author: fixed
```
**Result:** pass

---

### 4. PR author replies before someone else
```text
qodo: Please change this
author: fixed
reviewer: thanks
```
**Result:** pass

---

### 5. Multiple Qodo comments, then PR author replies once
```text
qodo: Please change this
qodo: more detail
qodo: example attached
author: fixed
```
**Result:** pass

---

### 6. Thread becomes outdated after a push
```text
qodo: Please change this
author pushes new commit
thread is marked outdated
```
**Result:** pass

---

### 7. PR author replies and later the thread also becomes outdated
```text
qodo: Please change this
author: fixed
author pushes new commit
thread becomes outdated
```
**Result:** pass

---

## Fail cases

### 8. No reply, not outdated
```text
qodo: Please change this
```
**Result:** fail

---

### 9. Reply only from someone other than the PR author
```text
qodo: Please change this
reviewer: looks good
```
**Result:** fail

---

### 10. Qodo comments multiple times, PR author never replies
```text
qodo: Please change this
qodo: more detail
qodo: still relevant
```
**Result:** fail

---

### 11. Main-thread PR comment by author, but no review-thread reply
```text
qodo posts review-thread comment
author replies in main PR conversation instead
```
**Result:** fail

Reason: only the **review thread** is checked.

---

## Ignored / non-applicable cases

### 12. Normal PR conversation comment in main thread
```text
qodo comments on the PR conversation
author replies there
```
**Result:** ignored by this workflow

---

### 13. Review thread not started by Qodo
```text
human reviewer: Please change this
author: fixed
```
**Result:** ignored by this workflow

---

### 14. Qodo joins a thread started by someone else
```text
human reviewer: Please change this
qodo: I also think this is an issue
author: fixed
```
**Result:** ignored by this workflow

Because the workflow only checks threads whose **first comment** is by Qodo.

---

### Steps to test

We can try out in this PR.

### AI usage

_____

  Manually driven Zed + GPT 5.4

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
