### PR TITLE
Allow housekeeping PRs without issue numbers

### DIFF
--- a/.github/workflows/link-issue.yml
+++ b/.github/workflows/link-issue.yml
@@ -51,26 +51,29 @@ jobs:
           outputOnly: true
       - run: echo "${{ steps.get_issue_number.outputs.ticketNumber }}"
       - name: Allow missing issue link for maintainers using `Closes NA`
-        if: steps.get_issue_number.outputs.ticketNumber == '-1'
         id: allow_missing_issue_link
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          TICKET_NUMBER: ${{ steps.get_issue_number.outputs.ticketNumber }}
         run: |
           set -euo pipefail
+
+          echo "allowed=false" >> "$GITHUB_OUTPUT"
+
+          if [ "$TICKET_NUMBER" != '-1' ]; then
+            exit 0
+          fi
 
           if printf '%s\n' "$PR_BODY" | grep -Eiq '^[[:space:]]*closes[[:space:]]+na[[:space:]]*$'; then
             case "$PR_AUTHOR_ASSOCIATION" in
               OWNER|MEMBER|COLLABORATOR)
                 echo "Maintainer '$PR_AUTHOR' used 'Closes NA'; allowing missing issue link."
                 echo "allowed=true" >> "$GITHUB_OUTPUT"
-                exit 0
                 ;;
             esac
           fi
-
-          echo "allowed=false" >> "$GITHUB_OUTPUT"
       - name: Issue number present
         if: steps.get_issue_number.outputs.ticketNumber == '-1' && steps.allow_missing_issue_link.outputs.allowed != 'true'
         run: |

--- a/.github/workflows/link-issue.yml
+++ b/.github/workflows/link-issue.yml
@@ -2,7 +2,7 @@ name: Link PR to Issue
 
 on:
   pull_request_target:
-    types: [ opened, reopened, edited ]
+    types: [ opened, reopened, edited, synchronize ]
 
 jobs:
   determine_issue_number:

--- a/.github/workflows/link-issue.yml
+++ b/.github/workflows/link-issue.yml
@@ -24,6 +24,7 @@ jobs:
       contents: read
     outputs:
       issue_number: ${{ steps.get_issue_number.outputs.ticketNumber }}
+      allow_missing_issue_link: ${{ steps.allow_missing_issue_link.outputs.allowed }}
     steps:
       - name: echo PR data
         env:
@@ -49,14 +50,36 @@ jobs:
           bodyRegexFlags: 'i'
           outputOnly: true
       - run: echo "${{ steps.get_issue_number.outputs.ticketNumber }}"
-      - name: Issue number present
+      - name: Allow missing issue link for maintainers using `Closes NA`
         if: steps.get_issue_number.outputs.ticketNumber == '-1'
+        id: allow_missing_issue_link
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          if printf '%s\n' "$PR_BODY" | grep -Eiq '^[[:space:]]*closes[[:space:]]+na[[:space:]]*$'; then
+            case "$PR_AUTHOR_ASSOCIATION" in
+              OWNER|MEMBER|COLLABORATOR)
+                echo "Maintainer '$PR_AUTHOR' used 'Closes NA'; allowing missing issue link."
+                echo "allowed=true" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+            esac
+          fi
+
+          echo "allowed=false" >> "$GITHUB_OUTPUT"
+      - name: Issue number present
+        if: steps.get_issue_number.outputs.ticketNumber == '-1' && steps.allow_missing_issue_link.outputs.allowed != 'true'
         run: |
           echo "No valid ticket number found!"
           exit 1
 
   move_issue:
     name: Mark issue as in progress
+    if: needs.determine_issue_number.outputs.issue_number != '-1'
     # after determine_issue_number to ensure that there is only one failure because of no ticket number
     needs: determine_issue_number
     runs-on: ubuntu-slim
@@ -88,7 +111,7 @@ jobs:
 
   ensure_assignment:
     name: Ensure that contributor is assigned (fails if not commented on issue)
-    if: github.event.pull_request.head.repo.full_name != 'JabRef/jabref'
+    if: github.event.pull_request.head.repo.full_name != 'JabRef/jabref' && needs.determine_issue_number.outputs.issue_number != '-1'
     # after determine_issue_number to ensure that there is only one failure because of no ticket number
     needs: determine_issue_number
     runs-on: ubuntu-slim


### PR DESCRIPTION
### Related issues and pull requests

Closes NA

### PR Description

Allow general maintenance by internal contributors with explicit permissions to JabRef project (OWNER|MEMBER|COLLABORATOR) to file PRs without issue numbers by specifying Closes NA (without failing the check).

### Steps to test

~This PR.~ Pull request target takes `main` branch into consideration so it'll fail in this PR.
We can try out after merging.

### AI usage

Manually driven Zed + GPT 5.4
_____

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
