### PR TITLE
Add "add space before citation" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- We added an "add space before" option in LibreOffice component. [#16349](https://github.com/JabRef/jabref/issues/16349)
+- We added an "add space before citation" option in the LibreOffice integration. [#16349](https://github.com/JabRef/jabref/issues/16349)
 - CSL Citations emitted by JabRef in LibreOffice can now be read by Zotero (under a new preference "Zotero Compatibility Mode") and vice versa. [#15878](https://github.com/JabRef/jabref/issues/15878)
 - We added support for bibliography generation using `.bst` files in the OpenOffice/LibreOffice integration. [#624](https://github.com/JabRef/jabref/issues/624)
 - The command `jabkit pdf update --format=xmp` now writes XMP metadata to the linked PDF. [#16087](https://github.com/JabRef/jabref/issues/16087)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- We added an "add space before" option in LibreOffice component. [#16349](https://github.com/JabRef/jabref/issues/16349)
 - CSL Citations emitted by JabRef in LibreOffice can now be read by Zotero (under a new preference "Zotero Compatibility Mode") and vice versa. [#15878](https://github.com/JabRef/jabref/issues/15878)
 - We added support for bibliography generation using `.bst` files in the OpenOffice/LibreOffice integration. [#624](https://github.com/JabRef/jabref/issues/624)
 - The command `jabkit pdf update --format=xmp` now writes XMP metadata to the linked PDF. [#16087](https://github.com/JabRef/jabref/issues/16087)

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
@@ -655,6 +655,10 @@ public class OpenOfficePanel {
         CheckMenuItem autoSync = new CheckMenuItem(Localization.lang("Automatically sync bibliography when inserting citations"));
         autoSync.selectedProperty().set(openOfficePreferences.getSyncWhenCiting());
 
+        CheckMenuItem addSpaceBefore = new CheckMenuItem(Localization.lang("Add space before citation"));
+        addSpaceBefore.selectedProperty().set(openOfficePreferences.getAddSpaceBefore());
+        addSpaceBefore.setOnAction(_ -> openOfficePreferences.setAddSpaceBefore(addSpaceBefore.isSelected()));
+
         CheckMenuItem addSpaceAfter = new CheckMenuItem(Localization.lang("Add space after citation"));
         addSpaceAfter.selectedProperty().set(openOfficePreferences.getAddSpaceAfter());
         addSpaceAfter.setOnAction(_ -> openOfficePreferences.setAddSpaceAfter(addSpaceAfter.isSelected()));
@@ -713,6 +717,7 @@ public class OpenOfficePanel {
 
         contextMenu.getItems().addAll(
                 autoSync,
+                addSpaceBefore,
                 addSpaceAfter,
                 zoteroCompatibilityMode,
                 new SeparatorMenuItem(),

--- a/jablib/src/main/java/org/jabref/logic/openoffice/OpenOfficePreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/OpenOfficePreferences.java
@@ -42,6 +42,7 @@ public class OpenOfficePreferences {
     private final StringProperty cslBibliographyHeaderFormat;
     private final StringProperty cslBibliographyBodyFormat;
     private final ObservableList<String> externalCslStyles;
+    private final BooleanProperty addSpaceBefore;
     private final BooleanProperty addSpaceAfter;
     private final BooleanProperty zoteroCompatibilityMode;
     private final ObservableList<String> externalBstStyles;
@@ -59,6 +60,7 @@ public class OpenOfficePreferences {
                                  String cslBibliographyHeaderFormat,
                                  String cslBibliographyBodyFormat,
                                  List<String> externalCslStyles,
+                                 boolean addSpaceBefore,
                                  boolean addSpaceAfter,
                                  boolean zoteroCompatibilityMode,
                                  List<String> externalBstStyles,
@@ -75,6 +77,7 @@ public class OpenOfficePreferences {
         this.cslBibliographyHeaderFormat = new SimpleStringProperty(cslBibliographyHeaderFormat);
         this.cslBibliographyBodyFormat = new SimpleStringProperty(cslBibliographyBodyFormat);
         this.externalCslStyles = FXCollections.observableArrayList(externalCslStyles);
+        this.addSpaceBefore = new SimpleBooleanProperty(addSpaceBefore);
         this.addSpaceAfter = new SimpleBooleanProperty(addSpaceAfter);
         this.zoteroCompatibilityMode = new SimpleBooleanProperty(zoteroCompatibilityMode);
         this.externalBstStyles = FXCollections.observableArrayList(externalBstStyles);
@@ -97,6 +100,7 @@ public class OpenOfficePreferences {
                 "Heading 2",                                    // cslBibliographyHeaderFormat
                 "Text body",                                    // cslBibliographyBodyFormat
                 List.of(),                                      // externalCslStyles
+                true,                                           // addSpaceBefore
                 true,                                           // addSpaceAfter
                 true,                                            // zoteroCompatibilityMode
                 List.of(),                                      // externalBstStyles
@@ -247,6 +251,18 @@ public class OpenOfficePreferences {
 
     public void setExternalCslStyles(List<String> paths) {
         externalCslStyles.setAll(paths);
+    }
+
+    public boolean getAddSpaceBefore() {
+        return addSpaceBefore.get();
+    }
+
+    public BooleanProperty addSpaceBeforeProperty() {
+        return addSpaceBefore;
+    }
+
+    public void setAddSpaceBefore(boolean addSpaceBefore) {
+        this.addSpaceBefore.setValue(addSpaceBefore);
     }
 
     public boolean getAddSpaceAfter() {

--- a/jablib/src/main/java/org/jabref/logic/openoffice/OpenOfficePreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/OpenOfficePreferences.java
@@ -90,7 +90,7 @@ public class OpenOfficePreferences {
                 OS.WINDOWS ? DEFAULT_WIN_EXEC_PATH              // executablePath
                            : OS.OS_X ? DEFAULT_OSX_EXEC_PATH
                                      : DEFAULT_LINUX_EXEC_PATH,
-                true,                             // useAllDatabases
+                true,                                           // useAllDatabases
                 false,                                          // syncWhenCiting
                 List.of(),                                      // externalJStyles
                 JStyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH,     // currentJStyle
@@ -102,7 +102,7 @@ public class OpenOfficePreferences {
                 List.of(),                                      // externalCslStyles
                 true,                                           // addSpaceBefore
                 true,                                           // addSpaceAfter
-                true,                                            // zoteroCompatibilityMode
+                true,                                           // zoteroCompatibilityMode
                 List.of(),                                      // externalBstStyles
                 "pandoc",                                       // pandocPath
                 BstCitationFormat.NUMERIC                       // bstCitationFormat

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/BSTCitationOOAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/BSTCitationOOAdapter.java
@@ -78,7 +78,7 @@ public class BSTCitationOOAdapter {
         boolean preceedingSpaceExists = checkPreceedingSpace(cursor);
         markManager.insertReferenceIntoOO(
                 entries, document, cursor, ooText,
-                !preceedingSpaceExists,
+                !preceedingSpaceExists && openOfficePreferences.getAddSpaceBefore(),
                 openOfficePreferences.getAddSpaceAfter(),
                 CSLCitationType.NORMAL);
         markManager.setRealTimeNumberUpdateRequired(

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
@@ -423,7 +423,7 @@ public class CSLCitationOOAdapter {
                 document,
                 cursor,
                 ooText,
-                !preceedingSpaceExists,
+                !preceedingSpaceExists && openOfficePreferences.getAddSpaceBefore(),
                 openOfficePreferences.getAddSpaceAfter(),
                 citationType,
                 bibDatabaseContext,

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -274,6 +274,7 @@ public class JabRefCliPreferences implements CliPreferences {
     public static final String OO_CSL_BIBLIOGRAPHY_TITLE = "cslBibliographyTitle";
     public static final String OO_CSL_BIBLIOGRAPHY_HEADER_FORMAT = "cslBibliographyHeaderFormat";
     public static final String OO_CSL_BIBLIOGRAPHY_BODY_FORMAT = "cslBibliographyBodyFormat";
+    public static final String OO_ADD_SPACE_BEFORE = "ooAddSpaceBefore";
     public static final String OO_ADD_SPACE_AFTER = "ooAddSpaceAfter";
     public static final String OO_ZOTERO_COMPATIBILITY_MODE = "ooZoteroCompatibilityMode";
     public static final String OO_EXTERNAL_BST_STYLES = "externalBstStyles";
@@ -2507,6 +2508,7 @@ public class JabRefCliPreferences implements CliPreferences {
                 get(OO_CSL_BIBLIOGRAPHY_HEADER_FORMAT, defaultValues.getCslBibliographyHeaderFormat()),
                 get(OO_CSL_BIBLIOGRAPHY_BODY_FORMAT, defaultValues.getCslBibliographyBodyFormat()),
                 getStringList(OO_EXTERNAL_CSL_STYLES),
+                getBoolean(OO_ADD_SPACE_BEFORE, defaultValues.getAddSpaceBefore()),
                 getBoolean(OO_ADD_SPACE_AFTER, defaultValues.getAddSpaceAfter()),
                 getBoolean(OO_ZOTERO_COMPATIBILITY_MODE, defaultValues.getZoteroCompatibilityMode()),
                 getStringList(OO_EXTERNAL_BST_STYLES),
@@ -2517,6 +2519,7 @@ public class JabRefCliPreferences implements CliPreferences {
         bindBoolean(openOfficePreferences.useAllDatabasesProperty(), OO_USE_ALL_OPEN_BASES, defaultValues.getUseAllDatabases());
         bindBoolean(openOfficePreferences.alwaysAddCitedOnPagesProperty(), OO_ALWAYS_ADD_CITED_ON_PAGES, defaultValues.getAlwaysAddCitedOnPages());
         bindBoolean(openOfficePreferences.syncWhenCitingProperty(), OO_SYNC_WHEN_CITING, defaultValues.getSyncWhenCiting());
+        bindBoolean(openOfficePreferences.addSpaceBeforeProperty(), OO_ADD_SPACE_BEFORE, defaultValues.getAddSpaceBefore());
         bindBoolean(openOfficePreferences.addSpaceAfterProperty(), OO_ADD_SPACE_AFTER, defaultValues.getAddSpaceAfter());
         bindBoolean(openOfficePreferences.zoteroCompatibilityModeProperty(), OO_ZOTERO_COMPATIBILITY_MODE, defaultValues.getZoteroCompatibilityMode());
 

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -1210,6 +1210,7 @@ Problem\ during\ separating\ cite\ markers=Problem during separating cite marker
 
 Automatically\ add\ "Cited\ on\ pages..."\ at\ the\ end\ of\ bibliographic\ entries=Automatically add "Cited on pages..." at the end of bibliographic entries
 Automatically\ sync\ bibliography\ when\ inserting\ citations=Automatically sync bibliography when inserting citations
+Add\ space\ before\ citation=Add space before citation
 Add\ space\ after\ citation=Add space after citation
 Zotero\ compatibility\ mode=Zotero compatibility mode
 Reference\ mark\ format=Reference mark format


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/16349

### PR Description
Add "add space before" option in LO preference. 

### Steps to test
1. Connect to a LibreOffice document, check the button is enabled by default.
2. Insert a citation, observe that there is a space between text and citation.
<img width="251" height="123" alt="image" src="https://github.com/user-attachments/assets/a2d6d89d-a3c8-4ae4-8e3e-2843b3d28d93" />

3. Disabled the option, insert a citation again. Observe there is no space.
<img width="223" height="175" alt="image" src="https://github.com/user-attachments/assets/9a68fe74-bc4d-4125-8457-c7beec8f8c3b" />

### AI usage
🧠
_____

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
