### PR TITLE
Hide notifications for AI task when auto-generation is turned on

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/ai/ingestion/IngestionTaskAggregator.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/ingestion/IngestionTaskAggregator.java
@@ -29,8 +29,12 @@ public class IngestionTaskAggregator {
     }
 
     public synchronized Pair<Future<Void>, GenerateEmbeddingsTask> startWithFuture(GenerateEmbeddingsTaskRequest request) {
+        return startWithFuture(request, true);
+    }
+
+    public synchronized Pair<Future<Void>, GenerateEmbeddingsTask> startWithFuture(GenerateEmbeddingsTaskRequest request, boolean showToUser) {
         return generateEmbeddingsTasks.computeIfAbsent(request.linkedFile(), _ -> {
-            GenerateEmbeddingsTask task = new GenerateEmbeddingsTask(request);
+            GenerateEmbeddingsTask task = new GenerateEmbeddingsTask(request, showToUser);
             task.onFinished(() -> generateEmbeddingsTasks.remove(request.linkedFile()));
             Future<Void> future = taskExecutor.execute(task);
             return new Pair<>(future, task);
@@ -38,7 +42,11 @@ public class IngestionTaskAggregator {
     }
 
     public synchronized GenerateEmbeddingsTask start(GenerateEmbeddingsTaskRequest request) {
-        return startWithFuture(request).getValue();
+        return startWithFuture(request, true).getValue();
+    }
+
+    public synchronized GenerateEmbeddingsTask start(GenerateEmbeddingsTaskRequest request, boolean showToUser) {
+        return startWithFuture(request, showToUser).getValue();
     }
 
     public synchronized Pair<Future<Void>, GenerateEmbeddingsForSeveralTask> start(GenerateEmbeddingsForSeveralTaskRequest request) {

--- a/jablib/src/main/java/org/jabref/logic/ai/ingestion/listeners/GenerateEmbeddingsAiDatabaseListener.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/ingestion/listeners/GenerateEmbeddingsAiDatabaseListener.java
@@ -106,7 +106,7 @@ public class GenerateEmbeddingsAiDatabaseListener implements AiDatabaseListener 
                     documentSplitter.get(),
                     context,
                     linkedFile
-            ));
+            ), false);
         }
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/ai/ingestion/tasks/generateembeddings/GenerateEmbeddingsTask.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/ingestion/tasks/generateembeddings/GenerateEmbeddingsTask.java
@@ -19,7 +19,8 @@ public class GenerateEmbeddingsTask extends TrackedBackgroundTask<Void> {
     private final LinkedFileIngestor linkedFileIngestor;
 
     public GenerateEmbeddingsTask(
-            GenerateEmbeddingsTaskRequest request
+            GenerateEmbeddingsTaskRequest request,
+            boolean showToUser
     ) {
         this.request = request;
         this.linkedFileIngestor = new LinkedFileIngestor(
@@ -30,11 +31,11 @@ public class GenerateEmbeddingsTask extends TrackedBackgroundTask<Void> {
                 request.documentSplitter()
         );
 
-        configure();
+        configure(showToUser);
     }
 
-    private void configure() {
-        showToUser(true);
+    private void configure(boolean showToUser) {
+        showToUser(showToUser);
         titleProperty().set(Localization.lang("Generating embeddings for file '%0'", request.linkedFile().getLink()));
     }
 

--- a/jablib/src/main/java/org/jabref/logic/ai/summarization/SummarizationTaskAggregator.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/summarization/SummarizationTaskAggregator.java
@@ -44,22 +44,26 @@ public class SummarizationTaskAggregator {
     /// {@link org.jabref.logic.ai.util.TrackedBackgroundTask#getStatus()} immediately after
     /// attaching, in case the task already finished before the listener was registered.
     public synchronized GenerateSummaryTask start(GenerateSummaryTaskRequest request) {
+        return start(request, true);
+    }
+
+    public synchronized GenerateSummaryTask start(GenerateSummaryTaskRequest request, boolean showToUser) {
         Optional<GenerateSummaryTask> task = getTask(request.fullEntry().entry());
 
         if (task.isEmpty()) {
-            return startNewTask(request);
+            return startNewTask(request, showToUser);
         }
 
         if (task.get().getStatus() == TrackedBackgroundTask.Status.CANCELLED && request.regenerate()) {
             tasks.remove(request.fullEntry().entry());
-            return startNewTask(request);
+            return startNewTask(request, showToUser);
         }
 
         return task.get();
     }
 
-    private synchronized GenerateSummaryTask startNewTask(GenerateSummaryTaskRequest request) {
-        GenerateSummaryTask task = new GenerateSummaryTask(request);
+    private synchronized GenerateSummaryTask startNewTask(GenerateSummaryTaskRequest request, boolean showToUser) {
+        GenerateSummaryTask task = new GenerateSummaryTask(request, showToUser);
 
         task.onFinished(() -> tasks.remove(request.fullEntry().entry()));
 

--- a/jablib/src/main/java/org/jabref/logic/ai/summarization/listeners/GenerateSummaryAiDatabaseListener.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/summarization/listeners/GenerateSummaryAiDatabaseListener.java
@@ -87,7 +87,7 @@ public class GenerateSummaryAiDatabaseListener implements AiDatabaseListener {
                         summarizator.get(),
                         new FullBibEntry(context, entry),
                         false
-                ));
+                ), false);
             });
         }
 
@@ -104,7 +104,7 @@ public class GenerateSummaryAiDatabaseListener implements AiDatabaseListener {
                     summarizator.get(),
                     new FullBibEntry(context, event.getBibEntry()),
                     false
-            ));
+            ), false);
         }
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/ai/summarization/tasks/GenerateSummaryTask.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/summarization/tasks/GenerateSummaryTask.java
@@ -15,7 +15,10 @@ public class GenerateSummaryTask extends TrackedBackgroundTask<AiSummary> {
     private final String citationKey; // Useful for logging.
     private final BibEntrySummarizator bibEntrySummarizator;
 
-    public GenerateSummaryTask(GenerateSummaryTaskRequest request) {
+    public GenerateSummaryTask(
+            GenerateSummaryTaskRequest request,
+            boolean showToUser
+    ) {
         this.request = request;
         this.citationKey = request.fullEntry().entry().getCitationKey().orElse("<no citation key>");
 
@@ -24,11 +27,11 @@ public class GenerateSummaryTask extends TrackedBackgroundTask<AiSummary> {
                 request.summarizator()
         );
 
-        configure();
+        configure(showToUser);
     }
 
-    private void configure() {
-        showToUser(true);
+    private void configure(boolean showToUser) {
+        showToUser(showToUser);
         titleProperty().set(Localization.lang("Waiting summary for %0...", citationKey));
     }
 


### PR DESCRIPTION
### Related issues and pull requests

Closes NA

### PR Description

Basically, when "Auto-generate AI summaries/embeddings when new files are added" is on, it produced a lot of annoying notifications. This PR just hides them. Not sure if that's the best idea, but it feels much better to use JabRef now.

And those options are disabled by default, so if user enables them, they acknowledge that the summaries/embeddings will be created, so staying silent is okay.

From code perspective - this is a bit wishy whacky solution, I think it would be better to put it in the request, but I decided to take an approach with argument, as it just produces less code changes. Open to discussions.

### Steps to test

- Add or remove linked files

No "Generating summary" or "Generating embeddings" messages should be shown.

### AI usage

I'm proud to say: no AT ALL!

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
