### PR TITLE
Fix `URLDownload` initialization

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProvider.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProvider.java
@@ -1,8 +1,10 @@
 package org.jabref.logic.ai.models;
 
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.net.URLDownload;
 import org.jabref.model.ai.llm.AiProvider;
 
@@ -31,9 +33,9 @@ public class OpenAiCompatibleModelProvider implements AiModelProvider {
 
         List<String> models = List.of();
 
-        try {
-            String modelsEndpoint = buildModelsEndpoint(apiBaseUrl);
+        String modelsEndpoint = buildModelsEndpoint(apiBaseUrl);
 
+        try {
             URLDownload urlDownload = new URLDownload(modelsEndpoint);
             urlDownload.addHeader("Authorization", "Bearer " + apiKey);
             urlDownload.addHeader("accept", "application/json");
@@ -42,7 +44,7 @@ public class OpenAiCompatibleModelProvider implements AiModelProvider {
             models = parseModelsFromResponse(new JsonNode(response));
 
             LOGGER.debug("Successfully fetched {} models from {}", models.size(), aiProvider.name());
-        } catch (Exception e) {
+        } catch (FetcherException | MalformedURLException e) {
             LOGGER.error("Failed to fetch models from {}", aiProvider.name(), e);
         }
 

--- a/jablib/src/main/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProvider.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProvider.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.ai.models;
 
 import java.net.MalformedURLException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,6 +25,8 @@ public class OpenAiCompatibleModelProvider implements AiModelProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenAiCompatibleModelProvider.class);
 
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+
     @Override
     public List<String> fetchModels(AiProvider aiProvider, String apiBaseUrl, @Nullable String apiKey) {
         if (apiKey == null || apiKey.isBlank()) {
@@ -37,6 +40,7 @@ public class OpenAiCompatibleModelProvider implements AiModelProvider {
 
         try {
             URLDownload urlDownload = new URLDownload(modelsEndpoint);
+            urlDownload.setConnectTimeout(CONNECT_TIMEOUT);
             urlDownload.addHeader("Authorization", "Bearer " + apiKey);
             urlDownload.addHeader("accept", "application/json");
 

--- a/jablib/src/main/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProvider.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProvider.java
@@ -11,6 +11,7 @@ import org.jabref.model.ai.llm.AiProvider;
 
 import kong.unirest.core.JsonNode;
 import kong.unirest.core.json.JSONArray;
+import kong.unirest.core.json.JSONException;
 import kong.unirest.core.json.JSONObject;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -48,7 +49,7 @@ public class OpenAiCompatibleModelProvider implements AiModelProvider {
             models = parseModelsFromResponse(new JsonNode(response));
 
             LOGGER.debug("Successfully fetched {} models from {}", models.size(), aiProvider.name());
-        } catch (FetcherException | MalformedURLException e) {
+        } catch (FetcherException | MalformedURLException | JSONException e) {
             LOGGER.error("Failed to fetch models from {}", aiProvider.name(), e);
         }
 

--- a/jablib/src/main/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProvider.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProvider.java
@@ -3,12 +3,10 @@ package org.jabref.logic.ai.models;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jabref.logic.net.URLDownload;
 import org.jabref.model.ai.llm.AiProvider;
 
-import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
-import kong.unirest.core.Unirest;
-import kong.unirest.core.UnirestException;
 import kong.unirest.core.json.JSONArray;
 import kong.unirest.core.json.JSONObject;
 import org.jspecify.annotations.NullMarked;
@@ -35,18 +33,16 @@ public class OpenAiCompatibleModelProvider implements AiModelProvider {
 
         try {
             String modelsEndpoint = buildModelsEndpoint(apiBaseUrl);
-            HttpResponse<JsonNode> response = Unirest.get(modelsEndpoint)
-                                                     .header("Authorization", "Bearer " + apiKey)
-                                                     .header("accept", "application/json")
-                                                     .asJson();
 
-            if (response.getStatus() == 200) {
-                models = parseModelsFromResponse(response.getBody());
-                LOGGER.debug("Successfully fetched {} models from {}", models.size(), aiProvider.name());
-            } else {
-                LOGGER.error("Failed to fetch models from {} (status: {})", aiProvider.name(), response.getStatus());
-            }
-        } catch (UnirestException e) {
+            URLDownload urlDownload = new URLDownload(modelsEndpoint);
+            urlDownload.addHeader("Authorization", "Bearer " + apiKey);
+            urlDownload.addHeader("accept", "application/json");
+
+            String response = urlDownload.asString();
+            models = parseModelsFromResponse(new JsonNode(response));
+
+            LOGGER.debug("Successfully fetched {} models from {}", models.size(), aiProvider.name());
+        } catch (Exception e) {
             LOGGER.error("Failed to fetch models from {}", aiProvider.name(), e);
         }
 

--- a/jablib/src/test/java/org/jabref/logic/ai/models/AiModelServiceTest.java
+++ b/jablib/src/test/java/org/jabref/logic/ai/models/AiModelServiceTest.java
@@ -17,17 +17,6 @@ class AiModelServiceTest {
 
     private AiModelService aiModelService;
 
-    @BeforeAll
-    static void ensureUnirestInitialized() {
-        // Ensure URLDownload's static initializer runs before any tests
-        // This configures Unirest and prevents UnirestConfigException
-        try {
-            Class.forName(URLDownload.class.getName());
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Failed to initialize URLDownload", e);
-        }
-    }
-
     @BeforeEach
     void setUp() {
         aiModelService = new AiModelService();
@@ -65,8 +54,6 @@ class AiModelServiceTest {
 
     @Test
     void fetchModelsSynchronouslyHandlesTimeout() {
-        // This test uses a URL that will likely timeout (non-routable IP)
-        // Unirest has a default timeout, so should fail and return empty list
         long startTime = System.currentTimeMillis();
 
         List<String> models = aiModelService.fetchModelsSynchronously(
@@ -78,7 +65,6 @@ class AiModelServiceTest {
         long duration = System.currentTimeMillis() - startTime;
 
         assertEquals(List.of(), models);
-        // Unirest default timeout is around 10 seconds, allow margin for test execution
         assertTrue(duration < 15000, "Should timeout within reasonable time, but took " + duration + "ms");
     }
 

--- a/jablib/src/test/java/org/jabref/logic/ai/models/AiModelServiceTest.java
+++ b/jablib/src/test/java/org/jabref/logic/ai/models/AiModelServiceTest.java
@@ -2,10 +2,8 @@ package org.jabref.logic.ai.models;
 
 import java.util.List;
 
-import org.jabref.logic.net.URLDownload;
 import org.jabref.model.ai.llm.AiProvider;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -54,6 +52,8 @@ class AiModelServiceTest {
 
     @Test
     void fetchModelsSynchronouslyHandlesTimeout() {
+        // This test uses a URL that will likely timeout (non-routable IP)
+        // Unirest has a default timeout, so should fail and return empty list
         long startTime = System.currentTimeMillis();
 
         List<String> models = aiModelService.fetchModelsSynchronously(
@@ -65,6 +65,7 @@ class AiModelServiceTest {
         long duration = System.currentTimeMillis() - startTime;
 
         assertEquals(List.of(), models);
+        // Unirest default timeout is around 10 seconds, allow margin for test execution
         assertTrue(duration < 15000, "Should timeout within reasonable time, but took " + duration + "ms");
     }
 

--- a/jablib/src/test/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProviderTest.java
+++ b/jablib/src/test/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProviderTest.java
@@ -2,10 +2,8 @@ package org.jabref.logic.ai.models;
 
 import java.util.List;
 
-import org.jabref.logic.net.URLDownload;
 import org.jabref.model.ai.llm.AiProvider;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/jablib/src/test/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProviderTest.java
+++ b/jablib/src/test/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProviderTest.java
@@ -16,17 +16,6 @@ class OpenAiCompatibleModelProviderTest {
 
     private OpenAiCompatibleModelProvider provider;
 
-    @BeforeAll
-    static void ensureUnirestInitialized() {
-        // Ensure URLDownload's static initializer runs before any tests
-        // This configures Unirest and prevents UnirestConfigException
-        try {
-            Class.forName(URLDownload.class.getName());
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Failed to initialize URLDownload", e);
-        }
-    }
-
     @BeforeEach
     void setUp() {
         provider = new OpenAiCompatibleModelProvider();


### PR DESCRIPTION
### Related issues and pull requests

Follow-up to https://github.com/JabRef/jabref/pull/16402
Relates to https://github.com/JabRef/jabref/issues/16059

Just a random error happened, fixing it.

### PR Description

Removed `Unirest` from OpenAI provider, as it seems to initialize it, before `URLDownload` does it.

### Steps to test

Bug present without this PR. To trigger it:

1. Open JabRef (I mean start clear and don't do anything, except what's written here).
2. Set valid OpenAI API key in preferences.
3. Click on combobox with AI providers and see all currently available models (this triggers `Unirest` initialization).
4. Then exit preference and try to use WebSearch (this will trigger the first usage of `URLDownload`, which initializes `Unirest`, and that causes error).

Error log:

```plain
java.util.concurrent.CompletionException: java.lang.NoClassDefFoundError: Could not initialize class org.jabref.logic.net.URLDownload
	at java.base/java.util.concurrent.CompletableFuture.wrapInCompletionException(CompletableFuture.java:323)
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:359)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:364)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1791)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.lang.NoClassDefFoundError: Could not initialize class org.jabref.logic.net.URLDownload
	at org.jabref.jablib/org.jabref.logic.importer.WebFetcher.getUrlDownload(WebFetcher.java:33)
	at org.jabref.jablib/org.jabref.logic.importer.fetcher.DoiFetcher.getAgency(DoiFetcher.java:228)
	at org.jabref.jablib/org.jabref.logic.importer.fetcher.DoiFetcher.doAPILimiting(DoiFetcher.java:95)
	at org.jabref.jablib/org.jabref.logic.importer.fetcher.DoiFetcher.asyncPerformSearchById(DoiFetcher.java:108)
	at org.jabref.jablib/org.jabref.logic.importer.fetcher.ArXivFetcher.inplaceAsyncInfuseArXivWithDoi(ArXivFetcher.java:299)
	at org.jabref.jablib/org.jabref.logic.importer.fetcher.ArXivFetcher.inplaceAsyncInfuseArXivWithDoi(ArXivFetcher.java:274)
	at org.jabref.jablib/org.jabref.logic.importer.fetcher.ArXivFetcher.lambda$enrichPageWithDoi$1(ArXivFetcher.java:360)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1789)
	... 3 more
Caused by: java.lang.ExceptionInInitializerError: Exception kong.unirest.core.UnirestConfigException: Http Clients are already built in order to build a new config execute Unirest.config().reset() before changing settings. 
This should be done rarely. [in thread "pool-12-thread-6"]
	at unirest.java.core@4.10.1/kong.unirest.core.Config.validateClientsNotRunning(Config.java:980)
	at unirest.java.core@4.10.1/kong.unirest.core.Config.followRedirects(Config.java:530)
	at org.jabref.jablib/org.jabref.logic.net.URLDownload.<clinit>(URLDownload.java:89)
	... 11 more
```

### AI usage

Used AI and Subhramit (not AI, but also very smart) to find why this issue happens. Also asked AI to rewrite the code without Unirest.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
