### PR TITLE
Gate build tests from running on any label

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -122,7 +122,7 @@ env:
 
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ github.event_name }}-${{ github.event.inputs.useEaJdk }}-${{ github.event.inputs.jdkVersion }}-${{ github.event.inputs.jdkVersionFlavour }}-${{ github.event.inputs.javafxVersion }}"
+  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ github.event_name }}-${{ github.event.action == 'labeled' && github.event.label.name != 'automerge' && github.event.label.name != 'dev: binaries' && github.run_id || 'shared' }}-${{ github.event.inputs.useEaJdk }}-${{ github.event.inputs.jdkVersion }}-${{ github.event.inputs.jdkVersionFlavour }}-${{ github.event.inputs.javafxVersion }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -149,7 +149,7 @@ jobs:
         env:
           BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
           LABEL_NAME: ${{ github.event.label.name }}
           REPO_OWNER: ${{ github.repository_owner }}
         run: |
@@ -157,7 +157,7 @@ jobs:
           set -x
           PS4='+ ${LINENO}: '
 
-          if [[ "$EVENT_NAME" != "labeled" || "$LABEL_NAME" == "automerge"  || "$LABEL_NAME" == "dev: binaries" ]]; then
+          if [[ "$EVENT_ACTION" != "labeled" || "$LABEL_NAME" == "automerge" || "$LABEL_NAME" == "dev: binaries" ]]; then
             echo "📦 build enabled"
             echo "📦 build enabled" >> $GITHUB_STEP_SUMMARY
             echo "should-build=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Related issues and pull requests

Closes NA

### PR Description

Triggered by https://github.com/JabRef/jabref/pull/15521

I added the `status: awaiting-second-review` label to the PR and the Binaries workflows started again, even though they had completed successfully already.

Turns out for PR label events, `github.event_name` is `pull_request`, so
https://github.com/JabRef/jabref/blob/36e2fe982d269b879f2816a4daea7b147337f310/.github/workflows/binaries.yml#L14-L19 the workflow always treated label events like normal PR events and enabled builds for every label.

However, `github.event.action` is `labeled` on a PR label event. So we can leverage that instead.

Now it will only enable the expensive (and time taking) binaries flow on label events if the label is:
- `automerge`
- `dev: binaries`

and will skip for unrelated labels.

### Steps to test

Try random labels on this PR after Binaries workflow is idle.

### AI usage

Zed + GPT 5.4 for RCA

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
