### PR TITLE
Add await for second review workflow triggers to concurrency group

### DIFF
--- a/.github/workflows/on-pr-awaiting-second-review-check.yml
+++ b/.github/workflows/on-pr-awaiting-second-review-check.yml
@@ -18,6 +18,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.repository }}-${{ github.event.pull_request.number || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
   require-second-approval:
     name: Require second approval


### PR DESCRIPTION
### Related issues and pull requests

Closes NA

### PR Description

Triggered by https://github.com/JabRef/jabref/pull/15521

I added the `status: awaiting-second-review` label to the PR and approved it after that. Two same CI failures surfaced (with different parentheses):

<img width="905" height="666" alt="image" src="https://github.com/user-attachments/assets/8b5eb83e-b82c-4ecf-ad3f-85e4cff33ada" />

This is because the two different workflow trigger events
- `pull_request_target:labeled`
- another run from `pull_request_review:submitted`

each triggered the workflow to have a fresh, separate run, which was odd/confusing to notice.

This fixes it by adding them to a concurrency group. 
Only the latest state matters, no matter who triggered it, so the earlier run is canceled.

### Steps to test

Approve, add label. Or add label, approve - only one failure should be there.

### AI usage

Zed + GPT 5.4

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
