### PR TITLE
Add rate limiting to CrossRef fetcher to prevent 429 errors in CI

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
@@ -24,6 +24,7 @@ import org.jabref.logic.importer.SearchBasedParserFetcher;
 import org.jabref.logic.importer.fetcher.transformers.DefaultQueryTransformer;
 import org.jabref.logic.importer.util.JsonReader;
 import org.jabref.logic.util.strings.StringSimilarity;
+import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.model.entry.Author;
 import org.jabref.model.entry.AuthorList;
 import org.jabref.model.entry.BibEntry;
@@ -47,9 +48,9 @@ public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, 
 
     private static final String API_URL = "https://api.crossref.org/works";
 
-    // Conservative rate limit for the CrossRef REST API public pool (no polite-pool mailto configured).
-    // CrossRef's polite pool supports up to 50 req/s; without a mailto header the public pool is stricter.
-    // 5 req/s keeps CI runs well within the undocumented public-pool threshold.
+    /// Conservative rate limit for the CrossRef REST API public pool (no polite-pool mailto configured).
+    /// CrossRef's polite pool supports up to 50 req/s; without a mailto header the public pool is stricter.
+    /// 5 req/s keeps CI runs well within the undocumented public-pool threshold.
     private static final FetcherRateLimiter RATE_LIMITER = FetcherRateLimiter.ofRequestsPerSecond("Crossref", 5.0);
 
     private static final RemoveEnclosingBracesFormatter REMOVE_BRACES_FORMATTER = new RemoveEnclosingBracesFormatter();
@@ -77,13 +78,16 @@ public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, 
     }
 
     @Override
-    public List<BibEntry> performSearch(BaseQueryNode queryNode) throws FetcherException {
+    public List<BibEntry> performSearch(@NonNull BaseQueryNode queryNode) throws FetcherException {
         RATE_LIMITER.acquire(queryNode.toString());
         return SearchBasedParserFetcher.super.performSearch(queryNode);
     }
 
     @Override
-    public Optional<BibEntry> performSearchById(String identifier) throws FetcherException {
+    public Optional<BibEntry> performSearchById(@NonNull String identifier) throws FetcherException {
+        if (StringUtil.isBlank(identifier)) {
+            return Optional.empty();
+        }
         RATE_LIMITER.acquire(identifier);
         return IdBasedParserFetcher.super.performSearchById(identifier);
     }

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
@@ -48,10 +48,10 @@ public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, 
 
     private static final String API_URL = "https://api.crossref.org/works";
 
-    /// Conservative rate limit for the CrossRef REST API public pool (no polite-pool mailto configured).
-    /// CrossRef's polite pool supports up to 50 req/s; without a mailto header the public pool is stricter.
-    /// 5 req/s keeps CI runs well within the undocumented public-pool threshold.
-    private static final FetcherRateLimiter RATE_LIMITER = FetcherRateLimiter.ofRequestsPerSecond("Crossref", 5.0);
+    /// Rate limit for the CrossRef REST API public pool.
+    /// CrossRef's public pool defaults to 50 req/s, as measured via X-Rate-Limit-Interval/X-Rate-Limit-Limit
+    /// response headers - consistent with [DoiFetcher]'s existing CROSSREF_DCN_RATE_LIMITER.
+    private static final FetcherRateLimiter RATE_LIMITER = FetcherRateLimiter.ofRequestsPerSecond("Crossref", 50.0);
 
     private static final RemoveEnclosingBracesFormatter REMOVE_BRACES_FORMATTER = new RemoveEnclosingBracesFormatter();
 

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
@@ -15,6 +15,7 @@ import org.jabref.logic.formatter.bibtexfields.ClearFormatter;
 import org.jabref.logic.formatter.bibtexfields.RemoveEnclosingBracesFormatter;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.importer.EntryBasedParserFetcher;
+import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.IdBasedParserFetcher;
 import org.jabref.logic.importer.IdParserFetcher;
 import org.jabref.logic.importer.ParseException;
@@ -37,6 +38,7 @@ import kong.unirest.core.json.JSONArray;
 import kong.unirest.core.json.JSONException;
 import kong.unirest.core.json.JSONObject;
 import org.apache.hc.core5.net.URIBuilder;
+import org.jspecify.annotations.NonNull;
 
 /// A class for fetching DOIs from CrossRef
 ///
@@ -44,6 +46,11 @@ import org.apache.hc.core5.net.URIBuilder;
 public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, SearchBasedParserFetcher, IdBasedParserFetcher {
 
     private static final String API_URL = "https://api.crossref.org/works";
+
+    // Conservative rate limit for the CrossRef REST API public pool (no polite-pool mailto configured).
+    // CrossRef's polite pool supports up to 50 req/s; without a mailto header the public pool is stricter.
+    // 5 req/s keeps CI runs well within the undocumented public-pool threshold.
+    private static final FetcherRateLimiter RATE_LIMITER = FetcherRateLimiter.ofRequestsPerSecond("Crossref", 5.0);
 
     private static final RemoveEnclosingBracesFormatter REMOVE_BRACES_FORMATTER = new RemoveEnclosingBracesFormatter();
 
@@ -55,6 +62,30 @@ public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, 
     @Override
     public Optional<HelpFile> getHelpPage() {
         return Optional.of(HelpFile.FETCHER_CROSSREF);
+    }
+
+    @Override
+    public Optional<DOI> findIdentifier(@NonNull BibEntry entry) throws FetcherException {
+        RATE_LIMITER.acquire(entry.getCitationKey().orElse(""));
+        return IdParserFetcher.super.findIdentifier(entry);
+    }
+
+    @Override
+    public List<BibEntry> performSearch(@NonNull BibEntry entry) throws FetcherException {
+        RATE_LIMITER.acquire(entry.getCitationKey().orElse(""));
+        return EntryBasedParserFetcher.super.performSearch(entry);
+    }
+
+    @Override
+    public List<BibEntry> performSearch(BaseQueryNode queryNode) throws FetcherException {
+        RATE_LIMITER.acquire(queryNode.toString());
+        return SearchBasedParserFetcher.super.performSearch(queryNode);
+    }
+
+    @Override
+    public Optional<BibEntry> performSearchById(String identifier) throws FetcherException {
+        RATE_LIMITER.acquire(identifier);
+        return IdBasedParserFetcher.super.performSearchById(identifier);
     }
 
     @Override


### PR DESCRIPTION
### Related issues and pull requests

Closes #16049 

### PR Description

`TitleFetcherTest.performSearchKopp2007( )` was failing cause CrossRef had no rate limiting. 

**Multiple fetcher tests running in parallel exceeded CrossRef's public pool threshold.**

The comment should explain the fix.

### Steps to test

./gradlew :jablib:fetcherTest --tests "org.jabref.logic.importer.fetcher.TitleFetcherTest"

### AI usage

No tokens left 😢

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
