### PR TITLE
Fix conflict in Unirest initialization order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where opening Preferences could break arXiv web search later. [#16059](https://github.com/JabRef/jabref/issues/16059)
 - We fixed an issue with the LibreOffice integration where the ordering for numeric CSL styles in footnotes was broken. [#12484](https://github.com/JabRef/jabref/issues/12484)
 - We fixed an issue where `git push` did not report rejected remote updates. [#16367](https://github.com/JabRef/jabref/pull/16367)
 - We fixed formatting issues in entry preview when `.bst` styles were used. [#16314](https://github.com/JabRef/jabref/issues/16314)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where opening Preferences could break arXiv web search later. [#16059](https://github.com/JabRef/jabref/issues/16059)
+- We fixed an issue where opening preferences could break arXiv web search later. [#16059](https://github.com/JabRef/jabref/issues/16059)
 - We fixed an issue where generating AI embeddings for an entry with a linked URL logged a misleading error about a missing file. [#16123](https://github.com/JabRef/jabref/issues/16123)
 - We fixed an issue with the LibreOffice integration where the ordering for numeric CSL styles in footnotes was broken. [#12484](https://github.com/JabRef/jabref/issues/12484)
 - We fixed an issue where `git push` did not report rejected remote updates. [#16367](https://github.com/JabRef/jabref/pull/16367)

--- a/jablib/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/jablib/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -84,13 +84,6 @@ public class URLDownload {
     // Can be null if SSL is not supported. If null, then ignore.
     private @Nullable SSLContext sslContext;
 
-    static {
-        Unirest.config()
-               .followRedirects(true)
-               .enableCookieManagement(true)
-               .setDefaultHeader("User-Agent", USER_AGENT);
-    }
-
     /// @param source the URL to download from
     /// @throws MalformedURLException if no protocol is specified in the source, or an unknown protocol is found
     public URLDownload(String source) throws MalformedURLException {
@@ -181,8 +174,7 @@ public class URLDownload {
     ///
     /// @return the status code of the response
     public boolean canBeReached() throws UnirestException {
-
-        int statusCode = Unirest.head(source.toString()).asString().getStatus();
+        int statusCode = Unirest.head(source.toString()).headers(parameters).asString().getStatus();
         return (statusCode >= 200) && (statusCode < 300);
     }
 

--- a/jablib/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/jablib/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -66,6 +66,9 @@ import org.slf4j.LoggerFactory;
 /// which uses an already opened connection).
 ///
 /// Nothing is cached.
+///
+/// Implentation note: This relies on <https://kong.github.io/unirest-java/configuration/> setting `followRedirects` to `true`
+/// and enabling cookie management.
 public class URLDownload {
 
     public static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0";

--- a/jablib/src/test/java/org/jabref/logic/ai/models/AiModelServiceTest.java
+++ b/jablib/src/test/java/org/jabref/logic/ai/models/AiModelServiceTest.java
@@ -2,10 +2,8 @@ package org.jabref.logic.ai.models;
 
 import java.util.List;
 
-import org.jabref.logic.net.URLDownload;
 import org.jabref.model.ai.llm.AiProvider;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -16,17 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class AiModelServiceTest {
 
     private AiModelService aiModelService;
-
-    @BeforeAll
-    static void ensureUnirestInitialized() {
-        // Ensure URLDownload's static initializer runs before any tests
-        // This configures Unirest and prevents UnirestConfigException
-        try {
-            Class.forName(URLDownload.class.getName());
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Failed to initialize URLDownload", e);
-        }
-    }
 
     @BeforeEach
     void setUp() {

--- a/jablib/src/test/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProviderTest.java
+++ b/jablib/src/test/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProviderTest.java
@@ -3,29 +3,19 @@ package org.jabref.logic.ai.models;
 import java.util.List;
 
 import org.jabref.logic.net.URLDownload;
+import org.jabref.logic.util.URLUtil;
 import org.jabref.model.ai.llm.AiProvider;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OpenAiCompatibleModelProviderTest {
 
     private OpenAiCompatibleModelProvider provider;
-
-    @BeforeAll
-    static void ensureUnirestInitialized() {
-        // Ensure URLDownload's static initializer runs before any tests
-        // This configures Unirest and prevents UnirestConfigException
-        try {
-            Class.forName(URLDownload.class.getName());
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Failed to initialize URLDownload", e);
-        }
-    }
 
     @BeforeEach
     void setUp() {
@@ -147,5 +137,12 @@ class OpenAiCompatibleModelProviderTest {
             assertTrue(models.isEmpty(),
                     "Provider " + provider + " should return empty list for blank API key");
         }
+    }
+
+    @Test
+    void urlDownloadCanBeInitializedAfterModelFetchingUsesUnirest() {
+        provider.fetchModels(AiProvider.OPEN_AI, "http://127.0.0.1:1", "test-key");
+
+        assertDoesNotThrow(() -> new URLDownload(URLUtil.create("https://example.org")));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProviderTest.java
+++ b/jablib/src/test/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProviderTest.java
@@ -138,11 +138,4 @@ class OpenAiCompatibleModelProviderTest {
                     "Provider " + provider + " should return empty list for blank API key");
         }
     }
-
-    @Test
-    void urlDownloadCanBeInitializedAfterModelFetchingUsesUnirest() {
-        provider.fetchModels(AiProvider.OPEN_AI, "http://127.0.0.1:1", "test-key");
-
-        assertDoesNotThrow(() -> new URLDownload(URLUtil.create("https://example.org")));
-    }
 }

--- a/jablib/src/test/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProviderTest.java
+++ b/jablib/src/test/java/org/jabref/logic/ai/models/OpenAiCompatibleModelProviderTest.java
@@ -2,14 +2,11 @@ package org.jabref.logic.ai.models;
 
 import java.util.List;
 
-import org.jabref.logic.net.URLDownload;
-import org.jabref.logic.util.URLUtil;
 import org.jabref.model.ai.llm.AiProvider;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 


### PR DESCRIPTION
### Related issues and pull requests

Fixes https://github.com/JabRef/jabref/issues/16059 and the exception mentioned in the details below.
~Supersedes~ Relates to https://github.com/JabRef/jabref/pull/16384

### PR Description

Remove `URLDownload`’s global `Unirest` configuration.
AI model fetching and URL downloads no longer conflict on initialization order.
 
If `Unirest` is already active, its static initializer throws an exception and the JVM marks the class unusable (see exception in details below, originally reported by @InAnYan)
What happens now is that the first code path that "uses" `Unirest` activates its global primary instance, later callers reuse it. No more static init.

<details>

```java
java.util.concurrent.CompletionException: java.lang.NoClassDefFoundError: Could not initialize class org.jabref.logic.net.URLDownload
	at java.base/java.util.concurrent.CompletableFuture.wrapInCompletionException(CompletableFuture.java:323)
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:359)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:364)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1791)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.lang.NoClassDefFoundError: Could not initialize class org.jabref.logic.net.URLDownload
	at org.jabref.jablib/org.jabref.logic.importer.WebFetcher.getUrlDownload(WebFetcher.java:33)
	at org.jabref.jablib/org.jabref.logic.importer.fetcher.DoiFetcher.getAgency(DoiFetcher.java:228)
	at org.jabref.jablib/org.jabref.logic.importer.fetcher.DoiFetcher.doAPILimiting(DoiFetcher.java:95)
	at org.jabref.jablib/org.jabref.logic.importer.fetcher.DoiFetcher.asyncPerformSearchById(DoiFetcher.java:108)
	at org.jabref.jablib/org.jabref.logic.importer.fetcher.ArXivFetcher.inplaceAsyncInfuseArXivWithDoi(ArXivFetcher.java:299)
	at org.jabref.jablib/org.jabref.logic.importer.fetcher.ArXivFetcher.inplaceAsyncInfuseArXivWithDoi(ArXivFetcher.java:274)
	at org.jabref.jablib/org.jabref.logic.importer.fetcher.ArXivFetcher.lambda$enrichPageWithDoi$1(ArXivFetcher.java:360)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1789)
	... 3 more
Caused by: java.lang.ExceptionInInitializerError: Exception kong.unirest.core.UnirestConfigException: Http Clients are already built in order to build a new config execute Unirest.config().reset() before changing settings. 
This should be done rarely. [in thread "pool-12-thread-6"]
	at unirest.java.core@4.10.1/kong.unirest.core.Config.validateClientsNotRunning(Config.java:980)
	at unirest.java.core@4.10.1/kong.unirest.core.Config.followRedirects(Config.java:530)
	at org.jabref.jablib/org.jabref.logic.net.URLDownload.<clinit>(URLDownload.java:89)
	... 11 more
```
</details>

### Steps to test

I don't exactly remember. Perhaps we needed to open Preferences, and then try out ArXiV search. But maybe it needed an OpenAI key configured. @InAnYan can you try it out and fill in here?

### AI usage

Mostly my mammalian brain, but also some usage of GPT 5.4 for exploration/verification of the code paths.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
