### PR TITLE
Shorten time for unassignment

### DIFF
--- a/.github/workflows/unassign-issues.yml
+++ b/.github/workflows/unassign-issues.yml
@@ -41,7 +41,7 @@ jobs:
             </details>
 
             We appreciate your contribution and are here to help if needed!
-          days_until_unassign: 14
+          days_until_unassign: 8
           unassigned_text: |
             ### 📋 Assignment Update
 


### PR DESCRIPTION
### Related issues and pull requests

Triggered by https://github.com/JabRef/jabref/issues/16123#issuecomment-4948606037

### PR Description

Each comment on an issue resets the timer.

Contributors eagerly grabbing issues typically either work directly or do nothing.

Thus, a week timeout seems more than enough - and our recent two weeks way too muzch.

### Steps to test

Merge and see the bot

### AI usage

🧠

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
