### PR TITLE
Add existing space-awareness to "add space after citation"

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/BSTCitationOOAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/BSTCitationOOAdapter.java
@@ -75,11 +75,12 @@ public class BSTCitationOOAdapter {
         };
 
         OOText ooText = OOFormat.setLocaleNone(OOText.fromString(citationText));
-        boolean preceedingSpaceExists = checkPreceedingSpace(cursor);
+        boolean precedingSpaceExists = CitationOOAdapterUtils.hasPrecedingSpace(cursor);
+        boolean succeedingSpaceExists = CitationOOAdapterUtils.hasSucceedingSpace(cursor);
         markManager.insertReferenceIntoOO(
                 entries, document, cursor, ooText,
-                !preceedingSpaceExists && openOfficePreferences.getAddSpaceBefore(),
-                openOfficePreferences.getAddSpaceAfter(),
+                !precedingSpaceExists && openOfficePreferences.getAddSpaceBefore(),
+                !succeedingSpaceExists && openOfficePreferences.getAddSpaceAfter(),
                 CSLCitationType.NORMAL);
         markManager.setRealTimeNumberUpdateRequired(
                 openOfficePreferences.getBstCitationFormat() == BstCitationFormat.NUMERIC);
@@ -242,14 +243,5 @@ public class BSTCitationOOAdapter {
         Map<String, Integer> identifierToNumber = new LinkedHashMap<>();
         emittedKeyOrder.forEach((key, index) -> identifierToNumber.put(keyToIdentifier.getOrDefault(key, key), index));
         return identifierToNumber;
-    }
-
-    private boolean checkPreceedingSpace(XTextCursor cursor) {
-        XTextCursor checkCursor = cursor.getText().createTextCursorByRange(cursor.getStart());
-        if (!checkCursor.goLeft((short) 1, true)) {
-            return true;
-        }
-        String cursorString = checkCursor.getString();
-        return " ".equals(cursorString) || cursorString.matches("\\R");
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
@@ -403,28 +403,15 @@ public class CSLCitationOOAdapter {
                                   CSLCitationType citationType,
                                   BibDatabaseContext bibDatabaseContext)
             throws CreationException, com.sun.star.uno.Exception {
-        boolean preceedingSpaceExists;
-        XTextCursor checkCursor = cursor.getText().createTextCursorByRange(cursor.getStart());
-
-        // Check if we're at the start of the document - if yes we set the flag and don't insert a space
-        if (!checkCursor.goLeft((short) 1, true)) {
-            // We're at the start of the document
-            preceedingSpaceExists = true;
-        } else {
-            // If not at the start of document, check if there is a space before
-            preceedingSpaceExists = " ".equals(checkCursor.getString());
-            // If not a space, check if it's a paragraph break
-            if (!preceedingSpaceExists) {
-                preceedingSpaceExists = checkCursor.getString().matches("\\R");
-            }
-        }
+        boolean precedingSpaceExists = CitationOOAdapterUtils.hasPrecedingSpace(cursor);
+        boolean succeedingSpaceExists = CitationOOAdapterUtils.hasSucceedingSpace(cursor);
         markManager.insertReferenceIntoOO(
                 entries,
                 document,
                 cursor,
                 ooText,
-                !preceedingSpaceExists && openOfficePreferences.getAddSpaceBefore(),
-                openOfficePreferences.getAddSpaceAfter(),
+                !precedingSpaceExists && openOfficePreferences.getAddSpaceBefore(),
+                !succeedingSpaceExists && openOfficePreferences.getAddSpaceAfter(),
                 citationType,
                 bibDatabaseContext,
                 bibEntryTypesManager,

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CitationOOAdapterUtils.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CitationOOAdapterUtils.java
@@ -5,6 +5,7 @@ import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 class CitationOOAdapterUtils {
+    private static final String LINE_BREAK = "\\R";
 
     private CitationOOAdapterUtils() {
     }
@@ -22,7 +23,7 @@ class CitationOOAdapterUtils {
             proceedingSpaceExists = " ".equals(checkCursor.getString());
             // If not a space, check if it's a paragraph break
             if (!proceedingSpaceExists) {
-                proceedingSpaceExists = checkCursor.getString().matches("\\R");
+                proceedingSpaceExists = checkCursor.getString().matches(LINE_BREAK);
             }
         }
 
@@ -38,7 +39,7 @@ class CitationOOAdapterUtils {
         } else {
             succeedingSpaceExists = " ".equals(checkCursor.getString());
             if (!succeedingSpaceExists) {
-                succeedingSpaceExists = checkCursor.getString().matches("\\R");
+                succeedingSpaceExists = checkCursor.getString().matches(LINE_BREAK);
             }
         }
 

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CitationOOAdapterUtils.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CitationOOAdapterUtils.java
@@ -1,0 +1,47 @@
+package org.jabref.logic.openoffice.oocsltext;
+
+import com.sun.star.text.XTextCursor;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+class CitationOOAdapterUtils {
+
+    private CitationOOAdapterUtils() {
+    }
+
+    static boolean hasPrecedingSpace(XTextCursor cursor) {
+        boolean proceedingSpaceExists;
+        XTextCursor checkCursor = cursor.getText().createTextCursorByRange(cursor.getStart());
+
+        // Check if we're at the start of the document - if yes we set the flag and don't insert a space
+        if (!checkCursor.goLeft((short) 1, true)) {
+            // We're at the start of the document
+            return true;
+        } else {
+            // If not at the start of document, check if there is a space before
+            proceedingSpaceExists = " ".equals(checkCursor.getString());
+            // If not a space, check if it's a paragraph break
+            if (!proceedingSpaceExists) {
+                proceedingSpaceExists = checkCursor.getString().matches("\\R");
+            }
+        }
+
+        return proceedingSpaceExists;
+    }
+
+    static boolean hasSucceedingSpace(XTextCursor cursor) {
+        boolean succeedingSpaceExists;
+        XTextCursor checkCursor = cursor.getText().createTextCursorByRange(cursor.getStart());
+
+        if (!checkCursor.goRight((short) 1, true)) {
+            return true;
+        } else {
+            succeedingSpaceExists = " ".equals(checkCursor.getString());
+            if (!succeedingSpaceExists) {
+                succeedingSpaceExists = checkCursor.getString().matches("\\R");
+            }
+        }
+
+        return succeedingSpaceExists;
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CitationOOAdapterUtils.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CitationOOAdapterUtils.java
@@ -11,7 +11,7 @@ class CitationOOAdapterUtils {
     }
 
     static boolean hasPrecedingSpace(XTextCursor cursor) {
-        boolean proceedingSpaceExists;
+        boolean procedingSpaceExists;
         XTextCursor checkCursor = cursor.getText().createTextCursorByRange(cursor.getStart());
 
         // Check if we're at the start of the document - if yes we set the flag and don't insert a space
@@ -20,14 +20,14 @@ class CitationOOAdapterUtils {
             return true;
         } else {
             // If not at the start of document, check if there is a space before
-            proceedingSpaceExists = " ".equals(checkCursor.getString());
+            procedingSpaceExists = " ".equals(checkCursor.getString());
             // If not a space, check if it's a paragraph break
-            if (!proceedingSpaceExists) {
-                proceedingSpaceExists = checkCursor.getString().matches(LINE_BREAK);
+            if (!procedingSpaceExists) {
+                procedingSpaceExists = checkCursor.getString().matches(LINE_BREAK);
             }
         }
 
-        return proceedingSpaceExists;
+        return procedingSpaceExists;
     }
 
     static boolean hasSucceedingSpace(XTextCursor cursor) {


### PR DESCRIPTION
### Related issues and pull requests

Closes #16385

### PR Description
Now, if there is a space after the text, inserting a citation will not add a space after the text. 
We also extracted the common logic between CSL and BST into a utility class.

### Steps to test
To be filled

### AI usage
🧠
_____

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
