### PR TITLE
Recognize ftp:// and ftps:// in LinkedFile.isOnlineLink()

### DIFF
--- a/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -36,7 +36,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public class LinkedFile implements Serializable {
 
-    private static final String REGEX_URL = "^((?:https?\\:\\/\\/|www\\.)(?:[-a-z0-9]+\\.)*[-a-z0-9]+.*)";
+    private static final String REGEX_URL = "^((?:https?\\:\\/\\/|ftps?\\:\\/\\/|www\\.)(?:[-a-z0-9]+\\.)*[-a-z0-9]+.*)";
     private static final Pattern URL_PATTERN = Pattern.compile(REGEX_URL);
 
     private static final LinkedFile NULL_OBJECT = new LinkedFile("", Path.of(""), "");
@@ -192,9 +192,9 @@ public class LinkedFile implements Serializable {
     }
 
     /// Checks if the given String is an online link
-    ///
+    /// Recognizes http://, https://, ftp://, ftps://, and www. prefixes.
     /// @param toCheck The String to check
-    /// @return `true`, if it starts with "http://", "https://" or contains "www."; `false` otherwise
+    /// @return `true`, if it starts with "http://", "https://", "ftp://", "ftps://" or contains "www."; `false` otherwise
     public static boolean isOnlineLink(String toCheck) {
         String normalizedFilePath = toCheck.trim().toLowerCase();
         return URL_PATTERN.matcher(normalizedFilePath).matches();

--- a/jablib/src/test/java/org/jabref/model/entry/LinkedFileTest.java
+++ b/jablib/src/test/java/org/jabref/model/entry/LinkedFileTest.java
@@ -1,0 +1,28 @@
+package org.jabref.model.entry;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LinkedFileTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "http://example.com/paper.pdf, true",
+            "https://example.com/paper.pdf, true",
+            "ftp://ftp.example.com/paper.pdf, true",
+            "ftps://ftp.example.com/paper.pdf, true",
+            "www.example.com/paper.pdf, true",
+            "HTTP://EXAMPLE.COM/paper.pdf, true",
+            "FTP://FTP.EXAMPLE.COM/paper.pdf, true",
+            "HTTPS://EXAMPLE.COM/paper.pdf, true",
+            "/local/path/file.pdf, false",
+            "C:\\Users\\file.pdf, false",
+            "file.txt, false",
+            "'', false"
+    })
+    void isOnlineLinkRecognizesFtp(String link, boolean expected) {
+        assertEquals(expected, LinkedFile.isOnlineLink(link));
+    }
+}


### PR DESCRIPTION
Related issues and pull requests
Closes #16400

Just a missing protocol in the regex, fixing it.

PR Description
LinkedFile.isOnlineLink() only matched http://, https://, and www. links, so ftp:// URLs were treated as local file paths. This caused cleanup, integrity checks, and file lookup to misbehave for FTP links.

I added ftps?:// to the URL_PATTERN regex so it also catches ftp:// and ftps://, making it consistent with URLUtil. Added a LinkedFileTest with cases for FTP links, case insensitivity, and local paths.

Steps to test
Bug present without this PR. To trigger it:

1. Create a BibEntry with a linked file using ftp://ftp.example.com/paper.pdf
2. Try cleanup actions — they will attempt to move/rename it as a local file
3. Check the context menu — it shows "Open folder" instead of "Download file"

With this PR, ftp:// links are correctly treated as online links.

AI usage
Used claude Chat to guide the regex change and test setup. All code was reviewed and is owned by me.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)