### PR TITLE
CI: Restore previous merge queue workflow

### DIFF
--- a/.github/workflows/on-pr-awaiting-second-review-check.yml
+++ b/.github/workflows/on-pr-awaiting-second-review-check.yml
@@ -1,7 +1,6 @@
 name: Await second review
 
 on:
-  merge_group:
   pull_request_target:
     types:
       - opened
@@ -29,17 +28,6 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            if (context.eventName === 'merge_group') {
-              // A merge group may batch several PRs and its payload carries no PR number,
-              // so the label check cannot run here. It already gated queue entry via the
-              // pull_request_target run, which must be green before a PR can be queued.
-              await core.summary
-                .addHeading('Await second review')
-                .addRaw('Merge group event: requirement was already enforced before the PR entered the merge queue.\n')
-                .write();
-              return;
-            }
-
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const pullNumber = context.payload.pull_request?.number;

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -694,6 +694,10 @@ jobs:
               'changelog-unreleased-only',
               'tests-windows',
             ]);
+            const ownerGated = new Set([
+              'tests-windows',
+              'databasetests',
+            ]);
             const alwaysRequired = new Set([
               'changes',
               'markdown',
@@ -706,6 +710,9 @@ jobs:
             const failedJobs = Object.entries(needs)
               .filter(([job, result]) => {
                 if (result.result === 'success') {
+                  return false;
+                }
+                if (result.result === 'skipped' && ownerGated.has(job) && context.repo.owner !== 'JabRef') {
                   return false;
                 }
                 if (result.result === 'skipped' && context.eventName !== 'pull_request' && pullRequestOnly.has(job)) {

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -41,44 +41,7 @@ jobs:
           name: pr_number
           path: pr_number.txt
 
-  changes:
-    name: Detect relevant source changes
-    runs-on: ubuntu-slim
-    outputs:
-      run-gradle-ci: ${{ steps.determine.outputs.run-gradle-ci }}
-    steps:
-      - uses: actions/checkout@v7
-        if: github.event_name != 'workflow_dispatch'
-        with:
-          fetch-depth: 0
-          show-progress: 'false'
-      - id: changed-non-workflow-files
-        if: github.event_name != 'workflow_dispatch'
-        uses: tj-actions/changed-files@v47
-        with:
-          files_ignore: |
-            .github/workflows/**
-      - id: changed-tests-code-workflow
-        if: github.event_name != 'workflow_dispatch'
-        uses: tj-actions/changed-files@v47
-        with:
-          files: |
-            .github/workflows/tests-code.yml
-      - name: Determine whether Gradle jobs should run
-        id: determine
-        shell: bash
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "run-gradle-ci=true" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ steps.changed-non-workflow-files.outputs.any_changed }}" == "true" || "${{ steps.changed-tests-code-workflow.outputs.any_changed }}" == "true" ]]; then
-            echo "run-gradle-ci=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run-gradle-ci=false" >> "$GITHUB_OUTPUT"
-          fi
-
   dependencyscopes:
-    needs: changes
-    if: needs.changes.outputs.run-gradle-ci == 'true'
     name: Dependency Scopes
     # too slow on ubuntu-slim
     runs-on: ubuntu-latest
@@ -93,8 +56,6 @@ jobs:
         run: gradle checkAllModuleInfo
 
   format:
-    needs: changes
-    if: needs.changes.outputs.run-gradle-ci == 'true'
     # ubuntu-slim doesn't offer docker
     runs-on: ubuntu-latest
     steps:
@@ -106,8 +67,6 @@ jobs:
           artifact-name: formatting-fix-patch
 
   format-javadoc:
-    needs: changes
-    if: needs.changes.outputs.run-gradle-ci == 'true'
     # too slow on ubuntu-slim
     runs-on: ubuntu-latest
     steps:
@@ -136,8 +95,7 @@ jobs:
     name: Checkstyle
     # too slow on ubuntu-slim
     runs-on: ubuntu-latest
-    needs: [ changes, format ]
-    if: needs.changes.outputs.run-gradle-ci == 'true'
+    needs: format
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
@@ -152,8 +110,7 @@ jobs:
     name: OpenRewrite
     # too slow on ubuntu-slim
     runs-on: ubuntu-latest
-    needs: [ changes, checkstyle ]
-    if: needs.changes.outputs.run-gradle-ci == 'true'
+    needs: checkstyle
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
@@ -178,8 +135,6 @@ jobs:
   modernizer:
     name: Modernizer
     # too slow on ubuntu-slim
-    needs: changes
-    if: needs.changes.outputs.run-gradle-ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -338,8 +293,6 @@ jobs:
             <(git show HEAD:CHANGELOG.md | clparse --format=json --separator=– - | jq '.releases[] | select(.version != null)')
 
   javadoc:
-    needs: changes
-    if: needs.changes.outputs.run-gradle-ci == 'true'
     name: JavaDoc
     # Sometimes takes longer than 15 minutes, therefore not ubuntu-slim
     runs-on: ubuntu-latest
@@ -353,8 +306,6 @@ jobs:
       - run: gradle javadoc
 
   tests:
-    needs: changes
-    if: needs.changes.outputs.run-gradle-ci == 'true'
     name: "Unit tests – ${{ matrix.module }}"
     runs-on: ubuntu-latest
     strategy:
@@ -382,10 +333,8 @@ jobs:
         run: scripts/after-failure.sh
 
   tests-windows:
-    needs: changes
     name: "Unit tests (Windows)"
     if: >
-      needs.changes.outputs.run-gradle-ci == 'true' &&
       github.repository_owner == 'JabRef' &&
       (
         github.event_name == 'push' ||
@@ -409,8 +358,6 @@ jobs:
           CI: "true"
 
   tests-windows-file-based:
-    needs: changes
-    if: needs.changes.outputs.run-gradle-ci == 'true'
     name: "Unit tests (Windows) - file-based"
     runs-on: windows-latest
     steps:
@@ -438,8 +385,6 @@ jobs:
           CI: "true"
 
   tests-jabkit-smoke:
-    needs: changes
-    if: needs.changes.outputs.run-gradle-ci == 'true'
     name: "JabKit Smoke Test"
     # too slow on ubuntu-slim
     runs-on: ubuntu-latest
@@ -453,8 +398,7 @@ jobs:
       - run: gradle :jabkit:runJabKitPortableSmokeTest
 
   databasetests:
-    needs: changes
-    if: github.repository_owner == 'JabRef' && needs.changes.outputs.run-gradle-ci == 'true'
+    if: (github.repository_owner == 'JabRef')
     name: Database tests
     runs-on: ubuntu-latest
     services:
@@ -484,8 +428,7 @@ jobs:
           DBMS: "postgresql"
 
   publish:
-    needs: changes
-    if: github.ref == 'refs/heads/main' && needs.changes.outputs.run-gradle-ci == 'true'
+    if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/publish.yml
     secrets:
       KOPPOR_SIGNING_SECRETKEYRINGFILE_BASE64: ${{ secrets.KOPPOR_SIGNING_SECRETKEYRINGFILE_BASE64 }}
@@ -510,10 +453,9 @@ jobs:
         uses: ./.github/actions/jbang-check
 
   jbang-pr:
-    needs: changes
     name: JBang (PR)
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main' && needs.changes.outputs.run-gradle-ci == 'true'
+    if: github.ref != 'refs/heads/main'
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
@@ -609,8 +551,6 @@ jobs:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   requirements_coverage:
-    needs: changes
-    if: needs.changes.outputs.run-gradle-ci == 'true'
     name: "Validate requirement coverage"
     runs-on: ubuntu-slim
     steps:
@@ -656,72 +596,3 @@ jobs:
             exit 1
           fi
           echo "✅ gradlew.bat blob is LF"
-
-  pr-gate:
-    name: PR gate
-    needs:
-      - changes
-      - dependencyscopes
-      - format
-      - format-javadoc
-      - checkstyle
-      - openrewrite
-      - modernizer
-      - markdown
-      - madr
-      - changelog
-      - changelog-unreleased-only
-      - javadoc
-      - tests
-      - tests-windows
-      - tests-windows-file-based
-      - tests-jabkit-smoke
-      - databasetests
-      - jbang-pr
-      - requirements_coverage
-      - gradlevalidation
-      - line_endings
-    if: always()
-    runs-on: ubuntu-slim
-    steps:
-      - name: Verify required checks
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const needs = ${{ toJSON(needs) }};
-            const runGradleCI = '${{ needs.changes.outputs.run-gradle-ci }}' === 'true';
-            const pullRequestOnly = new Set([
-              'changelog-unreleased-only',
-              'tests-windows',
-            ]);
-            const ownerGated = new Set([
-              'tests-windows',
-              'databasetests',
-            ]);
-            const alwaysRequired = new Set([
-              'changes',
-              'markdown',
-              'madr',
-              'changelog',
-              'gradlevalidation',
-              'line_endings',
-            ]);
-
-            const failedJobs = Object.entries(needs)
-              .filter(([job, result]) => {
-                if (result.result === 'success') {
-                  return false;
-                }
-                if (result.result === 'skipped' && ownerGated.has(job) && context.repo.owner !== 'JabRef') {
-                  return false;
-                }
-                if (result.result === 'skipped' && context.eventName !== 'pull_request' && pullRequestOnly.has(job)) {
-                  return false;
-                }
-                return runGradleCI || alwaysRequired.has(job);
-              })
-              .map(([job, result]) => `${job} (${result.result})`);
-
-            if (failedJobs.length > 0) {
-              core.setFailed(`Required checks did not succeed: ${failedJobs.join(', ')}`);
-            }

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -656,3 +656,65 @@ jobs:
             exit 1
           fi
           echo "✅ gradlew.bat blob is LF"
+
+  pr-gate:
+    name: PR gate
+    needs:
+      - changes
+      - dependencyscopes
+      - format
+      - format-javadoc
+      - checkstyle
+      - openrewrite
+      - modernizer
+      - markdown
+      - madr
+      - changelog
+      - changelog-unreleased-only
+      - javadoc
+      - tests
+      - tests-windows
+      - tests-windows-file-based
+      - tests-jabkit-smoke
+      - databasetests
+      - jbang-pr
+      - requirements_coverage
+      - gradlevalidation
+      - line_endings
+    if: always()
+    runs-on: ubuntu-slim
+    steps:
+      - name: Verify required checks
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const needs = ${{ toJSON(needs) }};
+            const runGradleCI = '${{ needs.changes.outputs.run-gradle-ci }}' === 'true';
+            const pullRequestOnly = new Set([
+              'changelog-unreleased-only',
+              'tests-windows',
+            ]);
+            const alwaysRequired = new Set([
+              'changes',
+              'markdown',
+              'madr',
+              'changelog',
+              'gradlevalidation',
+              'line_endings',
+            ]);
+
+            const failedJobs = Object.entries(needs)
+              .filter(([job, result]) => {
+                if (result.result === 'success') {
+                  return false;
+                }
+                if (result.result === 'skipped' && context.eventName !== 'pull_request' && pullRequestOnly.has(job)) {
+                  return false;
+                }
+                return runGradleCI || alwaysRequired.has(job);
+              })
+              .map(([job, result]) => `${job} (${result.result})`);
+
+            if (failedJobs.length > 0) {
+              core.setFailed(`Required checks did not succeed: ${failedJobs.join(', ')}`);
+            }


### PR DESCRIPTION
### Related issues and pull requests

Reverts the workflow changes from #16406 and #16403.

### PR Description

Restores the source-test workflow to its behavior before #16406, so its Gradle jobs run without source-change gating. It also removes the same-day merge-group success bypass from the second-review workflow, restoring the earlier merge-queue behavior.

### Second-review policy ideas 

- Native two-review rule: hard enforcement, applies to all PRs.
- Label-specific rule: PR-only bot can dequeue invalid PRs, but is not a hard branch rule.
- Required checks must run on merge groups; they cannot be required only on PRs.

Future idea: JabRef machine user can enforce the label-specific policy. On label or review changes, it disables auto-merge and dequeues labeled PRs lacking a second approval. Use a least-privilege token; keep PR code untrusted.



### Steps to test

1. Open the Actions run for a pull request or merge-group entry.
2. Confirm that the source-test jobs run without waiting for source-change detection.
3. Confirm that the second-review workflow no longer runs for merge-group events.

### AI usage

Codex (model GPT-5) was used to investigate and prepare this draft. The contributor must review, understand, and take ownership of the change before marking the PR ready for review.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

#### 1. Code self-review

- [/] No `== null` / `!= null` checks — workflow-only change.
- [/] No `Objects.requireNonNull(...)` — workflow-only change.
- [/] New classes annotated with `@NullMarked` — workflow-only change.
- [/] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — workflow-only change.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()` — workflow-only change.
- [/] No `catch (Exception e)` — workflow-only change.
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — workflow-only change.
- [/] Logged exceptions are passed as the last logger argument — workflow-only change.
- [/] New `BibEntry` objects built with withers — workflow-only change.
- [/] Modern Java used — workflow-only change.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant — workflow-only change.
- [/] Background work uses `BackgroundTask`, not `new Thread()` — workflow-only change.
- [x] No commented-out code, trivial comments, or AI-disclosure comments in source.
- [/] Markdown Javadoc uses Markdown syntax — workflow-only change.
- [/] All user-facing text localized — workflow-only change.
- [/] Sentence case, no trailing `!`, and labels do not end with `:` — workflow-only change.
- [/] Variance expressed with placeholders — workflow-only change.
- [/] User-controlled data is HTML-escaped before being written into HTML responses — workflow-only change.
- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests — workflow-only change.
- [/] Tests follow JabRef's JUnit conventions — workflow-only change.

#### 2. Verification commands

- [/] `./gradlew :jablib:check` — workflow-only change.
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh` — workflow-only change.
- [/] `./gradlew modernizer` — workflow-only change.
- [/] `./gradlew --no-configuration-cache :rewriteDryRun` — workflow-only change.
- [/] `./gradlew javadoc` — workflow-only change.
- [/] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` — no Markdown changed.
- [/] IntelliJ formatter — no Java changed.
- [x] `actionlint` passed for both workflows with the pre-existing disabled-coverage warning excluded; YAML syntax parsing passed.

#### 3. Documentation

- [/] `CHANGELOG.md` entry — internal CI behavior only.
- [x] Searched JabRef and jabref-koppor issues for a related issue; no confident issue matched.
- [/] Requirement added — minor internal CI fix.
- [/] Developer documentation updated — no user-facing or architectural documentation change.

#### 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, with every section filled.
- [x] All checklist items are retained and marked.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file`.
- [/] `CHANGELOG.md` contains no `TODO` placeholder.

</details>

### Checklist

- [ ] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (not applicable to this workflow-only change)
- [/] I added screenshots in the PR description (no user-visible change)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number (no user-visible change)
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (no user-visible change)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our user documentation repository (no user-visible change)
