### PR TITLE
Recognize ftp:// links in LinkedFile.isOnlineLink by delegating to UR…

### DIFF
--- a/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -28,6 +28,7 @@ import org.jabref.model.database.BibDatabaseContext;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.jabref.logic.util.URLUtil;
 
 /// Represents the link to an external file (e.g. associated PDF file).
 /// This class is {@link Serializable} which is needed for drag and drop in gui
@@ -194,10 +195,9 @@ public class LinkedFile implements Serializable {
     /// Checks if the given String is an online link
     ///
     /// @param toCheck The String to check
-    /// @return `true`, if it starts with "http://", "https://" or contains "www."; `false` otherwise
+    /// @return `true`, if it is a URL (http, https, ftp, ...); `false` otherwise
     public static boolean isOnlineLink(String toCheck) {
-        String normalizedFilePath = toCheck.trim().toLowerCase();
-        return URL_PATTERN.matcher(normalizedFilePath).matches();
+        return URLUtil.isURL(toCheck);
     }
 
     @Override

--- a/jablib/src/test/java/org/jabref/model/entry/LinkedFileTest.java
+++ b/jablib/src/test/java/org/jabref/model/entry/LinkedFileTest.java
@@ -1,0 +1,21 @@
+package org.jabref.model.entry;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LinkedFileTest {
+
+    @Test
+    void isOnlineLinkRecognizesVariousSchemes() {
+        assertTrue(LinkedFile.isOnlineLink("ftp://example.org/resource.pdf"));
+        assertTrue(LinkedFile.isOnlineLink("http://example.org"));
+        assertTrue(LinkedFile.isOnlineLink("https://example.org"));
+        assertTrue(LinkedFile.isOnlineLink("www.example.org/somepath"));
+
+        assertFalse(LinkedFile.isOnlineLink("C:\\Users\\me\\file.pdf"));
+        assertFalse(LinkedFile.isOnlineLink(""));
+        assertFalse(LinkedFile.isOnlineLink(null));
+    }
+}


### PR DESCRIPTION
Body: Hi maintainers — this small change makes LinkedFile.isOnlineLink(...) treat ftp:// links the same way URLUtil does.

Why

LinkedFile previously only detected http(s) and www links which caused ftp:// links to be treated as local paths in some cases. URLUtil already recognizes ftp URLs, so this change removes the inconsistency.
What I changed

LinkedFile.isOnlineLink now delegates to URLUtil.isURL(...) so the definition of "online link" is centralized.
Added a unit test to verify ftp://, http(s), and www links are detected while local paths, empty strings, and null are not.