### PR TITLE
Re-create Await second review

### DIFF
--- a/.github/workflows/on-pr-awaiting-second-review-check.yml
+++ b/.github/workflows/on-pr-awaiting-second-review-check.yml
@@ -32,15 +32,14 @@ jobs:
               return;
             }
 
-            // refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>
-            const headRef = context.payload.merge_group.head_ref ?? '';
-            let match = headRef.match(/\/pr-(\d+)-[0-9a-f]+$/);
+            // gh-readonly-queue/<base>/pr-<N>-<sha>, same parsing as on-pr-merge-queued.yml.
+            // The commit message is deliberately not used as a fallback: it can carry
+            // unrelated "#123" references and would then enforce against the wrong PR.
+            const refName = process.env.GITHUB_REF_NAME ?? '';
+            const headRef = context.payload.merge_group?.head_ref ?? '';
+            const match = refName.match(/(?:^|\/)pr-(\d+)-/) ?? headRef.match(/(?:^|\/)pr-(\d+)-/);
             if (!match) {
-              // Fallback: "Merge pull request #N from ..."
-              match = (context.payload.merge_group.head_commit?.message ?? '').match(/#(\d+)/);
-            }
-            if (!match) {
-              core.setFailed(`Could not determine PR number from merge group (head_ref: "${headRef}").`);
+              core.setFailed(`Could not determine PR number from merge group (GITHUB_REF_NAME: "${refName}", head_ref: "${headRef}").`);
               return;
             }
             const pullNumber = Number(match[1]);

--- a/.github/workflows/on-pr-awaiting-second-review-check.yml
+++ b/.github/workflows/on-pr-awaiting-second-review-check.yml
@@ -66,6 +66,12 @@ jobs:
               per_page: 100,
             });
 
+            // The loop below is last-write-wins, so the order has to be oldest-first.
+            // Review ids increase with submission time and are always set, unlike
+            // submitted_at. The API happens to return this order already; relying on
+            // that would make the approval count depend on undocumented behaviour.
+            reviews.sort((a, b) => a.id - b.id);
+
             const latestOpinionatedReviewStateByUser = new Map();
             for (const review of reviews) {
               const login = review.user?.login;

--- a/.github/workflows/on-pr-awaiting-second-review-check.yml
+++ b/.github/workflows/on-pr-awaiting-second-review-check.yml
@@ -1,0 +1,90 @@
+name: Await second review
+
+on:
+  # PR-level runs are unconditional stamps: GitHub requires every required check
+  # to report success on the current PR head SHA before the PR can enter the
+  # merge queue. Types are the GitHub defaults, listed explicitly on purpose:
+  # "synchronize" is critical (each push creates a new head SHA needing a stamp).
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  # Enforcement happens here, where label and review state are settled.
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  require-second-approval:
+    name: Require second approval
+    if: github.repository == 'JabRef/jabref'
+    runs-on: ubuntu-slim
+    steps:
+      - name: Check whether a second approval is required
+        uses: actions/github-script@v9
+        with:
+          script: |
+            if (context.eventName !== 'merge_group') {
+              // Stamp only. Carries no state, so it can never be stale or wrong.
+              return;
+            }
+
+            // refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>
+            const headRef = context.payload.merge_group.head_ref ?? '';
+            let match = headRef.match(/\/pr-(\d+)-[0-9a-f]+$/);
+            if (!match) {
+              // Fallback: "Merge pull request #N from ..."
+              match = (context.payload.merge_group.head_commit?.message ?? '').match(/#(\d+)/);
+            }
+            if (!match) {
+              core.setFailed(`Could not determine PR number from merge group (head_ref: "${headRef}").`);
+              return;
+            }
+            const pullNumber = Number(match[1]);
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const requiredLabel = 'status: awaiting-second-review';
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+
+            if (!pullRequest.labels.some((label) => label.name === requiredLabel)) {
+              core.info(`PR #${pullNumber}: label "${requiredLabel}" not present, nothing to enforce.`);
+              return;
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+
+            const latestOpinionatedReviewStateByUser = new Map();
+            for (const review of reviews) {
+              const login = review.user?.login;
+              if (!login || login === pullRequest.user.login) {
+                continue;
+              }
+              if (['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(review.state)) {
+                latestOpinionatedReviewStateByUser.set(login, review.state);
+              }
+            }
+
+            const approvers = [...latestOpinionatedReviewStateByUser.entries()]
+              .filter(([, state]) => state === 'APPROVED')
+              .map(([login]) => login);
+
+            core.info(`PR #${pullNumber}: approvers: ${approvers.join(', ') || 'none'}`);
+
+            if (approvers.length < 2) {
+              core.setFailed(`PR #${pullNumber} has label "${requiredLabel}" but only ${approvers.length} approval(s). It will be removed from the merge queue.`);
+            }
+    


### PR DESCRIPTION
### Related issues and pull requests

Follow-up to https://github.com/JabRef/jabref/pull/16432

### PR Description

I think, the check should be in the merge-group and failing there so that the PR is put out of the merge group.

Rewritten `.github/workflows/on-pr-awaiting-second-review-check.yml` accordingly.

After this is merged, the "Require second approval" should be a mandatory check.

### Steps to test

See CI passing.

### AI usage

Full use of Claude - except this text.

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
