### PR TITLE
madrlint check: Explicitly install JDK to speed up CI

### DIFF
--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -254,6 +254,10 @@ jobs:
         uses: jbangdev/setup-jbang@2b1b465a7b75f4222b81426f23a01e013aa7b95c # v0.1.1
       - name: Trust madrlint source
         run: jbang trust add https://github.com/adr/
+      - uses: actions/setup-java@v6
+        with:
+          distribution: 'corretto'
+          java-version: '25'
       - name: Lint ADRs
         # madrlint is pinned to a commit (not the moving `madrlint@adr/madrlint` alias) so
         # upstream changes cannot alter lint results without a deliberate bump here.

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -249,15 +249,15 @@ jobs:
           key: ${{ steps.cache-key.outputs.cache_key }}
           restore-keys:
             jbang-madrlint-
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'corretto'
+          java-version: '25'
       - name: Setup JBang
         # Pinned to a commit for deterministic CI; comment tracks the tag.
         uses: jbangdev/setup-jbang@2b1b465a7b75f4222b81426f23a01e013aa7b95c # v0.1.1
       - name: Trust madrlint source
         run: jbang trust add https://github.com/adr/
-      - uses: actions/setup-java@v6
-        with:
-          distribution: 'corretto'
-          java-version: '25'
       - name: Lint ADRs
         # madrlint is pinned to a commit (not the moving `madrlint@adr/madrlint` alias) so
         # upstream changes cannot alter lint results without a deliberate bump here.


### PR DESCRIPTION
### Summary

Triggered by

<img width="2136" height="524" alt="grafik" src="https://github.com/user-attachments/assets/f5b254d1-01f5-4af1-9372-dd22a2e38a0a" />

I think, JDK installation by GitHub is faster.

As of today, only Jva 21+ is required - https://github.com/adr/madrlint/blob/e37d19b6699e45dd1543bccd858f4f49af350e49/madrlint.java#L2

### Steps to test

See CI being faster

### AI usage

🧠

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
