### PR TITLE
Improve localization tests

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -917,8 +917,8 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
                 clipBoardManager.getJabRefClipboardTransferData(),
                 entriesToAdd,
                 bibDatabaseContext,
-                Localization.lang("Pasted %0 entry(s) to %1"),
-                Localization.lang("Pasted %0 entry(s) to %1. %2 were skipped"),
+                params -> Localization.lang("Pasted %0 entry(s) to %1", params),
+                params -> Localization.lang("Pasted %0 entry(s) to %1. %2 were skipped", params),
                 dialogService,
                 importHandler,
                 stateManager
@@ -948,8 +948,8 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
                 new TransferInformation(sourceBibDatabaseContext, TransferMode.NONE), // "NONE", because we don't know the modifiers here and thus cannot say whether the attached file (and entry(s)) should be copied or moved
                 entriesToAdd,
                 bibDatabaseContext,
-                Localization.lang("Moved %0 entry(s) to %1"),
-                Localization.lang("Moved %0 entry(s) to %1. %2 were skipped"),
+                params -> Localization.lang("Moved %0 entry(s) to %1", params),
+                params -> Localization.lang("Moved %0 entry(s) to %1. %2 were skipped", params),
                 dialogService,
                 importHandler,
                 stateManager

--- a/jabgui/src/main/java/org/jabref/gui/edit/CopyTo.java
+++ b/jabgui/src/main/java/org/jabref/gui/edit/CopyTo.java
@@ -89,8 +89,8 @@ public class CopyTo extends SimpleCommand {
                 new TransferInformation(sourceDatabaseContext, TransferMode.COPY),
                 entriesToAdd,
                 targetDatabaseContext,
-                Localization.lang("Copied %0 entry(s) to %1, including cross-references"),
-                Localization.lang("Copied %0 entry(s) to %1. %2 were skipped including cross-references"),
+                params -> Localization.lang("Copied %0 entry(s) to %1, including cross-references", params),
+                params -> Localization.lang("Copied %0 entry(s) to %1. %2 were skipped including cross-references", params),
                 dialogService,
                 importHandler,
                 stateManager
@@ -102,8 +102,8 @@ public class CopyTo extends SimpleCommand {
                 new TransferInformation(sourceDatabaseContext, TransferMode.COPY),
                 selectedEntries,
                 targetDatabaseContext,
-                Localization.lang("Copied %0 entry(s) to %1, without cross-references"),
-                Localization.lang("Copied %0 entry(s) to %1. %2 were skipped without cross-references"),
+                params -> Localization.lang("Copied %0 entry(s) to %1, without cross-references", params),
+                params -> Localization.lang("Copied %0 entry(s) to %1. %2 were skipped without cross-references", params),
                 dialogService,
                 importHandler,
                 stateManager

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -878,7 +878,7 @@ public class OOBibBase {
 
         if (!result.newDatabase.hasEntries()) {
             dialogService.showErrorDialogAndWait(
-                    Localization.lang(errorTitle),
+                    errorTitle,
                     Localization.lang("Your OpenOffice/LibreOffice document references"
                             + " no citation keys"
                             + " which could also be found in your current library."));
@@ -888,7 +888,7 @@ public class OOBibBase {
         List<String> unresolvedKeys = result.unresolvedKeys;
         if (!unresolvedKeys.isEmpty()) {
             dialogService.showErrorDialogAndWait(
-                    Localization.lang(errorTitle),
+                    errorTitle,
                     Localization.lang("Your OpenOffice/LibreOffice document references"
                                     + " at least %0 citation keys"
                                     + " which could not be found in your current library."

--- a/jabgui/src/main/java/org/jabref/gui/util/InsertUtil.java
+++ b/jabgui/src/main/java/org/jabref/gui/util/InsertUtil.java
@@ -15,12 +15,22 @@ import org.jspecify.annotations.Nullable;
 
 public class InsertUtil {
 
+    /// Renders a user feedback message for a given number of entries.
+    ///
+    /// Implementations have to call [Localization#lang(String, Object...)] with a **literal** key,
+    /// because the localization consistency tests can only detect literal keys.
+    @FunctionalInterface
+    public interface FeedbackMessage {
+        /// @param params Replacement strings for the parameters %0, %1, etc. of the message
+        String format(Object... params);
+    }
+
     /// @param jabRefClipboardTransferData - can be null if called via clipboard and clipboard content was NOT created by JabRef
     public static void addEntriesWithFeedback(@Nullable TransferInformation jabRefClipboardTransferData,
                                               List<BibEntry> entriesToAdd,
                                               BibDatabaseContext targetDatabaseContext,
-                                              String successMessage,
-                                              String partialMessage,
+                                              FeedbackMessage successMessage,
+                                              FeedbackMessage partialMessage,
                                               DialogService dialogService,
                                               ImportHandler importHandler,
                                               StateManager stateManager
@@ -35,11 +45,11 @@ public class InsertUtil {
                                                      .orElse(Localization.lang("target library"));
 
             if (importedCount == entriesToAdd.size()) {
-                dialogService.notify(Localization.lang(successMessage, String.valueOf(importedCount), targetName));
+                dialogService.notify(successMessage.format(importedCount, targetName));
             } else if (importedCount == 0) {
                 dialogService.notify(Localization.lang("No entry was copied to %0", targetName));
             } else {
-                dialogService.notify(Localization.lang(partialMessage, String.valueOf(importedCount), targetName, String.valueOf(skippedCount)));
+                dialogService.notify(partialMessage.format(importedCount, targetName, skippedCount));
             }
         });
 

--- a/jabgui/src/main/java/org/jabref/gui/util/InsertUtil.java
+++ b/jabgui/src/main/java/org/jabref/gui/util/InsertUtil.java
@@ -11,8 +11,10 @@ import org.jabref.model.TransferInformation;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public class InsertUtil {
 
     /// Renders a user feedback message for a given number of entries.

--- a/jabgui/src/main/java/org/jabref/gui/util/InsertUtil.java
+++ b/jabgui/src/main/java/org/jabref/gui/util/InsertUtil.java
@@ -22,6 +22,7 @@ public class InsertUtil {
     /// Implementations have to call [Localization#lang(String, Object...)] with a **literal** key,
     /// because the localization consistency tests can only detect literal keys.
     @FunctionalInterface
+    @NullMarked
     public interface FeedbackMessage {
         /// @param params Replacement strings for the parameters %0, %1, etc. of the message
         String format(Object... params);

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughAction.java
@@ -105,7 +105,7 @@ public class WalkthroughAction extends SimpleCommand {
                 )
                 .addStep(WalkthroughStep
                         .tooltip(Localization.lang("Click on \"Preferences\""))
-                        .resolver(NodeResolver.menuItem("Preferences"))
+                        .resolver(NodeResolver.menuItem(Localization.lang("Preferences")))
                         .trigger(Trigger.create().withWindowChangeListener().onClick())
                         .position(TooltipPosition.RIGHT)
                         .activeWindow(WindowResolver.clazz(ContextMenu.class))

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
@@ -19,7 +19,6 @@ import org.jabref.gui.walkthrough.declarative.step.PanelPosition;
 import org.jabref.gui.walkthrough.declarative.step.PanelStep;
 import org.jabref.gui.walkthrough.declarative.step.TooltipStep;
 import org.jabref.gui.walkthrough.declarative.step.VisibleComponent;
-import org.jabref.logic.l10n.Localization;
 
 /// Renders walkthrough steps and content blocks into JavaFX nodes.
 public class WalkthroughRenderer {
@@ -179,8 +178,9 @@ public class WalkthroughRenderer {
         return contentBox;
     }
 
+    /// @param text the already localized button text
     private Button makeButton(String text, String styleClass, Runnable beforeNavigate, Runnable navigationAction) {
-        Button button = new Button(Localization.lang(text));
+        Button button = new Button(text);
         button.getStyleClass().add(styleClass);
         button.setOnAction(_ -> {
             beforeNavigate.run();

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/declarative/NodeResolver.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/declarative/NodeResolver.java
@@ -15,7 +15,6 @@ import javafx.scene.control.MenuItem;
 import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.icon.JabRefIconView;
-import org.jabref.logic.l10n.Localization;
 
 import com.google.common.collect.Streams;
 import com.sun.javafx.scene.NodeHelper;
@@ -149,11 +148,11 @@ public interface NodeResolver {
                 )).findFirst();
     }
 
-    /// Creates a resolver that finds a menu item by its language key.
+    /// Creates a resolver that finds a menu item by its text.
     ///
-    /// @param key the language key of the menu item
-    /// @return a resolver that finds the menu item by language key
-    static NodeResolver menuItem(@NonNull String key) {
+    /// @param text the already localized text of the menu item
+    /// @return a resolver that finds the menu item by text
+    static NodeResolver menuItem(@NonNull String text) {
         return scene -> {
             if (!(scene.getWindow() instanceof ContextMenu menu)) {
                 return Optional.empty();
@@ -167,7 +166,7 @@ public interface NodeResolver {
                        .filter(item -> NodeResolver.isVisible(item.getStyleableNode()))
                        .filter(item -> Optional
                                .ofNullable(item.getText())
-                               .map(str -> str.contains(Localization.lang(key)))
+                               .map(str -> str.contains(text))
                                .orElse(false))
                        .map(MenuItem::getStyleableNode).findFirst();
         };

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/declarative/WindowResolver.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/declarative/WindowResolver.java
@@ -6,8 +6,6 @@ import java.util.Optional;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 
-import org.jabref.logic.l10n.Localization;
-
 import org.jspecify.annotations.NonNull;
 
 /// Resolves windows using various strategies.
@@ -20,14 +18,14 @@ public interface WindowResolver {
 
     /// Creates a resolver that finds a window by its title.
     ///
-    /// @param key the language key of the window title
+    /// @param title the already localized window title
     /// @return a resolver that finds the window by title
-    static WindowResolver title(@NonNull String key) {
+    static WindowResolver title(@NonNull String title) {
         return () -> Window.getWindows().stream()
                            .filter(Window::isShowing)
                            .filter(Stage.class::isInstance)
                            .map(Stage.class::cast)
-                           .filter(stage -> stage.getTitle().contains(Localization.lang(key)))
+                           .filter(stage -> stage.getTitle().contains(title))
                            .map(Window.class::cast)
                            .findFirst();
     }

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -97,8 +97,6 @@ Cancel=Cancel
 
 Case\ sensitive=Case sensitive
 
-change\ assignment\ of\ entries=change assignment of entries
-
 Change\ case=Change case
 
 Change\ entry\ type=Change entry type
@@ -579,7 +577,6 @@ Add\ subgroup=Add subgroup
 Modified\ group\ "%0".=Modified group "%0".
 Modified\ groups=Modified groups
 move\ group=move group
-Moved\ group\ "%0".=Moved group "%0".
 Please\ enter\ a\ name\ for\ the\ group.=Please enter a name for the group.
 No\ group=No group
 Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Refine supergroup: When selected, view entries contained in both this group and its supergroup
@@ -609,8 +606,6 @@ Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups=D
 Cannot\ create\ group=Cannot create group
 Cannot\ create\ group.\ Please\ create\ a\ library\ first.=Cannot create group. Please create a library first.
 Assign\ the\ original\ group's\ entries\ to\ this\ group?=Assign the original group's entries to this group?
-Assigned\ %0\ entries\ to\ group\ "%1".=Assigned %0 entries to group "%1".
-Assigned\ 1\ entry\ to\ group\ "%0".=Assigned 1 entry to group "%0".
 Automatically\ create\ groups=Automatically create groups
 Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Include subgroups: When selected, view entries contained in this group or its subgroups
 Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Independent group: When selected, view only this group's entries
@@ -977,8 +972,6 @@ New\ BibTeX\ sublibrary=New BibTeX sublibrary
 
 Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Switches between full and abbreviated journal name if the journal name is known.
 
-The\ group\ "%0"\ already\ contains\ the\ selection.=The group "%0" already contains the selection.
-
 This\ operation\ requires\ all\ selected\ entries\ to\ have\ citation\ keys\ defined.=This operation requires all selected entries to have citation keys defined.
 
 This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=This operation requires one or more entries to be selected.
@@ -1022,8 +1015,6 @@ Warnings=Warnings
 Warn\ before\ overwriting\ existing\ keys=Warn before overwriting existing keys
 Warning\:\ You\ added\ field\ "%0"\ twice.\ Only\ one\ will\ be\ kept.=Warning: You added field "%0" twice. Only one will be kept.
 Warning\:\ Current\ properties\ are\ the\ same\ as\ before.=Warning: Current properties are the same as before.
-
-web\ link=web link
 
 What\ do\ you\ want\ to\ do?=What do you want to do?
 Whatever\ option\ you\ choose,\ Mr.\ DLib\ may\ share\ its\ data\ with\ research\ partners\ to\ further\ improve\ recommendation\ quality\ as\ part\ of\ a\ 'living\ lab'.\ Mr.\ DLib\ may\ also\ release\ public\ datasets\ that\ may\ contain\ anonymized\ information\ about\ you\ and\ the\ recommendations\ (sensitive\ information\ such\ as\ metadata\ of\ your\ articles\ will\ be\ anonymised\ through\ e.g.\ hashing).\ Research\ partners\ are\ obliged\ to\ adhere\ to\ the\ same\ strict\ data\ protection\ policy\ as\ Mr.\ DLib.=Whatever option you choose, Mr. DLib may share its data with research partners to further improve recommendation quality as part of a 'living lab'. Mr. DLib may also release public datasets that may contain anonymized information about you and the recommendations (sensitive information such as metadata of your articles will be anonymised through e.g. hashing). Research partners are obliged to adhere to the same strict data protection policy as Mr. DLib.
@@ -1417,7 +1408,6 @@ Could\ not\ open\ browser.=Could not open browser.
 Please\ open\ %0\ manually.=Please open %0 manually.
 The\ link\ has\ been\ copied\ to\ the\ clipboard.=The link has been copied to the clipboard.
 
-Open\ %0\ file=Open %0 file
 Could\ not\ detect\ terminal\ automatically\ using\ '%0'.\ Please\ define\ a\ custom\ terminal\ in\ the\ preferences.=Could not detect terminal automatically using '%0'. Please define a custom terminal in the preferences.
 
 Convert=Convert

--- a/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParser.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParser.java
@@ -74,8 +74,11 @@ class JavaLocalizationEntryParser {
         return languageKey;
     }
 
-    public static List<String> getLocalizationParameter(String content, LocalizationBundleForTest type) {
+    public static List<String> getLocalizationParameter(String rawContent, LocalizationBundleForTest type) {
         List<String> result = new ArrayList<>();
+
+        // Comments may contain `Localization.lang(...)` snippets, which are no real usages.
+        String content = blankOutComments(rawContent);
 
         Matcher matcher;
         if (type == LocalizationBundleForTest.LANG) {
@@ -106,5 +109,69 @@ class JavaLocalizationEntryParser {
         }
 
         return result;
+    }
+
+    /// Replaces the content of all Java comments (`//`, `///`, `/* */`, javadoc) by spaces.
+    /// Newlines are kept, so that the result has the same length as the input and the same line structure.
+    /// String literals, text blocks, and character literals are left untouched -
+    /// a `//` inside a string (e.g., a URL) does not start a comment.
+    static String blankOutComments(String source) {
+        char[] chars = source.toCharArray();
+        int length = chars.length;
+        int i = 0;
+        while (i < length) {
+            char current = chars[i];
+            char next = (i + 1) < length ? chars[i + 1] : '\0';
+            if ((current == '/') && (next == '/')) {
+                while ((i < length) && (chars[i] != '\n')) {
+                    chars[i] = ' ';
+                    i++;
+                }
+            } else if ((current == '/') && (next == '*')) {
+                chars[i] = ' ';
+                chars[i + 1] = ' ';
+                i += 2;
+                while (i < length) {
+                    if ((chars[i] == '*') && ((i + 1) < length) && (chars[i + 1] == '/')) {
+                        chars[i] = ' ';
+                        chars[i + 1] = ' ';
+                        i += 2;
+                        break;
+                    }
+                    if (chars[i] != '\n') {
+                        chars[i] = ' ';
+                    }
+                    i++;
+                }
+            } else if ((current == '"') && (next == '"') && ((i + 2) < length) && (chars[i + 2] == '"')) {
+                // text block
+                i += 3;
+                while (i < length) {
+                    if (chars[i] == '\\') {
+                        i += 2;
+                    } else if ((chars[i] == '"') && ((i + 2) < length) && (chars[i + 1] == '"') && (chars[i + 2] == '"')) {
+                        i += 3;
+                        break;
+                    } else {
+                        i++;
+                    }
+                }
+            } else if ((current == '"') || (current == '\'')) {
+                i++;
+                while (i < length) {
+                    if (chars[i] == '\\') {
+                        i += 2;
+                    } else if (chars[i] == current) {
+                        i++;
+                        break;
+                    } else {
+                        i++;
+                    }
+                }
+            } else {
+                i++;
+            }
+        }
+        return new String(chars);
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParser.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParser.java
@@ -10,6 +10,15 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 @ResourceLock("Localization.lang")
 class JavaLocalizationEntryParser {
 
+    private enum CommentState {
+        NORMAL,
+        LINE_COMMENT,
+        BLOCK_COMMENT,
+        STRING,
+        CHARACTER,
+        TEXT_BLOCK
+    }
+
     private static final String INFINITE_WHITESPACE = "\\s*";
     private static final String DOT = "\\.";
     private static final Pattern LOCALIZATION_START_PATTERN = Pattern.compile("Localization" + INFINITE_WHITESPACE + DOT + INFINITE_WHITESPACE + "lang" + INFINITE_WHITESPACE + "\\(");
@@ -112,66 +121,92 @@ class JavaLocalizationEntryParser {
     }
 
     /// Replaces the content of all Java comments (`//`, `///`, `/* */`, javadoc) by spaces.
-    /// Newlines are kept, so that the result has the same length as the input and the same line structure.
-    /// String literals, text blocks, and character literals are left untouched -
-    /// a `//` inside a string (e.g., a URL) does not start a comment.
+    /// Newlines are kept, so that the result has the same length as the input and the same
+    /// line structure. String literals, text blocks, and character literals are left untouched,
+    /// so a `//` inside a string (e.g. a URL) does not start a comment.
     static String blankOutComments(String source) {
         char[] chars = source.toCharArray();
-        int length = chars.length;
-        int i = 0;
-        while (i < length) {
-            char current = chars[i];
-            char next = (i + 1) < length ? chars[i + 1] : '\0';
-            if ((current == '/') && (next == '/')) {
-                while ((i < length) && (chars[i] != '\n')) {
-                    chars[i] = ' ';
-                    i++;
-                }
-            } else if ((current == '/') && (next == '*')) {
-                chars[i] = ' ';
-                chars[i + 1] = ' ';
-                i += 2;
-                while (i < length) {
-                    if ((chars[i] == '*') && ((i + 1) < length) && (chars[i + 1] == '/')) {
+
+        CommentState state = CommentState.NORMAL;
+        char quote = '\0';
+
+        for (int i = 0; i < chars.length; i++) {
+            switch (state) {
+                case NORMAL -> {
+                    if (startsWith(chars, i, '/', '/')) {
                         chars[i] = ' ';
                         chars[i + 1] = ' ';
+                        i++;
+                        state = CommentState.LINE_COMMENT;
+                    } else if (startsWith(chars, i, '/', '*')) {
+                        chars[i] = ' ';
+                        chars[i + 1] = ' ';
+                        i++;
+                        state = CommentState.BLOCK_COMMENT;
+                    } else if (startsTextBlock(chars, i)) {
                         i += 2;
-                        break;
+                        state = CommentState.TEXT_BLOCK;
+                    } else if (chars[i] == '"') {
+                        quote = '"';
+                        state = CommentState.STRING;
+                    } else if (chars[i] == '\'') {
+                        quote = '\'';
+                        state = CommentState.CHARACTER;
                     }
-                    if (chars[i] != '\n') {
+                }
+
+                case LINE_COMMENT -> {
+                    if (chars[i] == '\n') {
+                        state = CommentState.NORMAL;
+                    } else {
                         chars[i] = ' ';
                     }
-                    i++;
                 }
-            } else if ((current == '"') && (next == '"') && ((i + 2) < length) && (chars[i + 2] == '"')) {
-                // text block
-                i += 3;
-                while (i < length) {
-                    if (chars[i] == '\\') {
-                        i += 2;
-                    } else if ((chars[i] == '"') && ((i + 2) < length) && (chars[i + 1] == '"') && (chars[i + 2] == '"')) {
-                        i += 3;
-                        break;
-                    } else {
+
+                case BLOCK_COMMENT -> {
+                    if (startsWith(chars, i, '*', '/')) {
+                        chars[i] = ' ';
+                        chars[i + 1] = ' ';
                         i++;
+                        state = CommentState.NORMAL;
+                    } else if (chars[i] != '\n') {
+                        chars[i] = ' ';
                     }
                 }
-            } else if ((current == '"') || (current == '\'')) {
-                i++;
-                while (i < length) {
+
+                case STRING,
+                     CHARACTER -> {
                     if (chars[i] == '\\') {
-                        i += 2;
-                    } else if (chars[i] == current) {
-                        i++;
-                        break;
-                    } else {
-                        i++;
+                        i++; // skip escaped character
+                    } else if (chars[i] == quote) {
+                        state = CommentState.NORMAL;
                     }
                 }
-            } else {
-                i++;
+
+                case TEXT_BLOCK -> {
+                    if (chars[i] == '\\') {
+                        i++; // skip escaped character
+                    } else if (startsTextBlock(chars, i)) {
+                        i += 2;
+                        state = CommentState.NORMAL;
+                    }
+                }
             }
         }
+
         return new String(chars);
+    }
+
+    private static boolean startsWith(char[] chars, int index, char first, char second) {
+        return index + 1 < chars.length
+                && chars[index] == first
+                && chars[index + 1] == second;
+    }
+
+    private static boolean startsTextBlock(char[] chars, int index) {
+        return index + 2 < chars.length
+                && chars[index] == '"'
+                && chars[index + 1] == '"'
+                && chars[index + 2] == '"';
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParser.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParser.java
@@ -23,14 +23,13 @@ class JavaLocalizationEntryParser {
     private static final String DOT = "\\.";
     private static final Pattern LOCALIZATION_START_PATTERN = Pattern.compile("Localization" + INFINITE_WHITESPACE + DOT + INFINITE_WHITESPACE + "lang" + INFINITE_WHITESPACE + "\\(");
 
-    private static final Pattern LOCALIZATION_MENU_START_PATTERN = Pattern.compile("Localization" + INFINITE_WHITESPACE + DOT + INFINITE_WHITESPACE + "menuTitle" + INFINITE_WHITESPACE + "\\(");
     private static final Pattern ESCAPED_QUOTATION_SYMBOL = Pattern.compile("\\\\\"");
 
     private static final String QUOTATION_PLACEHOLDER = "QUOTATIONPLACEHOLDER";
     private static final Pattern QUOTATION_SYMBOL_PATTERN = Pattern.compile(QUOTATION_PLACEHOLDER);
 
-    public static List<String> getLanguageKeysInString(String content, LocalizationBundleForTest type) {
-        List<String> parameters = getLocalizationParameter(content, type);
+    public static List<String> getLanguageKeysInString(String content) {
+        List<String> parameters = getLocalizationParameter(content);
 
         List<String> result = new ArrayList<>();
 
@@ -83,18 +82,13 @@ class JavaLocalizationEntryParser {
         return languageKey;
     }
 
-    public static List<String> getLocalizationParameter(String rawContent, LocalizationBundleForTest type) {
+    public static List<String> getLocalizationParameter(String rawContent) {
         List<String> result = new ArrayList<>();
 
         // Comments may contain `Localization.lang(...)` snippets, which are no real usages.
         String content = blankOutComments(rawContent);
 
-        Matcher matcher;
-        if (type == LocalizationBundleForTest.LANG) {
-            matcher = LOCALIZATION_START_PATTERN.matcher(content);
-        } else {
-            matcher = LOCALIZATION_MENU_START_PATTERN.matcher(content);
-        }
+        Matcher matcher = LOCALIZATION_START_PATTERN.matcher(content);
         while (matcher.find()) {
             // find contents between the brackets, covering multi-line strings as well
             int index = matcher.end();

--- a/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParserTest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -65,6 +66,66 @@ public class JavaLocalizationEntryParserTest {
                 // "\\n" in the *.java source file
                 "Localization.lang(\"Escaped newline\\\\nthere\")"
         );
+    }
+
+    /// Code snippets in which `Localization.lang` only occurs inside a comment, hence no key must be found.
+    public static Stream<String> commentedOutLocalizations() {
+        return Stream.of(
+                "// Localization.lang(\"key in line comment\")",
+                "/// Localization.lang(\"key in markdown comment\")",
+                "int i = 0; // Localization.lang(\"key in trailing line comment\")",
+                "/* Localization.lang(\"key in block comment\") */",
+                "/*\n * Localization.lang(\"key in multi line block comment\")\n */",
+                "/**\n * Localization.lang(\"key in javadoc\")\n */",
+                // unterminated block comment at the end of a file
+                "/* Localization.lang(\"key in unterminated block comment\")"
+        );
+    }
+
+    public static Stream<Arguments> commentsMixedWithCode() {
+        return Stream.of(
+                // the comment must not swallow the real key
+                Arguments.of("// Localization.lang(\"commented\")\nLocalization.lang(\"real\")", List.of("real")),
+                Arguments.of("Localization.lang(\"real\") // Localization.lang(\"commented\")", List.of("real")),
+                Arguments.of("/* Localization.lang(\"commented\") */ Localization.lang(\"real\")", List.of("real")),
+                // a comment inside the argument list is ignored, the key is still found
+                Arguments.of("Localization.lang(\"real\" /* comment */)", List.of("real")),
+                Arguments.of("Localization.lang(\"real\" // comment\n)", List.of("real")),
+                // "//" inside a string literal does not start a comment
+                Arguments.of("String url = \"https://example.org\"; Localization.lang(\"real\")", List.of("real")),
+                // a quote inside a comment must not be treated as the start of a string literal
+                Arguments.of("// it's commented\nLocalization.lang(\"real\")", List.of("real")),
+                Arguments.of("/* \" */ Localization.lang(\"real\")", List.of("real")),
+                // character literals containing quotes do not confuse the parser
+                Arguments.of("char c = '\"'; Localization.lang(\"real\")", List.of("real")),
+                // comment markers inside a text block do not start a comment
+                Arguments.of("String s = \"\"\"\n// no comment /* here\n\"\"\"; Localization.lang(\"real\")", List.of("real"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("commentedOutLocalizations")
+    void localizationInCommentIsIgnored(String code) {
+        assertEquals(List.of(), JavaLocalizationEntryParser.getLanguageKeysInString(code, LocalizationBundleForTest.LANG));
+    }
+
+    @ParameterizedTest
+    @MethodSource("commentsMixedWithCode")
+    void localizationKeysAreFoundNextToComments(String code, List<String> expectedLanguageKeys) {
+        assertEquals(expectedLanguageKeys, JavaLocalizationEntryParser.getLanguageKeysInString(code, LocalizationBundleForTest.LANG));
+    }
+
+    @Test
+    void menuTitleInCommentIsIgnored() {
+        assertEquals(List.of(), JavaLocalizationEntryParser.getLanguageKeysInString("// Localization.menuTitle(\"File\")", LocalizationBundleForTest.MENU));
+    }
+
+    @Test
+    void blankOutCommentsKeepsLengthAndLineStructure() {
+        String source = "int i = 0; // comment\n/* block\ncomment */ int j = 1;";
+        String blanked = JavaLocalizationEntryParser.blankOutComments(source);
+        assertEquals(source.length(), blanked.length());
+        assertEquals("int i = 0;" + " ".repeat(11) + "\n" + " ".repeat(8) + "\n" + " ".repeat(10) + " int j = 1;", blanked);
     }
 
     @ParameterizedTest

--- a/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParserTest.java
@@ -76,10 +76,7 @@ public class JavaLocalizationEntryParserTest {
                 "int i = 0; // Localization.lang(\"key in trailing line comment\")",
                 "/* Localization.lang(\"key in block comment\") */",
                 "/*\n * Localization.lang(\"key in multi line block comment\")\n */",
-                """
-                        /**
-                         * Localization.lang("key in javadoc")
-                         */""",
+                "/" + "*" + "*" + "\n * Localization.lang(\"key in javadoc\")\n */", // Hide fake javadoc from autoformatter
                 // unterminated block comment at the end of a file
                 "/* Localization.lang(\"key in unterminated block comment\")"
         );

--- a/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParserTest.java
@@ -106,18 +106,13 @@ public class JavaLocalizationEntryParserTest {
     @ParameterizedTest
     @MethodSource("commentedOutLocalizations")
     void localizationInCommentIsIgnored(String code) {
-        assertEquals(List.of(), JavaLocalizationEntryParser.getLanguageKeysInString(code, LocalizationBundleForTest.LANG));
+        assertEquals(List.of(), JavaLocalizationEntryParser.getLanguageKeysInString(code));
     }
 
     @ParameterizedTest
     @MethodSource("commentsMixedWithCode")
     void localizationKeysAreFoundNextToComments(String code, List<String> expectedLanguageKeys) {
-        assertEquals(expectedLanguageKeys, JavaLocalizationEntryParser.getLanguageKeysInString(code, LocalizationBundleForTest.LANG));
-    }
-
-    @Test
-    void menuTitleInCommentIsIgnored() {
-        assertEquals(List.of(), JavaLocalizationEntryParser.getLanguageKeysInString("// Localization.menuTitle(\"File\")", LocalizationBundleForTest.MENU));
+        assertEquals(expectedLanguageKeys, JavaLocalizationEntryParser.getLanguageKeysInString(code));
     }
 
     @Test
@@ -137,20 +132,20 @@ public class JavaLocalizationEntryParserTest {
     @ParameterizedTest
     @MethodSource("multiLineChecks")
     void localizationKeyParsing(String code, List<String> expectedLanguageKeys) {
-        List<String> languageKeysInString = JavaLocalizationEntryParser.getLanguageKeysInString(code, LocalizationBundleForTest.LANG);
+        List<String> languageKeysInString = JavaLocalizationEntryParser.getLanguageKeysInString(code);
         assertEquals(expectedLanguageKeys, languageKeysInString);
     }
 
     @ParameterizedTest
     @MethodSource("singleLineParameterChecks")
     void localizationParameterParsing(String code, String expectedParameter) {
-        List<String> languageKeysInString = JavaLocalizationEntryParser.getLocalizationParameter(code, LocalizationBundleForTest.LANG);
+        List<String> languageKeysInString = JavaLocalizationEntryParser.getLocalizationParameter(code);
         assertEquals(List.of(expectedParameter), languageKeysInString);
     }
 
     @ParameterizedTest
     @MethodSource("causesRuntimeExceptions")
     void throwsRuntimeException(String code) {
-        assertThrows(RuntimeException.class, () -> JavaLocalizationEntryParser.getLanguageKeysInString(code, LocalizationBundleForTest.LANG));
+        assertThrows(RuntimeException.class, () -> JavaLocalizationEntryParser.getLanguageKeysInString(code));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/JavaLocalizationEntryParserTest.java
@@ -76,7 +76,10 @@ public class JavaLocalizationEntryParserTest {
                 "int i = 0; // Localization.lang(\"key in trailing line comment\")",
                 "/* Localization.lang(\"key in block comment\") */",
                 "/*\n * Localization.lang(\"key in multi line block comment\")\n */",
-                "/**\n * Localization.lang(\"key in javadoc\")\n */",
+                """
+                        /**
+                         * Localization.lang("key in javadoc")
+                         */""",
                 // unterminated block comment at the end of a file
                 "/* Localization.lang(\"key in unterminated block comment\")"
         );

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationBundleForTest.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationBundleForTest.java
@@ -1,5 +1,0 @@
-package org.jabref.logic.l10n;
-
-enum LocalizationBundleForTest {
-    LANG, MENU
-}

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
@@ -96,7 +96,7 @@ class LocalizationConsistencyTest {
     @Test
     void languageKeysShouldNotContainUnderscoresForSpaces() throws IOException {
         final List<LocalizationEntry> quotedEntries = LocalizationParser
-                .findLocalizationParametersStringsInJavaFiles(LocalizationBundleForTest.LANG)
+                .findLocalizationParametersStringsInJavaFiles()
                 .stream()
                 .filter(key -> key.getKey().contains("\\_"))
                 .collect(Collectors.toList());
@@ -112,7 +112,7 @@ class LocalizationConsistencyTest {
     @Test
     void languageKeysShouldNotContainHtmlBrAndHtmlP() throws IOException {
         final List<LocalizationEntry> entriesWithHtml = LocalizationParser
-                .findLocalizationParametersStringsInJavaFiles(LocalizationBundleForTest.LANG)
+                .findLocalizationParametersStringsInJavaFiles()
                 .stream()
                 .filter(key -> key.getKey().contains("<br>") || key.getKey().contains("<p>"))
                 .collect(Collectors.toList());
@@ -127,7 +127,7 @@ class LocalizationConsistencyTest {
 
     @Test
     void findMissingLocalizationKeys() throws IOException {
-        List<LocalizationEntry> missingKeys = new ArrayList<>(LocalizationParser.findMissingKeys(LocalizationBundleForTest.LANG));
+        List<LocalizationEntry> missingKeys = new ArrayList<>(LocalizationParser.findMissingKeys());
         assertEquals(List.of(), missingKeys,
                 missingKeys.stream()
                            .map(key -> LocalizationKey.fromKey(key.getKey()))
@@ -148,7 +148,7 @@ class LocalizationConsistencyTest {
 
     @Test
     void findObsoleteLocalizationKeys() throws IOException {
-        Set<String> obsoleteKeys = LocalizationParser.findObsolete(LocalizationBundleForTest.LANG);
+        Set<String> obsoleteKeys = LocalizationParser.findObsolete();
         assertEquals(Set.of(), obsoleteKeys,
                 obsoleteKeys.stream().collect(Collectors.joining("\n",
                         "Obsolete keys found in language properties file: \n\n",
@@ -168,16 +168,11 @@ class LocalizationConsistencyTest {
         // - Localization.lang("test %1", var)
         // - Localization.lang("Problem downloading from %1", address)
         // - Localization.lang("test %1 %2", var1, var2)
-        Set<LocalizationEntry> keys = LocalizationParser.findLocalizationParametersStringsInJavaFiles(LocalizationBundleForTest.LANG);
+        Set<LocalizationEntry> keys = LocalizationParser.findLocalizationParametersStringsInJavaFiles();
         for (LocalizationEntry e : keys) {
             // TODO: Forbidden Localization.lang("test" + var2) not covered by the test
             //       In case this kind of code is found, an error should be reported
             //       JabRef's infrastructure only supports Localization.lang("Some Message"); and not something else.
-            assertTrue(e.getKey().startsWith("\""), "Illegal localization parameter found. Must include a String with potential concatenation or replacement parameters. Illegal parameter: Localization.lang(" + e.getKey());
-        }
-
-        keys = LocalizationParser.findLocalizationParametersStringsInJavaFiles(LocalizationBundleForTest.MENU);
-        for (LocalizationEntry e : keys) {
             assertTrue(e.getKey().startsWith("\""), "Illegal localization parameter found. Must include a String with potential concatenation or replacement parameters. Illegal parameter: Localization.lang(" + e.getKey());
         }
     }

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
@@ -99,7 +99,7 @@ class LocalizationConsistencyTest {
                 .findLocalizationParametersStringsInJavaFiles()
                 .stream()
                 .filter(key -> key.getKey().contains("\\_"))
-                .collect(Collectors.toList());
+                .toList();
         assertEquals(List.of(), quotedEntries,
                 "Language keys must not use underscores for spaces! Use \"This is a message\" instead of \"This_is_a_message\".\n" +
                         "Please correct the following entries:\n" +
@@ -115,7 +115,7 @@ class LocalizationConsistencyTest {
                 .findLocalizationParametersStringsInJavaFiles()
                 .stream()
                 .filter(key -> key.getKey().contains("<br>") || key.getKey().contains("<p>"))
-                .collect(Collectors.toList());
+                .toList();
         assertEquals(List.of(), entriesWithHtml,
                 "Language keys must not contain HTML <br> or <p>. Use \\n for a line break.\n" +
                         "Please correct the following entries:\n" +

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationEntry.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationEntry.java
@@ -8,12 +8,10 @@ class LocalizationEntry implements Comparable<LocalizationEntry> {
 
     private final Path path;
     private final String key;
-    private final LocalizationBundleForTest bundle;
 
-    LocalizationEntry(Path path, String key, LocalizationBundleForTest bundle) {
+    LocalizationEntry(Path path, String key) {
         this.path = path;
         this.key = key;
-        this.bundle = bundle;
     }
 
     public Path getPath() {
@@ -22,10 +20,6 @@ class LocalizationEntry implements Comparable<LocalizationEntry> {
 
     public String getKey() {
         return key;
-    }
-
-    public String getId() {
-        return "%s___%s".formatted(bundle, key);
     }
 
     @Override
@@ -38,29 +32,21 @@ class LocalizationEntry implements Comparable<LocalizationEntry> {
         }
 
         LocalizationEntry that = (LocalizationEntry) o;
-
-        if (!Objects.equals(key, that.key)) {
-            return false;
-        }
-        return bundle == that.bundle;
+        return Objects.equals(key, that.key);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(key, bundle);
-    }
-
-    public LocalizationBundleForTest getBundle() {
-        return bundle;
+        return Objects.hash(key);
     }
 
     @Override
     public String toString() {
-        return "%s (%s %s)".formatted(key, path, bundle);
+        return "%s (%s)".formatted(key, path);
     }
 
     @Override
     public int compareTo(LocalizationEntry o) {
-        return getId().compareTo(o.getId());
+        return key.compareTo(o.key);
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
@@ -134,19 +134,17 @@ public class LocalizationParser {
     }
 
     private static List<LocalizationEntry> getLanguageKeysInJavaFile(Path path) {
-        List<String> lines;
-        try {
-            lines = Files.readAllLines(path, StandardCharsets.UTF_8);
-        } catch (IOException exception) {
-            throw new RuntimeException(exception);
-        }
-        String content = String.join("\n", lines);
-        return JavaLocalizationEntryParser.getLanguageKeysInString(content).stream()
-                                          .map(key -> new LocalizationEntry(path, key))
-                                          .collect(Collectors.toList());
+        return parseJavaFile(path, JavaLocalizationEntryParser::getLanguageKeysInString);
     }
 
     private static List<LocalizationEntry> getLocalizationParametersInJavaFile(Path path) {
+        return parseJavaFile(path, JavaLocalizationEntryParser::getLocalizationParameter);
+    }
+
+    /// Reads the given Java file and turns everything the parser finds in it into localization entries.
+    ///
+    /// The line endings are normalized to `\n`, because the parser treats `\n` as the end of a line comment.
+    private static List<LocalizationEntry> parseJavaFile(Path path, Function<String, List<String>> parser) {
         List<String> lines;
         try {
             lines = Files.readAllLines(path, StandardCharsets.UTF_8);
@@ -154,9 +152,9 @@ public class LocalizationParser {
             throw new RuntimeException(exception);
         }
         String content = String.join("\n", lines);
-        return JavaLocalizationEntryParser.getLocalizationParameter(content).stream()
-                                          .map(key -> new LocalizationEntry(path, key))
-                                          .collect(Collectors.toList());
+        return parser.apply(content).stream()
+                     .map(key -> new LocalizationEntry(path, key))
+                     .collect(Collectors.toList());
     }
 
     /// Loads the fxml file and returns all used language resources.

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -65,24 +64,24 @@ public class LocalizationParser {
     }
 
     public static Set<LocalizationEntry> findLocalizationParametersStringsInJavaFiles() throws IOException {
-        return findInModules("src/main/java", LocalizationParser::isJavaFile, LocalizationParser::getLocalizationParametersInJavaFile);
+        return findInModules("src/main/java", ".java", LocalizationParser::getLocalizationParametersInJavaFile);
     }
 
     private static Set<LocalizationEntry> findLocalizationEntriesInJavaFiles() throws IOException {
-        return findInModules("src/main/java", LocalizationParser::isJavaFile, LocalizationParser::getLanguageKeysInJavaFile);
+        return findInModules("src/main/java", ".java", LocalizationParser::getLanguageKeysInJavaFile);
     }
 
     private static Set<LocalizationEntry> findLocalizationEntriesInFxmlFiles() throws IOException {
-        return findInModules("src/main/resources", LocalizationParser::isFxmlFile, LocalizationParser::getLanguageKeysInFxmlFile);
+        return findInModules("src/main/resources", ".fxml", LocalizationParser::getLanguageKeysInFxmlFile);
     }
 
     /// Collects the localization entries of all matching files below the given source directory of each module.
     ///
     /// @param sourceDirectory the module relative directory to walk, e.g. `src/main/java`
-    /// @param fileFilter      determines which of the found files are parsed
+    /// @param extension       only files having this file name extension are parsed
     /// @param extractor       extracts the localization entries of a single file
     private static Set<LocalizationEntry> findInModules(String sourceDirectory,
-                                                        Predicate<Path> fileFilter,
+                                                        String extension,
                                                         Function<Path, Collection<LocalizationEntry>> extractor) throws IOException {
         Set<LocalizationEntry> result = new HashSet<>();
         for (String module : MODULES) {
@@ -92,7 +91,7 @@ public class LocalizationParser {
             }
             // Files.walk holds a directory handle, thus the stream needs to be closed
             try (Stream<Path> paths = Files.walk(root)) {
-                paths.filter(fileFilter)
+                paths.filter(path -> path.toString().endsWith(extension))
                      .map(extractor)
                      .forEach(result::addAll);
             }
@@ -123,14 +122,6 @@ public class LocalizationParser {
             throw new RuntimeException(e);
         }
         return properties;
-    }
-
-    private static boolean isJavaFile(Path path) {
-        return path.toString().endsWith(".java");
-    }
-
-    private static boolean isFxmlFile(Path path) {
-        return path.toString().endsWith(".fxml");
     }
 
     private static List<LocalizationEntry> getLanguageKeysInJavaFile(Path path) {

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
@@ -41,7 +41,7 @@ public class LocalizationParser {
 
     /// Returns all keys used in the sources which are not declared in the English properties file.
     public static SortedSet<LocalizationEntry> findMissingKeys() throws IOException {
-        Set<String> englishKeys = getKeysInPropertiesFile(ENGLISH_PROPERTIES_FILE);
+        Set<String> englishKeys = getEnglishKeys();
         return findLocalizationEntriesInFiles().stream()
                                                .filter(entry -> !englishKeys.contains(entry.getKey()))
                                                .collect(Collectors.toCollection(TreeSet::new));
@@ -52,9 +52,9 @@ public class LocalizationParser {
         Set<String> keysInSourceFiles = findLocalizationEntriesInFiles().stream()
                                                                         .map(LocalizationEntry::getKey)
                                                                         .collect(Collectors.toSet());
-        return getKeysInPropertiesFile(ENGLISH_PROPERTIES_FILE).stream()
-                                                               .filter(key -> !keysInSourceFiles.contains(key))
-                                                               .collect(Collectors.toCollection(TreeSet::new));
+        return getEnglishKeys().stream()
+                               .filter(key -> !keysInSourceFiles.contains(key))
+                               .collect(Collectors.toCollection(TreeSet::new));
     }
 
     private static Set<LocalizationEntry> findLocalizationEntriesInFiles() throws IOException {
@@ -100,9 +100,9 @@ public class LocalizationParser {
         return result;
     }
 
-    /// Returns the trimmed key set of the given property file. Each key is already unescaped.
-    public static SortedSet<String> getKeysInPropertiesFile(String path) {
-        Properties properties = getProperties(path);
+    /// Returns the trimmed key set of the English properties file. Each key is already unescaped.
+    private static SortedSet<String> getEnglishKeys() {
+        Properties properties = getProperties(ENGLISH_PROPERTIES_FILE);
         return properties.keySet().stream()
                          .map(Object::toString)
                          .map(String::trim)

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
@@ -3,7 +3,6 @@ package org.jabref.logic.l10n;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
@@ -19,13 +18,14 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javafx.fxml.FXMLLoader;
 
 import com.airhacks.afterburner.views.ViewLoader;
-import org.jooq.lambda.Unchecked;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.mockito.Answers;
 import org.mockito.MockedStatic;
@@ -83,43 +83,39 @@ public class LocalizationParser {
 
     public static Set<LocalizationEntry> findLocalizationParametersStringsInJavaFiles(LocalizationBundleForTest type)
             throws IOException {
-        try {
-            return MODULES.stream()
-                          .map(path -> Path.of("..", path, "src", "main", "java").normalize())
-                          .flatMap(Unchecked.function(path -> Files.walk(path)))
-                          .filter(LocalizationParser::isJavaFile)
-                          .flatMap(path -> getLocalizationParametersInJavaFile(path, type).stream())
-                          .collect(Collectors.toSet());
-        } catch (UncheckedIOException ioe) {
-            throw new IOException(ioe);
-        }
+        return findInModules("src/main/java", LocalizationParser::isJavaFile, path -> getLocalizationParametersInJavaFile(path, type));
     }
 
     private static Set<LocalizationEntry> findLocalizationEntriesInJavaFiles(LocalizationBundleForTest type) throws IOException {
-        try {
-            return MODULES.stream()
-                       .map(path -> Path.of("..", path, "src", "main", "java").normalize())
-                       .flatMap(Unchecked.function(path -> Files.walk(path)))
-                       .filter(LocalizationParser::isJavaFile)
-                       .flatMap(javaPath -> getLanguageKeysInJavaFile(javaPath, type).stream())
-                       .collect(Collectors.toSet());
-        } catch (UncheckedIOException ioe) {
-            throw new IOException(ioe);
-        }
+        return findInModules("src/main/java", LocalizationParser::isJavaFile, path -> getLanguageKeysInJavaFile(path, type));
     }
 
     private static Set<LocalizationEntry> findLocalizationEntriesInFxmlFiles(LocalizationBundleForTest type) throws IOException {
-        try {
-            return MODULES.stream()
-                       .map(path -> Path.of("..", path, "src", "main", "resources").normalize())
-                       .filter(Files::isDirectory)
-                       .flatMap(Unchecked.function(path -> Files.walk(path)))
-                       .filter(LocalizationParser::isFxmlFile)
-                       .flatMap(fxmlPath -> getLanguageKeysInFxmlFile(fxmlPath, type).stream())
-                       .collect(Collectors.toSet());
-        } catch (UncheckedIOException ioe) {
-            throw new IOException(ioe);
+        return findInModules("src/main/resources", LocalizationParser::isFxmlFile, path -> getLanguageKeysInFxmlFile(path, type));
+    }
+
+    /// Collects the localization entries of all matching files below the given source directory of each module.
+    ///
+    /// @param sourceDirectory the module relative directory to walk, e.g. `src/main/java`
+    /// @param fileFilter      determines which of the found files are parsed
+    /// @param extractor       extracts the localization entries of a single file
+    private static Set<LocalizationEntry> findInModules(String sourceDirectory,
+                                                        Predicate<Path> fileFilter,
+                                                        Function<Path, Collection<LocalizationEntry>> extractor) throws IOException {
+        Set<LocalizationEntry> result = new HashSet<>();
+        for (String module : MODULES) {
+            Path root = Path.of("..", module).resolve(sourceDirectory).normalize();
+            if (!Files.isDirectory(root)) {
+                continue;
+            }
+            // Files.walk holds a directory handle, thus the stream needs to be closed
+            try (Stream<Path> paths = Files.walk(root)) {
+                paths.filter(fileFilter)
+                     .map(extractor)
+                     .forEach(result::addAll);
+            }
         }
+        return result;
     }
 
     /// Returns the trimmed key set of the given property file. Each key is already unescaped.

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
@@ -47,12 +47,14 @@ public class LocalizationParser {
                                                .collect(Collectors.toCollection(TreeSet::new));
     }
 
+    /// Returns all keys declared in the English properties file which are not used in the sources.
     public static SortedSet<String> findObsolete() throws IOException {
-        Set<String> englishKeys = getKeysInPropertiesFile(ENGLISH_PROPERTIES_FILE);
-        Set<String> keysInSourceFiles = findLocalizationEntriesInFiles()
-                .stream().map(LocalizationEntry::getKey).collect(Collectors.toSet());
-        englishKeys.removeAll(keysInSourceFiles);
-        return new TreeSet<>(englishKeys);
+        Set<String> keysInSourceFiles = findLocalizationEntriesInFiles().stream()
+                                                                        .map(LocalizationEntry::getKey)
+                                                                        .collect(Collectors.toSet());
+        return getKeysInPropertiesFile(ENGLISH_PROPERTIES_FILE).stream()
+                                                               .filter(key -> !keysInSourceFiles.contains(key))
+                                                               .collect(Collectors.toCollection(TreeSet::new));
     }
 
     private static Set<LocalizationEntry> findLocalizationEntriesInFiles() throws IOException {

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
@@ -39,19 +39,12 @@ public class LocalizationParser {
 
     private static final String ENGLISH_PROPERTIES_FILE = "/l10n/JabRef_en.properties";
 
+    /// Returns all keys used in the sources which are not declared in the English properties file.
     public static SortedSet<LocalizationEntry> findMissingKeys() throws IOException {
-        Set<LocalizationEntry> entries = findLocalizationEntriesInFiles();
-        Set<String> keysInJavaFiles = entries.stream()
-                                             .map(LocalizationEntry::getKey)
-                                             .collect(Collectors.toSet());
-
         Set<String> englishKeys = getKeysInPropertiesFile(ENGLISH_PROPERTIES_FILE);
-        List<String> missingKeys = new ArrayList<>(keysInJavaFiles);
-        missingKeys.removeAll(englishKeys);
-
-        return entries.stream()
-                      .filter(e -> missingKeys.contains(e.getKey()))
-                      .collect(Collectors.toCollection(TreeSet::new));
+        return findLocalizationEntriesInFiles().stream()
+                                               .filter(entry -> !englishKeys.contains(entry.getKey()))
+                                               .collect(Collectors.toCollection(TreeSet::new));
     }
 
     public static SortedSet<String> findObsolete() throws IOException {

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
@@ -148,7 +148,7 @@ public class LocalizationParser {
         String content = String.join("\n", lines);
         return parser.apply(content).stream()
                      .map(key -> new LocalizationEntry(path, key))
-                     .collect(Collectors.toList());
+                     .toList();
     }
 
     /// Loads the fxml file and returns all used language resources.

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
@@ -34,6 +34,9 @@ import org.mockito.Mockito;
 @ResourceLock("Localization.lang")
 public class LocalizationParser {
 
+    /// All modules containing Java sources and FXML files which may use localization keys.
+    private static final List<String> MODULES = List.of("jablib", "jabkit", "jabsrv", "jabgui", "jabls");
+
     public static SortedSet<LocalizationEntry> findMissingKeys(LocalizationBundleForTest type) throws IOException {
         Set<LocalizationEntry> entries = findLocalizationEntriesInFiles(type);
         Set<String> keysInJavaFiles = entries.stream()
@@ -80,11 +83,13 @@ public class LocalizationParser {
 
     public static Set<LocalizationEntry> findLocalizationParametersStringsInJavaFiles(LocalizationBundleForTest type)
             throws IOException {
-        try (Stream<Path> pathStream = Files.walk(Path.of("src/main"))) {
-            return pathStream
-                    .filter(LocalizationParser::isJavaFile)
-                    .flatMap(path -> getLocalizationParametersInJavaFile(path, type).stream())
-                    .collect(Collectors.toSet());
+        try {
+            return MODULES.stream()
+                          .map(path -> Path.of("..", path, "src", "main", "java").normalize())
+                          .flatMap(Unchecked.function(path -> Files.walk(path)))
+                          .filter(LocalizationParser::isJavaFile)
+                          .flatMap(path -> getLocalizationParametersInJavaFile(path, type).stream())
+                          .collect(Collectors.toSet());
         } catch (UncheckedIOException ioe) {
             throw new IOException(ioe);
         }
@@ -92,8 +97,7 @@ public class LocalizationParser {
 
     private static Set<LocalizationEntry> findLocalizationEntriesInJavaFiles(LocalizationBundleForTest type) throws IOException {
         try {
-            return List.of("jablib", "jabkit", "jabsrv", "jabgui", "jabls")
-                       .stream()
+            return MODULES.stream()
                        .map(path -> Path.of("..", path, "src", "main", "java").normalize())
                        .flatMap(Unchecked.function(path -> Files.walk(path)))
                        .filter(LocalizationParser::isJavaFile)
@@ -106,8 +110,7 @@ public class LocalizationParser {
 
     private static Set<LocalizationEntry> findLocalizationEntriesInFxmlFiles(LocalizationBundleForTest type) throws IOException {
         try {
-            return List.of("jablib", "jabkit", "jabsrv", "jabgui", "jabls")
-                       .stream()
+            return MODULES.stream()
                        .map(path -> Path.of("..", path, "src", "main", "resources").normalize())
                        .filter(Files::isDirectory)
                        .flatMap(Unchecked.function(path -> Files.walk(path)))

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
@@ -37,18 +37,15 @@ public class LocalizationParser {
     /// All modules containing Java sources and FXML files which may use localization keys.
     private static final List<String> MODULES = List.of("jablib", "jabkit", "jabsrv", "jabgui", "jabls");
 
-    public static SortedSet<LocalizationEntry> findMissingKeys(LocalizationBundleForTest type) throws IOException {
-        Set<LocalizationEntry> entries = findLocalizationEntriesInFiles(type);
+    private static final String ENGLISH_PROPERTIES_FILE = "/l10n/JabRef_en.properties";
+
+    public static SortedSet<LocalizationEntry> findMissingKeys() throws IOException {
+        Set<LocalizationEntry> entries = findLocalizationEntriesInFiles();
         Set<String> keysInJavaFiles = entries.stream()
                                              .map(LocalizationEntry::getKey)
                                              .collect(Collectors.toSet());
 
-        Set<String> englishKeys;
-        if (type == LocalizationBundleForTest.LANG) {
-            englishKeys = getKeysInPropertiesFile("/l10n/JabRef_en.properties");
-        } else {
-            englishKeys = getKeysInPropertiesFile("/l10n/Menu_en.properties");
-        }
+        Set<String> englishKeys = getKeysInPropertiesFile(ENGLISH_PROPERTIES_FILE);
         List<String> missingKeys = new ArrayList<>(keysInJavaFiles);
         missingKeys.removeAll(englishKeys);
 
@@ -57,41 +54,31 @@ public class LocalizationParser {
                       .collect(Collectors.toCollection(TreeSet::new));
     }
 
-    public static SortedSet<String> findObsolete(LocalizationBundleForTest type) throws IOException {
-        Set<String> englishKeys;
-        if (type == LocalizationBundleForTest.LANG) {
-            englishKeys = getKeysInPropertiesFile("/l10n/JabRef_en.properties");
-        } else {
-            englishKeys = getKeysInPropertiesFile("/l10n/Menu_en.properties");
-        }
-        Set<String> keysInSourceFiles = findLocalizationEntriesInFiles(type)
+    public static SortedSet<String> findObsolete() throws IOException {
+        Set<String> englishKeys = getKeysInPropertiesFile(ENGLISH_PROPERTIES_FILE);
+        Set<String> keysInSourceFiles = findLocalizationEntriesInFiles()
                 .stream().map(LocalizationEntry::getKey).collect(Collectors.toSet());
         englishKeys.removeAll(keysInSourceFiles);
         return new TreeSet<>(englishKeys);
     }
 
-    private static Set<LocalizationEntry> findLocalizationEntriesInFiles(LocalizationBundleForTest type) throws IOException {
-        if (type == LocalizationBundleForTest.MENU) {
-            return findLocalizationEntriesInJavaFiles(type);
-        } else {
-            Set<LocalizationEntry> entriesInFiles = new HashSet<>();
-            entriesInFiles.addAll(findLocalizationEntriesInJavaFiles(type));
-            entriesInFiles.addAll(findLocalizationEntriesInFxmlFiles(type));
-            return entriesInFiles;
-        }
+    private static Set<LocalizationEntry> findLocalizationEntriesInFiles() throws IOException {
+        Set<LocalizationEntry> entriesInFiles = new HashSet<>();
+        entriesInFiles.addAll(findLocalizationEntriesInJavaFiles());
+        entriesInFiles.addAll(findLocalizationEntriesInFxmlFiles());
+        return entriesInFiles;
     }
 
-    public static Set<LocalizationEntry> findLocalizationParametersStringsInJavaFiles(LocalizationBundleForTest type)
-            throws IOException {
-        return findInModules("src/main/java", LocalizationParser::isJavaFile, path -> getLocalizationParametersInJavaFile(path, type));
+    public static Set<LocalizationEntry> findLocalizationParametersStringsInJavaFiles() throws IOException {
+        return findInModules("src/main/java", LocalizationParser::isJavaFile, LocalizationParser::getLocalizationParametersInJavaFile);
     }
 
-    private static Set<LocalizationEntry> findLocalizationEntriesInJavaFiles(LocalizationBundleForTest type) throws IOException {
-        return findInModules("src/main/java", LocalizationParser::isJavaFile, path -> getLanguageKeysInJavaFile(path, type));
+    private static Set<LocalizationEntry> findLocalizationEntriesInJavaFiles() throws IOException {
+        return findInModules("src/main/java", LocalizationParser::isJavaFile, LocalizationParser::getLanguageKeysInJavaFile);
     }
 
-    private static Set<LocalizationEntry> findLocalizationEntriesInFxmlFiles(LocalizationBundleForTest type) throws IOException {
-        return findInModules("src/main/resources", LocalizationParser::isFxmlFile, path -> getLanguageKeysInFxmlFile(path, type));
+    private static Set<LocalizationEntry> findLocalizationEntriesInFxmlFiles() throws IOException {
+        return findInModules("src/main/resources", LocalizationParser::isFxmlFile, LocalizationParser::getLanguageKeysInFxmlFile);
     }
 
     /// Collects the localization entries of all matching files below the given source directory of each module.
@@ -151,7 +138,7 @@ public class LocalizationParser {
         return path.toString().endsWith(".fxml");
     }
 
-    private static List<LocalizationEntry> getLanguageKeysInJavaFile(Path path, LocalizationBundleForTest type) {
+    private static List<LocalizationEntry> getLanguageKeysInJavaFile(Path path) {
         List<String> lines;
         try {
             lines = Files.readAllLines(path, StandardCharsets.UTF_8);
@@ -159,12 +146,12 @@ public class LocalizationParser {
             throw new RuntimeException(exception);
         }
         String content = String.join("\n", lines);
-        return JavaLocalizationEntryParser.getLanguageKeysInString(content, type).stream()
-                                          .map(key -> new LocalizationEntry(path, key, type))
+        return JavaLocalizationEntryParser.getLanguageKeysInString(content).stream()
+                                          .map(key -> new LocalizationEntry(path, key))
                                           .collect(Collectors.toList());
     }
 
-    private static List<LocalizationEntry> getLocalizationParametersInJavaFile(Path path, LocalizationBundleForTest type) {
+    private static List<LocalizationEntry> getLocalizationParametersInJavaFile(Path path) {
         List<String> lines;
         try {
             lines = Files.readAllLines(path, StandardCharsets.UTF_8);
@@ -172,15 +159,15 @@ public class LocalizationParser {
             throw new RuntimeException(exception);
         }
         String content = String.join("\n", lines);
-        return JavaLocalizationEntryParser.getLocalizationParameter(content, type).stream()
-                                          .map(key -> new LocalizationEntry(path, key, type))
+        return JavaLocalizationEntryParser.getLocalizationParameter(content).stream()
+                                          .map(key -> new LocalizationEntry(path, key))
                                           .collect(Collectors.toList());
     }
 
     /// Loads the fxml file and returns all used language resources.
     ///
     /// Note: FXML prefixes localization keys with `%`.
-    private static Collection<LocalizationEntry> getLanguageKeysInFxmlFile(Path path, LocalizationBundleForTest type) {
+    private static Collection<LocalizationEntry> getLanguageKeysInFxmlFile(Path path) {
         Collection<String> result = new ArrayList<>();
 
         // Afterburner ViewLoader forces a controller factory, but we do not need any controller
@@ -222,7 +209,7 @@ public class LocalizationParser {
         }
 
         return result.stream()
-                     .map(key -> new LocalizationEntry(path, key, type))
+                     .map(key -> new LocalizationEntry(path, key))
                      .toList();
     }
 

--- a/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
+++ b/jablib/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
@@ -114,9 +114,12 @@ public class LocalizationParser {
     }
 
     public static Properties getProperties(String path) {
+        InputStream inputStream = LocalizationParser.class.getResourceAsStream(path);
+        if (inputStream == null) {
+            throw new IllegalArgumentException("Could not find the properties file " + path);
+        }
         Properties properties = new Properties();
-        try (InputStream is = LocalizationConsistencyTest.class.getResourceAsStream(path);
-             InputStreamReader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
+        try (inputStream; InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
             properties.load(reader);
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
### Summary

Localization tests had a big flaw: The parser could not diff between comments and real code.
Meaning
```java
... = Localization.lang("YadaYada");
```

and 

```java
/// In my javadoc I describe something about Localization.lang("YadaYada") to help you understand a problem
```

or likewise would equally parsed by the LocalizationParser as references to Localization.lang("..."). This would create false positive results for LocalizationConsistency checks with missing localization keys.

This PR enhances the Localization parser by replacing all the comments in the code by spaces (to keep line and column numbers) before looking for missing localization keys. I was not able to benchmark this PR in comparison to before, but just by running the consistency tests locally, i did not feel any real difference.

Also this PR fixes some issues, where `Localization.lang(variable)` was run, which is not recognized by the localization parser at all.

        `jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

Run LocalizationConsistency tests.

### Related issues and pull requests

Refs https://github.com/JabRef/jabref/pull/16386#discussion_r3670181863

Closes none

### AI usage

Claude Code (model claude-opus-5-0), OpenAI GPT-5.5 and a human brain.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
