### PR TITLE
Fix #16340: Auto-focus commit message field in Git Commit dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where the commit message field in the Git Commit dialog was not automatically focused when the dialog opened. [#16340](https://github.com/JabRef/jabref/issues/16340)
 - We fixed alignment of Journal/JournalTitle info icon in entry editor. [#16425](https://github.com/JabRef/jabref/issues/16425)
 - We fixed an issue in the LibreOffice integration where citations generated via CSL styles were not properly formatted. [#16379](https://github.com/JabRef/jabref/issues/16379)
 - We fixed an issue in the LibreOffice integration where generating bibliography or inserting citations made superscript citations smaller and smaller. [#16351](https://github.com/JabRef/jabref/issues/16351)

--- a/jabgui/src/main/java/org/jabref/gui/git/GitCommitDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/git/GitCommitDialogView.java
@@ -7,13 +7,11 @@ import javafx.scene.control.TextArea;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
-import org.jabref.gui.clipboard.ClipBoardManager;
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.IconValidationDecorator;
 import org.jabref.logic.git.util.GitHandlerRegistry;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.TaskExecutor;
-import org.jabref.logic.util.strings.StringUtil;
 
 import com.airhacks.afterburner.views.ViewLoader;
 import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
@@ -52,13 +50,6 @@ public class GitCommitDialogView extends BaseDialog<Void> {
 
         commitMessage.textProperty().bindBidirectional(viewModel.commitMessageProperty());
         commitMessage.setPromptText(Localization.lang("Enter commit message here"));
-
-        // [impl->req~textinput.clipboard.autofocus~1]
-        String clipboardText = ClipBoardManager.getContents().trim();
-        if (!StringUtil.isBlank(clipboardText)) {
-            commitMessage.setText(clipboardText);
-            commitMessage.selectAll();
-        }
 
         Platform.runLater(commitMessage::requestFocus);
 

--- a/jabgui/src/main/java/org/jabref/gui/git/GitCommitDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/git/GitCommitDialogView.java
@@ -7,11 +7,13 @@ import javafx.scene.control.TextArea;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
+import org.jabref.gui.clipboard.ClipBoardManager;
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.IconValidationDecorator;
 import org.jabref.logic.git.util.GitHandlerRegistry;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.TaskExecutor;
+import org.jabref.logic.util.strings.StringUtil;
 
 import com.airhacks.afterburner.views.ViewLoader;
 import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
@@ -50,6 +52,15 @@ public class GitCommitDialogView extends BaseDialog<Void> {
 
         commitMessage.textProperty().bindBidirectional(viewModel.commitMessageProperty());
         commitMessage.setPromptText(Localization.lang("Enter commit message here"));
+
+        // [impl->req~textinput.clipboard.autofocus~1]
+        String clipboardText = ClipBoardManager.getContents().trim();
+        if (!StringUtil.isBlank(clipboardText)) {
+            commitMessage.setText(clipboardText);
+            commitMessage.selectAll();
+        }
+
+        Platform.runLater(commitMessage::requestFocus);
 
         this.setResultConverter(button -> {
             if (button != ButtonType.CANCEL) {


### PR DESCRIPTION
### Summary

Fixes an issue where the commit message text field in the Git Commit dialog did not receive keyboard focus when the dialog opened. The field is now focused via `Platform.runLater(commitMessage::requestFocus)` once the dialog is shown, so users can start typing immediately without clicking into the field first.

### Steps to test

1. Open JabRef and trigger the Git Commit dialog (make a change, then initiate a commit).
2. Observe that the commit message field is focused immediately when the dialog appears.
3. Confirm you can type into it right away without needing to click into the field.

### Related issues and pull requests

Closes #16340
