### PR TITLE
Fix failed saves on bib file open in TeXstudio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where JabRef was unable to save the changed `.bib` file if it was open in TeXstudio on Windows. [#11916](https://github.com/JabRef/jabref/issues/11916)
 - We fixed alignment of Journal/JournalTitle info icon in entry editor. [#16425](https://github.com/JabRef/jabref/issues/16425)
 - We fixed an issue in the LibreOffice integration where citations generated via CSL styles were not properly formatted. [#16379](https://github.com/JabRef/jabref/issues/16379)
 - We fixed an issue in the LibreOffice integration where generating bibliography or inserting citations made superscript citations smaller and smaller. [#16351](https://github.com/JabRef/jabref/issues/16351)

--- a/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -2,6 +2,7 @@ package org.jabref.logic.exporter;
 
 import java.io.FilterOutputStream;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
@@ -289,8 +290,11 @@ public class AtomicFileOutputStream extends FilterOutputStream {
                     Thread.sleep(MOVE_RETRY_INITIAL_DELAY_MILLIS << (attempt - 1));
                 } catch (InterruptedException interruptedException) {
                     Thread.currentThread().interrupt();
-                    LOGGER.warn("Could not move temporary file", exception);
-                    throw exception;
+                    InterruptedIOException interruptedIOException = new InterruptedIOException("Interrupted while moving temporary file " + temporaryFile + " onto " + targetFile);
+                    interruptedIOException.initCause(interruptedException);
+                    interruptedIOException.addSuppressed(exception);
+                    LOGGER.warn("Interrupted while moving temporary file {} onto {}", temporaryFile, targetFile, interruptedIOException);
+                    throw interruptedIOException;
                 }
             }
         }

--- a/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -1,14 +1,17 @@
 package org.jabref.logic.exporter;
 
-import java.io.FileOutputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
 import java.util.Set;
@@ -21,7 +24,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/// A file output stream that is similar to the standard {@link FileOutputStream}, except that all writes are first
+/// A file output stream that is similar to the standard {@link java.io.FileOutputStream}, except that all writes are first
 /// redirected to a temporary file. When the stream is closed, the temporary file (atomically) replaces the target file.
 ///
 ///
@@ -50,11 +53,21 @@ public class AtomicFileOutputStream extends FilterOutputStream {
     private static final String TEMPORARY_EXTENSION = ".tmp";
     private static final String SAVE_EXTENSION = "." + BackupFileType.SAVE.getExtensions().getFirst();
 
+    /// Number of attempts to move the temporary file onto the target file. See [#moveTemporaryFileToTargetFile()].
+    private static final int MOVE_ATTEMPTS = 5;
+
+    /// Delay before the second move attempt; doubled after each further failed attempt.
+    private static final long MOVE_RETRY_INITIAL_DELAY_MILLIS = 20;
+
     /// The file we want to create/replace.
     private final Path targetFile;
 
     /// The file to which writes are redirected to.
     private final Path temporaryFile;
+
+    /// Null if the stream was constructed from an injected [OutputStream] (tests), because neither locking
+    /// nor syncing is possible then.
+    @Nullable private final FileChannel temporaryFileChannel;
 
     /// Can be null in case of failure to acquire a lock (for example, a network drive).
     /// If null, then ignore.
@@ -72,8 +85,24 @@ public class AtomicFileOutputStream extends FilterOutputStream {
     /// @param path       the path of the file to write to or replace
     /// @param keepBackup whether to keep the backup file (.sav) after a successful write process
     public AtomicFileOutputStream(Path path, boolean keepBackup) throws IOException {
-        // Files.newOutputStream(getPathOfTemporaryFile(path)) leads to a "sun.nio.ch.ChannelOutputStream", which does not offer "lock"
-        this(path, getPathOfTemporaryFile(path), Files.newOutputStream(getPathOfTemporaryFile(path)), keepBackup);
+        this(path,
+                getPathOfTemporaryFile(path),
+                FileChannel.open(getPathOfTemporaryFile(path),
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.WRITE,
+                        StandardOpenOption.TRUNCATE_EXISTING),
+                keepBackup);
+    }
+
+    /// The temporary file is opened as a [FileChannel], because the channel is needed both for [FileChannel#tryLock()]
+    /// and for [FileChannel#force(boolean)]. `Files.newOutputStream(...)` returns a `sun.nio.ch.ChannelOutputStream`,
+    /// which offers neither.
+    private AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, FileChannel temporaryFileChannel, boolean keepBackup) throws IOException {
+        this(path,
+                pathOfTemporaryFile,
+                Channels.newOutputStream(temporaryFileChannel),
+                temporaryFileChannel,
+                keepBackup);
     }
 
     /// Creates a new output stream to write to or replace the file at the specified path.
@@ -86,25 +115,32 @@ public class AtomicFileOutputStream extends FilterOutputStream {
 
     /// Required for proper testing
     AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, OutputStream temporaryFileOutputStream, boolean keepBackup) throws IOException {
+        this(path, pathOfTemporaryFile, temporaryFileOutputStream, null, keepBackup);
+    }
+
+    private AtomicFileOutputStream(Path path,
+                                   Path pathOfTemporaryFile,
+                                   OutputStream temporaryFileOutputStream,
+                                   @Nullable FileChannel temporaryFileChannel,
+                                   boolean keepBackup) throws IOException {
         super(temporaryFileOutputStream);
         this.targetFile = path;
         this.temporaryFile = pathOfTemporaryFile;
         this.backupFile = getPathOfSaveBackupFile(path);
         this.keepBackup = keepBackup;
+        this.temporaryFileChannel = temporaryFileChannel;
+
+        if (temporaryFileChannel == null) {
+            return;
+        }
 
         try {
             // Lock files (so that at least not another JabRef instance writes at the same time to the same tmp file)
-            if (out instanceof FileOutputStream stream) {
-                try {
-                    temporaryFileLock = stream.getChannel().tryLock();
-                } catch (IOException ex) {
-                    // workaround for https://bugs.openjdk.org/browse/JDK-8167023
-                    LOGGER.warn("Could not acquire file lock. Maybe we are on a network drive?", ex);
-                    temporaryFileLock = null;
-                }
-            } else {
-                temporaryFileLock = null;
-            }
+            temporaryFileLock = temporaryFileChannel.tryLock();
+        } catch (IOException ex) {
+            // workaround for https://bugs.openjdk.org/browse/JDK-8167023
+            LOGGER.warn("Could not acquire file lock. Maybe we are on a network drive?", ex);
+            temporaryFileLock = null;
         } catch (OverlappingFileLockException exception) {
             throw new IOException("Could not obtain write access to " + temporaryFile + ". Maybe another instance of JabRef is currently writing to the same file?", exception);
         }
@@ -170,8 +206,8 @@ public class AtomicFileOutputStream extends FilterOutputStream {
             try {
                 // Make sure we have written everything to the temporary file
                 flush();
-                if (out instanceof FileOutputStream stream) {
-                    stream.getFD().sync();
+                if (temporaryFileChannel != null) {
+                    temporaryFileChannel.force(true);
                 }
             } catch (IOException exception) {
                 // Try to close nonetheless
@@ -207,13 +243,8 @@ public class AtomicFileOutputStream extends FilterOutputStream {
                 }
             }
 
-            try {
-                // Move temporary file (replace original if it exists)
-                Files.move(temporaryFile, targetFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-            } catch (IOException e) {
-                LOGGER.warn("Could not move temporary file", e);
-                throw e;
-            }
+            // Move temporary file (replace original if it exists)
+            moveTemporaryFileToTargetFile();
 
             // Restore file permissions
             if (FileUtil.IS_POSIX_COMPLIANT) {
@@ -231,6 +262,37 @@ public class AtomicFileOutputStream extends FilterOutputStream {
         } finally {
             // Remove temporary file (but not the backup!)
             cleanup();
+        }
+    }
+
+    /// Moves the temporary file onto the target file, replacing it.
+    ///
+    /// On Windows, replacing a file requires `DELETE` access to it. That fails with a sharing violation
+    /// (`ERROR_SHARING_VIOLATION`) while any other process holds a handle that was opened without
+    /// `FILE_SHARE_DELETE`. Qt-based editors (for example TeXstudio, which re-reads `.bib` files while the user
+    /// types), anti-virus scanners and the search indexer all open files that way, typically only for a few
+    /// milliseconds. Retrying briefly therefore clears virtually all of these collisions.
+    ///
+    /// See <[#11916](https://github.com/JabRef/jabref/issues/11916)>.
+    private void moveTemporaryFileToTargetFile() throws IOException {
+        for (int attempt = 1; attempt <= MOVE_ATTEMPTS; attempt++) {
+            try {
+                Files.move(temporaryFile, targetFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+                return;
+            } catch (FileSystemException exception) {
+                if (attempt == MOVE_ATTEMPTS) {
+                    LOGGER.warn("Could not move temporary file", exception);
+                    throw exception;
+                }
+                LOGGER.debug("Attempt {} of {} to move {} onto {} failed", attempt, MOVE_ATTEMPTS, temporaryFile, targetFile, exception);
+                try {
+                    Thread.sleep(MOVE_RETRY_INITIAL_DELAY_MILLIS << (attempt - 1));
+                } catch (InterruptedException interruptedException) {
+                    Thread.currentThread().interrupt();
+                    LOGGER.warn("Could not move temporary file", exception);
+                    throw exception;
+                }
+            }
         }
     }
 

--- a/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -24,7 +24,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/// A file output stream that is similar to the standard {@link java.io.FileOutputStream}, except that all writes are first
+/// A file output stream that is similar to the standard [java.io.FileOutputStream], except that all writes are first
 /// redirected to a temporary file. When the stream is closed, the temporary file (atomically) replaces the target file.
 ///
 ///


### PR DESCRIPTION
### Summary
Retry atomic save on Windows sharing violations and restore temp-file lock and fsync which caused 
```
org.jabref.logic.exporter.SaveException: Problems saving: java.nio.file.FileSystemException: C:\test-jabref\Chocolate.bib.tmp -> C:\test-jabref\Chocolate.bib: The process cannot access the file because it is being used by another process.
```

If you wish to read the full RCA, please go to https://github.com/texstudio-org/texstudio/issues/4258#issuecomment-5146464285.

### Steps to test

On Windows, 
1. Open the bib file in JabRef
2. Open the bib file in TeXstudio
3. Make any change to any of the bib entries, such as editing an author
4. Press <kbd>Ctrl+S</kbd> or go to File -> Save multiple times and ensure no exception occurs.

The above exception should occur in the current `main` branch, if the above steps are followed.
For a video, see https://github.com/texstudio-org/texstudio/issues/4258#issuecomment-4739476025.

### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/11916
Refs. https://github.com/texstudio-org/texstudio/issues/4258

### AI usage
Claude Opus 5 for the planning, manually refined and implemented.
Code comments generated/refined using the same.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [ ] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
