### PR TITLE
Add a space after insersion when there are no texts after a cursor

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CitationOOAdapterUtils.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CitationOOAdapterUtils.java
@@ -35,6 +35,7 @@ class CitationOOAdapterUtils {
         XTextCursor checkCursor = cursor.getText().createTextCursorByRange(cursor.getStart());
 
         if (!checkCursor.goRight((short) 1, true)) {
+            // We're at the end of the line
             return false;
         } else {
             succeedingSpaceExists = " ".equals(checkCursor.getString());

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CitationOOAdapterUtils.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CitationOOAdapterUtils.java
@@ -35,7 +35,7 @@ class CitationOOAdapterUtils {
         XTextCursor checkCursor = cursor.getText().createTextCursorByRange(cursor.getStart());
 
         if (!checkCursor.goRight((short) 1, true)) {
-            return true;
+            return false;
         } else {
             succeedingSpaceExists = " ".equals(checkCursor.getString());
             if (!succeedingSpaceExists) {


### PR DESCRIPTION
### Summary
Before, inserting a citation when there is no texts after the cursor, there will not be a space after the citaion when "add sapce after" is enabled. This PR fixed this problem.

### Steps to test
Add some texts then insert a citation, notice there is a space after the citation.
<img width="477" height="113" alt="image" src="https://github.com/user-attachments/assets/d465fdc9-d275-49d7-bdb6-988a054649f4" />

### Related issues and pull requests

Follow-up https://github.com/JabRef/jabref/pull/16420

### AI usage
🧠
_____

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
