### PR TITLE
Support track-changes mode for LibreOffice Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- The LibreOffice/OpenOffice integration now works with Track Changes enabled in the document. [#9403](https://github.com/JabRef/jabref/issues/9403) [#14018](https://github.com/JabRef/jabref/issues/14018)
 - We added configurable keyword delimiter detection for imported BibTeX, so that delimiters such as `;` are recognized and normalized to your configured keyword separator. [#12974](https://github.com/JabRef/jabref/issues/12974)
 - We added an "add space before citation" option in the LibreOffice integration. [#16349](https://github.com/JabRef/jabref/issues/16349)
 - CSL Citations emitted by JabRef in LibreOffice can now be read by Zotero (under a new preference "Zotero Compatibility Mode") and vice versa. [#15878](https://github.com/JabRef/jabref/issues/15878)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- The LibreOffice/OpenOffice integration now works with Track Changes enabled in the document. [#9403](https://github.com/JabRef/jabref/issues/9403) [#14018](https://github.com/JabRef/jabref/issues/14018)
+- The LibreOffice/OpenOffice integration now works with Track Changes enabled in the document. [#9403](https://github.com/JabRef/jabref/issues/9403). [#14018](https://github.com/JabRef/jabref/issues/14018)
 - We added configurable keyword delimiter detection for imported BibTeX, so that delimiters such as `;` are recognized and normalized to your configured keyword separator. [#12974](https://github.com/JabRef/jabref/issues/12974)
 - We added an "add space before citation" option in the LibreOffice integration. [#16349](https://github.com/JabRef/jabref/issues/16349)
 - CSL Citations emitted by JabRef in LibreOffice can now be read by Zotero (under a new preference "Zotero Compatibility Mode") and vice versa. [#15878](https://github.com/JabRef/jabref/issues/15878)

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -668,19 +668,29 @@ public class OOBibBase {
             // MUST always be paired with an unlockControllers() call
             doc.lockControllers();
 
-            if (convertReferenceMarks) {
-                cslCitationOOAdapter.convertReferenceMarksToPreference();
-            }
+            OOVoidResult<OOError> insertResult = supplyWithTrackChangesSuspended(doc, () -> {
+                try {
+                    if (convertReferenceMarks) {
+                        cslCitationOOAdapter.convertReferenceMarksToPreference();
+                    }
 
-            if (citationType == CitationType.AUTHORYEAR_PAR) {
-                // "Cite" button
-                cslCitationOOAdapter.insertCitation(cursor.get(), citationStyle, entries, bibDatabaseContext, bibEntryTypesManager);
-            } else if (citationType == CitationType.AUTHORYEAR_INTEXT) {
-                // "Cite in-text" button
-                cslCitationOOAdapter.insertInTextCitation(cursor.get(), citationStyle, entries, bibDatabaseContext, bibEntryTypesManager);
-            } else if (citationType == CitationType.INVISIBLE_CIT) {
-                // "Insert empty citation"
-                cslCitationOOAdapter.insertEmptyCitation(cursor.get(), citationStyle, entries, bibDatabaseContext);
+                    if (citationType == CitationType.AUTHORYEAR_PAR) {
+                        // "Cite" button
+                        cslCitationOOAdapter.insertCitation(cursor.get(), citationStyle, entries, bibDatabaseContext, bibEntryTypesManager);
+                    } else if (citationType == CitationType.AUTHORYEAR_INTEXT) {
+                        // "Cite in-text" button
+                        cslCitationOOAdapter.insertInTextCitation(cursor.get(), citationStyle, entries, bibDatabaseContext, bibEntryTypesManager);
+                    } else if (citationType == CitationType.INVISIBLE_CIT) {
+                        // "Insert empty citation"
+                        cslCitationOOAdapter.insertEmptyCitation(cursor.get(), citationStyle, entries, bibDatabaseContext);
+                    }
+                    return OOVoidResult.ok();
+                } catch (CreationException | com.sun.star.uno.Exception e) {
+                    return OOVoidResult.error(OOError.fromMisc(e));
+                }
+            });
+            if (insertResult.isError()) {
+                return insertResult;
             }
 
             // If "Automatically sync bibliography when inserting citations" is enabled
@@ -688,8 +698,6 @@ public class OOBibBase {
                 syncOptions.ifPresent(options -> guiActionUpdateDocument(options.databases, citationStyle));
             }
             return OOVoidResult.ok();
-        } catch (CreationException | com.sun.star.uno.Exception e) {
-            return OOVoidResult.error(OOError.fromMisc(e));
         } finally {
             // Release controller lock
             doc.unlockControllers();
@@ -745,10 +753,14 @@ public class OOBibBase {
                                                     OOResult<XTextCursor, OOError> cursor) {
         try {
             doc.lockControllers();
-            bstCitationOOAdapter.insertCitation(cursor.get(), entries, bibDatabaseContext);
-            return OOVoidResult.ok();
-        } catch (CreationException | com.sun.star.uno.Exception e) {
-            return OOVoidResult.error(OOError.fromMisc(e));
+            return supplyWithTrackChangesSuspended(doc, () -> {
+                try {
+                    bstCitationOOAdapter.insertCitation(cursor.get(), entries, bibDatabaseContext);
+                    return OOVoidResult.ok();
+                } catch (CreationException | com.sun.star.uno.Exception e) {
+                    return OOVoidResult.error(OOError.fromMisc(e));
+                }
+            });
         } finally {
             doc.unlockControllers();
         }

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -60,6 +60,7 @@ import com.sun.star.container.NoSuchElementException;
 import com.sun.star.lang.WrappedTargetException;
 import com.sun.star.text.XTextCursor;
 import com.sun.star.text.XTextDocument;
+import com.sun.star.text.XTextRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -304,35 +305,47 @@ public class OOBibBase {
      *
      * ******************************************************/
 
-    private static OOVoidResult<OOError> checkIfOpenOfficeIsRecordingChanges(XTextDocument doc) {
+    private OOVoidResult<OOError> checkCitationMarkersOutsidePendingDeletions(XTextDocument doc, OOStyle style, OOFrontend frontend) {
         String errorTitle = Localization.lang("Recording and/or Recorded changes");
         try {
-            boolean recordingChanges = UnoRedlines.getRecordChanges(doc);
-            int nRedlines = UnoRedlines.countRedlines(doc);
-            if (recordingChanges || (nRedlines > 0)) {
-                String msg = "";
-                if (recordingChanges) {
-                    msg += Localization.lang("Cannot work with"
-                            + " [Edit]/[Track Changes]/[Record] turned on.");
-                }
-                if (nRedlines > 0) {
-                    if (recordingChanges) {
-                        msg += "\n";
-                    }
-                    msg += Localization.lang("Changes by JabRef"
-                            + " could result in unexpected interactions with"
-                            + " recorded changes.");
-                    msg += "\n";
-                    msg += Localization.lang("Use [Edit]/[Track Changes]/[Manage] to resolve them first.");
-                }
-                return OOVoidResult.error(new OOError(errorTitle, msg));
+            // Keep the common path cheap: only run the overlap scan while Writer is actively
+            // recording changes.
+            if (!UnoRedlines.getRecordChanges(doc)) {
+                return OOVoidResult.ok();
             }
+
+            List<XTextRange> citationRanges = frontend.getCitationRanges(doc, style)
+                                                     .stream()
+                                                     .map(RangeForOverlapCheck::getRange)
+                                                     .toList();
+            if (UnoRedlines.countDeletedRangesTouching(doc, citationRanges) == 0) {
+                return OOVoidResult.ok();
+            }
+            String msg = Localization.lang("Citations inside deletions that have not been accepted yet may reappear.")
+                    + "\n"
+                    + Localization.lang("Use [Edit]/[Track Changes]/[Manage] to resolve them first.");
+            return OOVoidResult.error(new OOError(errorTitle, msg));
         } catch (WrappedTargetException ex) {
-            String msg = Localization.lang("Error while checking if Writer"
-                    + " is recording changes or has recorded changes.");
+            String msg = Localization.lang("Error while checking if Writer is recording changes or has recorded changes.");
             return OOVoidResult.error(new OOError(errorTitle, msg, ex));
+        } catch (NoDocumentException ex) {
+            return OOVoidResult.error(OOError.from(ex).setTitle(errorTitle));
         }
-        return OOVoidResult.ok();
+    }
+
+    /// Run a marker-rewriting action with change recording suspended.
+    ///
+    /// This prevents duplicated citations when Writer's change recording is enabled: deleting the
+    /// old marker would otherwise only mark it as deleted, leaving old and new marker side by side.
+    private <T> T supplyWithTrackChangesSuspended(XTextDocument doc, Supplier<T> action) {
+        List<T> holder = new ArrayList<>(1);
+        try {
+            UnoRedlines.withRecordChangesSuspended(doc, () -> holder.add(action.get()));
+        } catch (WrappedTargetException ex) {
+            LOGGER.warn("Could not suspend change recording", ex);
+            return action.get();
+        }
+        return holder.getFirst();
     }
 
     OOVoidResult<OOError> styleIsRequired(OOStyle style) {
@@ -475,11 +488,6 @@ public class OOBibBase {
         }
         XTextDocument doc = odoc.get();
 
-        if (testDialog(errorTitle, checkIfOpenOfficeIsRecordingChanges(doc))) {
-            LOGGER.warn(errorTitle);
-            return FAIL;
-        }
-
         OOResult<List<CitationEntry>, JabRefException> result = ManageCitations.getCitationEntries(doc);
         if (testDialog(errorTitle, result.asVoidResult().mapError(OOError::from))) {
             return FAIL;
@@ -562,9 +570,12 @@ public class OOBibBase {
         }
 
         if (style instanceof JStyle jStyle) {
+            OOVoidResult<OOError> pendingDeletionOverlap = syncOptions.isPresent()
+                    ? checkCitationMarkersOutsidePendingDeletions(doc, style, frontend.get())
+                    : OOVoidResult.ok();
             if (testDialog(errorTitle,
                     checkStylesExistInTheDocument(jStyle, doc),
-                    checkIfOpenOfficeIsRecordingChanges(doc))) {
+                    pendingDeletionOverlap)) {
                 return;
             }
         }
@@ -719,7 +730,9 @@ public class OOBibBase {
         }
 
         if (syncOptions.isPresent()) {
-            return Update.resyncDocument(doc, jStyle, fcursor.get(), syncOptions.get()).asVoidResult().mapError(OOError::from);
+            return supplyWithTrackChangesSuspended(doc,
+                    () -> Update.resyncDocument(doc, jStyle, fcursor.get(), syncOptions.get())
+                                .asVoidResult().mapError(OOError::from));
         }
         return OOVoidResult.ok();
     }
@@ -759,8 +772,7 @@ public class OOBibBase {
 
             if (testDialog(errorTitle,
                     fcursor.asVoidResult(),
-                    checkStylesExistInTheDocument(jStyle, doc),
-                    checkIfOpenOfficeIsRecordingChanges(doc))) {
+                    checkStylesExistInTheDocument(jStyle, doc))) {
                 return;
             }
 
@@ -772,16 +784,22 @@ public class OOBibBase {
                     return;
                 }
                 OOFrontend frontend = ofrontend.get();
+                if (testDialog(errorTitle, checkCitationMarkersOutsidePendingDeletions(doc, jStyle, frontend))) {
+                    return;
+                }
 
-                OOResult<Boolean, JabRefException> mergeResult = EditMerge.mergeCitationGroups(doc, frontend, jStyle);
+                OOResult<Boolean, JabRefException> mergeResult = supplyWithTrackChangesSuspended(doc,
+                        () -> EditMerge.mergeCitationGroups(doc, frontend, jStyle));
                 if (testDialog(errorTitle, mergeResult.asVoidResult().mapError(OOError::from))) {
                     return;
                 }
 
                 if (mergeResult.get()) {
-                    UnoCrossRef.refresh(doc);
-                    Update.SyncOptions syncOptions = new Update.SyncOptions(databases);
-                    OOResult<List<String>, JabRefException> syncResult = Update.resyncDocument(doc, jStyle, fcursor.get(), syncOptions);
+                    OOResult<List<String>, JabRefException> syncResult = supplyWithTrackChangesSuspended(doc, () -> {
+                        UnoCrossRef.refresh(doc);
+                        Update.SyncOptions syncOptions = new Update.SyncOptions(databases);
+                        return Update.resyncDocument(doc, jStyle, fcursor.get(), syncOptions);
+                    });
                     testDialog(errorTitle, syncResult.asVoidResult().mapError(OOError::from));
                 }
             } finally {
@@ -812,8 +830,7 @@ public class OOBibBase {
 
             if (testDialog(errorTitle,
                     fcursor.asVoidResult(),
-                    checkStylesExistInTheDocument(jStyle, doc),
-                    checkIfOpenOfficeIsRecordingChanges(doc))) {
+                    checkStylesExistInTheDocument(jStyle, doc))) {
                 return;
             }
 
@@ -825,16 +842,22 @@ public class OOBibBase {
                     return;
                 }
                 OOFrontend frontend = ofrontend.get();
+                if (testDialog(errorTitle, checkCitationMarkersOutsidePendingDeletions(doc, jStyle, frontend))) {
+                    return;
+                }
 
-                OOResult<Boolean, JabRefException> separateResult = EditSeparate.separateCitations(doc, frontend, databases, jStyle);
+                OOResult<Boolean, JabRefException> separateResult = supplyWithTrackChangesSuspended(doc,
+                        () -> EditSeparate.separateCitations(doc, frontend, databases, jStyle));
                 if (testDialog(errorTitle, separateResult.asVoidResult().mapError(OOError::from))) {
                     return;
                 }
 
                 if (separateResult.get()) {
-                    UnoCrossRef.refresh(doc);
-                    Update.SyncOptions syncOptions = new Update.SyncOptions(databases);
-                    OOResult<List<String>, JabRefException> syncResult = Update.resyncDocument(doc, jStyle, fcursor.get(), syncOptions);
+                    OOResult<List<String>, JabRefException> syncResult = supplyWithTrackChangesSuspended(doc, () -> {
+                        UnoCrossRef.refresh(doc);
+                        Update.SyncOptions syncOptions = new Update.SyncOptions(databases);
+                        return Update.resyncDocument(doc, jStyle, fcursor.get(), syncOptions);
+                    });
                     testDialog(errorTitle, syncResult.asVoidResult().mapError(OOError::from));
                 }
             } finally {
@@ -925,8 +948,7 @@ public class OOBibBase {
         if (style instanceof JStyle jStyle) {
             if (testDialog(errorTitle,
                     fcursor.asVoidResult(),
-                    checkStylesExistInTheDocument(jStyle, doc),
-                    checkIfOpenOfficeIsRecordingChanges(doc))) {
+                    checkStylesExistInTheDocument(jStyle, doc))) {
                 return;
             }
 
@@ -936,28 +958,39 @@ public class OOBibBase {
             }
             OOFrontend frontend = ofrontend.get();
 
-            if (testDialog(errorTitle, checkRangeOverlaps(doc, frontend))) {
+            if (testDialog(errorTitle,
+                    checkRangeOverlaps(doc, frontend),
+                    checkCitationMarkersOutsidePendingDeletions(doc, jStyle, frontend))) {
                 return;
             }
 
-            testDialog(errorTitle, updateJStyleBibliography(databases, jStyle, doc, frontend, fcursor, errorTitle));
+            testDialog(errorTitle, supplyWithTrackChangesSuspended(doc,
+                    () -> updateJStyleBibliography(databases, jStyle, doc, frontend, fcursor, errorTitle)));
         } else if (style instanceof CitationStyle citationStyle) {
             if (!citationStyle.hasBibliography()) {
                 return;
             }
+            OOResult<OOFrontend, OOError> ofrontend = getFrontend(doc);
             if (testDialog(errorTitle,
                     fcursor.asVoidResult(),
-                    checkIfOpenOfficeIsRecordingChanges(doc))) {
+                    ofrontend.asVoidResult())) {
                 return;
             }
-            testDialog(errorTitle, updateCSLBibliography(databases, citationStyle, doc, fcursor, errorTitle));
+            testDialog(errorTitle,
+                    checkCitationMarkersOutsidePendingDeletions(doc, citationStyle, ofrontend.get()),
+                    supplyWithTrackChangesSuspended(doc,
+                            () -> updateCSLBibliography(databases, citationStyle, doc, fcursor, errorTitle)));
         } else if (style instanceof BstStyle bstStyle) {
+            OOResult<OOFrontend, OOError> ofrontend = getFrontend(doc);
             if (testDialog(errorTitle,
                     fcursor.asVoidResult(),
-                    checkIfOpenOfficeIsRecordingChanges(doc))) {
+                    ofrontend.asVoidResult())) {
                 return;
             }
-            testDialog(errorTitle, updateBstBibliography(databases, bstStyle, doc, fcursor, errorTitle));
+            testDialog(errorTitle,
+                    checkCitationMarkersOutsidePendingDeletions(doc, bstStyle, ofrontend.get()),
+                    supplyWithTrackChangesSuspended(doc,
+                            () -> updateBstBibliography(databases, bstStyle, doc, fcursor, errorTitle)));
         }
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -341,8 +341,18 @@ public class OOBibBase {
         List<T> holder = new ArrayList<>(1);
         try {
             UnoRedlines.withRecordChangesSuspended(doc, () -> holder.add(action.get()));
+        } catch (UnoRedlines.TrackChangesRestoreException ex) {
+            LOGGER.warn("Could not restore change recording", ex);
+            dialogService.showWarningDialogAndWait(
+                    Localization.lang("Track changes"),
+                    Localization.lang("JabRef updated the document, but could not restore Track Changes."
+                            + " Please verify [Edit]/[Track Changes]/[Record]."));
+            return holder.getFirst();
         } catch (WrappedTargetException ex) {
             LOGGER.warn("Could not suspend change recording", ex);
+            if (!holder.isEmpty()) {
+                return holder.getFirst();
+            }
             return action.get();
         }
         return holder.getFirst();

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -315,9 +315,9 @@ public class OOBibBase {
             }
 
             List<XTextRange> citationRanges = frontend.getCitationRanges(doc, style)
-                                                     .stream()
-                                                     .map(RangeForOverlapCheck::getRange)
-                                                     .toList();
+                                                      .stream()
+                                                      .map(RangeForOverlapCheck::getRange)
+                                                      .toList();
             if (UnoRedlines.countDeletedRangesTouching(doc, citationRanges) == 0) {
                 return OOVoidResult.ok();
             }
@@ -571,8 +571,8 @@ public class OOBibBase {
 
         if (style instanceof JStyle jStyle) {
             OOVoidResult<OOError> pendingDeletionOverlap = syncOptions.isPresent()
-                    ? checkCitationMarkersOutsidePendingDeletions(doc, style, frontend.get())
-                    : OOVoidResult.ok();
+                                                           ? checkCitationMarkersOutsidePendingDeletions(doc, style, frontend.get())
+                                                           : OOVoidResult.ok();
             if (testDialog(errorTitle,
                     checkStylesExistInTheDocument(jStyle, doc),
                     pendingDeletionOverlap)) {

--- a/jablib/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
@@ -27,7 +27,6 @@ import org.jabref.model.openoffice.style.CitationGroup;
 import org.jabref.model.openoffice.style.CitationGroupId;
 import org.jabref.model.openoffice.style.CitationGroups;
 import org.jabref.model.openoffice.style.CitationType;
-import org.jabref.model.openoffice.style.OODataModel;
 import org.jabref.model.openoffice.uno.CreationException;
 import org.jabref.model.openoffice.uno.NoDocumentException;
 import org.jabref.model.openoffice.uno.UnoCursor;
@@ -51,10 +50,7 @@ public class OOFrontend {
     public final Backend52 backend;
     public final CitationGroups citationGroups;
 
-    public OOFrontend(XTextDocument doc)
-            throws
-            NoDocumentException,
-            WrappedTargetException {
+    public OOFrontend(XTextDocument doc) throws NoDocumentException, WrappedTargetException {
 
         // TODO: dataModel should come from looking at the document and preferences.
         this.backend = new Backend52();
@@ -70,30 +66,14 @@ public class OOFrontend {
     public static OOResult<OOFrontend, JabRefException> create(XTextDocument doc) {
         try {
             return OOResult.ok(new OOFrontend(doc));
-        } catch (NoDocumentException | WrappedTargetException e) {
-            return OOResult.error(new JabRefException(e.getMessage(), e));
-        } catch (RuntimeException e) {
+        } catch (NoDocumentException | WrappedTargetException | RuntimeException e) {
             return OOResult.error(new JabRefException(e.getMessage(), e));
         }
     }
 
-    public OODataModel getDataModel() {
-        return backend.dataModel;
-    }
-
-    public Optional<String> healthReport(XTextDocument doc)
-            throws
-            NoDocumentException {
-        return backend.healthReport(doc);
-    }
-
     private static Map<CitationGroupId, CitationGroup>
-    readCitationGroupsFromDocument(Backend52 backend,
-                                   XTextDocument doc,
-                                   List<String> citationGroupNames)
-            throws
-            WrappedTargetException,
-            NoDocumentException {
+    readCitationGroupsFromDocument(Backend52 backend, XTextDocument doc, List<String> citationGroupNames)
+            throws WrappedTargetException, NoDocumentException {
 
         Map<CitationGroupId, CitationGroup> citationGroups = new HashMap<>();
         for (String name : citationGroupNames) {
@@ -112,11 +92,8 @@ public class OOFrontend {
     /// In the result, RangeSortable.getIndexInPosition() contains unique indexes within the original partition (not after mapFootnotesToFootnoteMarks).
     ///
     /// @param mapFootnotesToFootnoteMarks If true, replace ranges in footnotes with the range of the corresponding footnote mark. This is used for numbering the citations.
-    private List<RangeSortable<CitationGroup>> createVisualSortInput(XTextDocument doc,
-                                                                     boolean mapFootnotesToFootnoteMarks)
-            throws
-            NoDocumentException,
-            WrappedTargetException {
+    private List<RangeSortable<CitationGroup>> createVisualSortInput(XTextDocument doc, boolean mapFootnotesToFootnoteMarks)
+            throws NoDocumentException, WrappedTargetException {
 
         List<RangeSortEntry<CitationGroup>> sortables = new ArrayList<>();
         for (CitationGroup group : citationGroups.getCitationGroupsUnordered()) {
@@ -188,13 +165,10 @@ public class OOFrontend {
     /// This is (1) sufficient for combineCiteMarkers which looks for consecutive XTextRanges within each XText, (2) not confused by multicolumn layout or multipage display.
     public List<CitationGroup>
     getCitationGroupsSortedWithinPartitions(XTextDocument doc, boolean mapFootnotesToFootnoteMarks)
-            throws
-            NoDocumentException,
-            WrappedTargetException {
+            throws NoDocumentException, WrappedTargetException {
         // This is like getVisuallySortedCitationGroups,
         // but we skip the visualSort part.
-        List<RangeSortable<CitationGroup>> sortables =
-                createVisualSortInput(doc, mapFootnotesToFootnoteMarks);
+        List<RangeSortable<CitationGroup>> sortables = createVisualSortInput(doc, mapFootnotesToFootnoteMarks);
 
         return sortables.stream().map(RangeSortable::getContent).collect(Collectors.toList());
     }
@@ -237,10 +211,7 @@ public class OOFrontend {
 
     /// Remove `group` both from the document and notify `citationGroups`
     public void removeCitationGroup(CitationGroup group, XTextDocument doc)
-            throws
-            WrappedTargetException,
-            NoDocumentException,
-            NotRemoveableException {
+            throws WrappedTargetException, NoDocumentException, NotRemoveableException {
 
         backend.removeCitationGroup(group, doc);
         this.citationGroups.afterRemoveCitationGroup(group);
@@ -261,34 +232,34 @@ public class OOFrontend {
     ///
     /// @return Optional.empty() if the reference mark is missing.
     public Optional<XTextRange> getMarkRange(XTextDocument doc, CitationGroup group)
-            throws
-            NoDocumentException,
-            WrappedTargetException {
+            throws NoDocumentException, WrappedTargetException {
         return backend.getMarkRange(group, doc);
     }
 
     public XTextCursor getFillCursorForCitationGroup(XTextDocument doc, CitationGroup group)
-            throws
-            NoDocumentException,
-            WrappedTargetException,
-            CreationException {
+            throws NoDocumentException, WrappedTargetException, CreationException {
         return backend.getFillCursorForCitationGroup(group, doc);
     }
 
     /// Remove brackets added by getFillCursorForCitationGroup.
     public void cleanFillCursorForCitationGroup(XTextDocument doc, CitationGroup group)
-            throws
-            NoDocumentException,
-            WrappedTargetException {
+            throws NoDocumentException, WrappedTargetException {
 
         backend.cleanFillCursorForCitationGroup(group, doc);
     }
 
+    // TODO: @pluto-han - tackle unification of the next two methods
+    public List<RangeForOverlapCheck<CitationGroupId>> getCitationRanges(XTextDocument doc, OOStyle style)
+            throws NoDocumentException, WrappedTargetException {
+        if (style instanceof JStyle) {
+            return getJStyleCitationRanges(doc);
+        }
+        return getReferenceMarkCitationRanges(doc);
+    }
+
     /// @return A RangeForOverlapCheck for each citation group. result.size() == nRefMarks
     public List<RangeForOverlapCheck<CitationGroupId>> getJStyleCitationRanges(XTextDocument doc)
-            throws
-            NoDocumentException,
-            WrappedTargetException {
+            throws NoDocumentException, WrappedTargetException {
 
         List<RangeForOverlapCheck<CitationGroupId>> result =
                 new ArrayList<>(citationGroups.numberOfCitationGroups());
@@ -304,10 +275,9 @@ public class OOFrontend {
         return result;
     }
 
-    private List<RangeForOverlapCheck<CitationGroupId>> getCSLCitationRanges(XTextDocument doc)
-            throws
-            NoDocumentException,
-            WrappedTargetException {
+    /// @return A RangeForOverlapCheck for each non-JStyle citation represented by a Writer reference mark.
+    private List<RangeForOverlapCheck<CitationGroupId>> getReferenceMarkCitationRanges(XTextDocument doc)
+            throws NoDocumentException, WrappedTargetException {
 
         List<RangeForOverlapCheck<CitationGroupId>> result = new ArrayList<>();
 
@@ -333,9 +303,7 @@ public class OOFrontend {
     }
 
     public List<RangeForOverlapCheck<CitationGroupId>> bibliographyRanges(XTextDocument doc)
-            throws
-            NoDocumentException,
-            WrappedTargetException {
+            throws NoDocumentException, WrappedTargetException {
 
         List<RangeForOverlapCheck<CitationGroupId>> result = new ArrayList<>();
 
@@ -441,7 +409,7 @@ public class OOFrontend {
             if (style instanceof JStyle) {
                 citationRanges = getJStyleCitationRanges(doc);
             } else {
-                citationRanges = getCSLCitationRanges(doc);
+                citationRanges = getReferenceMarkCitationRanges(doc);
             }
 
             List<RangeForOverlapCheck<CitationGroupId>> ranges = new ArrayList<>();
@@ -510,9 +478,7 @@ public class OOFrontend {
     ///
     /// Wish: selecting an entry (or a button in the line) in the GUI could move the cursor in the document to the entry.
     public List<CitationEntry> getCitationEntries(XTextDocument doc)
-            throws
-            WrappedTargetException,
-            NoDocumentException {
+            throws WrappedTargetException, NoDocumentException {
         return this.backend.getCitationEntries(doc, citationGroups);
     }
 
@@ -526,13 +492,10 @@ public class OOFrontend {
     }
 
     public void imposeGlobalOrder(XTextDocument doc, FunctionalTextViewCursor fcursor)
-            throws
-            WrappedTargetException,
-            NoDocumentException {
+            throws WrappedTargetException, NoDocumentException {
 
         boolean mapFootnotesToFootnoteMarks = true;
-        List<CitationGroup> sortedCitationGroups =
-                getVisuallySortedCitationGroups(doc, mapFootnotesToFootnoteMarks, fcursor);
+        List<CitationGroup> sortedCitationGroups = getVisuallySortedCitationGroups(doc, mapFootnotesToFootnoteMarks, fcursor);
         List<CitationGroupId> sortedCitationGroupIds = OOListUtil.map(sortedCitationGroups, group -> group.groupId);
         citationGroups.setGlobalOrder(sortedCitationGroupIds);
     }

--- a/jablib/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
@@ -265,9 +265,13 @@ public class OOFrontend {
                 new ArrayList<>(citationGroups.numberOfCitationGroups());
 
         for (CitationGroup group : citationGroups.getCitationGroupsUnordered()) {
-            XTextRange range = this.getMarkRange(doc, group).orElseThrow(IllegalStateException::new);
-            String description = range.getString();
-            result.add(new RangeForOverlapCheck<>(range,
+            Optional<XTextRange> range = this.getMarkRange(doc, group);
+            if (range.isEmpty()) {
+                continue;
+            }
+            XTextRange textRange = range.get();
+            String description = textRange.getString();
+            result.add(new RangeForOverlapCheck<>(textRange,
                     group.groupId,
                     RangeForOverlapCheck.REFERENCE_MARK_KIND,
                     description));

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/BSTReferenceMarkManager.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/BSTReferenceMarkManager.java
@@ -327,6 +327,10 @@ public class BSTReferenceMarkManager {
 
         for (BSTReferenceMark mark : marksInOrder) {
             XTextRange range = mark.getTextContent().getAnchor();
+            if (range == null) {
+                LOGGER.debug("Skipping dangling BST reference mark without anchor: {}", mark.getName());
+                continue;
+            }
             sortEntries.add(new RangeSortEntry<>(range, 0, mark));
         }
 

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLReferenceMarkManager.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLReferenceMarkManager.java
@@ -638,6 +638,10 @@ public class CSLReferenceMarkManager {
 
         for (CSLReferenceMark mark : marksInOrder) {
             XTextRange range = mark.getTextContent().getAnchor();
+            if (range == null) {
+                LOGGER.debug("Skipping dangling reference mark without anchor: {}", mark.getName());
+                continue;
+            }
             sortEntries.add(new RangeSortEntry<>(range, 0, mark));
         }
 

--- a/jablib/src/main/java/org/jabref/model/openoffice/uno/UnoRedlines.java
+++ b/jablib/src/main/java/org/jabref/model/openoffice/uno/UnoRedlines.java
@@ -1,7 +1,10 @@
 package org.jabref.model.openoffice.uno;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
+import com.sun.star.beans.PropertyVetoException;
 import com.sun.star.beans.UnknownPropertyException;
 import com.sun.star.beans.XPropertySet;
 import com.sun.star.container.NoSuchElementException;
@@ -10,13 +13,15 @@ import com.sun.star.container.XEnumerationAccess;
 import com.sun.star.document.XRedlinesSupplier;
 import com.sun.star.lang.WrappedTargetException;
 import com.sun.star.text.XTextDocument;
+import com.sun.star.text.XTextRange;
 
 /// Change tracking and Redlines
 public class UnoRedlines {
 
+    private static final String REDLINE_TYPE_DELETE = "Delete";
+
     public static boolean getRecordChanges(XTextDocument doc)
-            throws
-            WrappedTargetException {
+            throws WrappedTargetException {
 
         // https://wiki.openoffice.org/wiki/Documentation/DevGuide/Text/Settings
         // "Properties of com.sun.star.text.TextDocument"
@@ -30,30 +35,123 @@ public class UnoRedlines {
         }
     }
 
+    public static void setRecordChanges(XTextDocument doc, boolean recordChanges)
+            throws WrappedTargetException {
+
+        XPropertySet propertySet = UnoCast.cast(XPropertySet.class, doc).get();
+
+        try {
+            propertySet.setPropertyValue("RecordChanges", recordChanges);
+        } catch (UnknownPropertyException | PropertyVetoException
+                 | com.sun.star.lang.IllegalArgumentException ex) {
+            throw new IllegalStateException("Could not set 'RecordChanges'", ex);
+        }
+    }
+
     private static Optional<XRedlinesSupplier> getRedlinesSupplier(XTextDocument doc) {
         return UnoCast.cast(XRedlinesSupplier.class, doc);
     }
 
-    public static int countRedlines(XTextDocument doc) {
+    /// The ranges covered by not-yet-accepted deletions.
+    public static List<XTextRange> getDeletedRanges(XTextDocument doc) {
         Optional<XRedlinesSupplier> supplier = getRedlinesSupplier(doc);
         if (supplier.isEmpty()) {
-            return 0;
+            return List.of();
         }
         XEnumerationAccess enumerationAccess = supplier.get().getRedlines();
         XEnumeration enumeration = enumerationAccess.createEnumeration();
         if (enumeration == null) {
-            return 0;
-        } else {
-            int count = 0;
-            while (enumeration.hasMoreElements()) {
-                try {
-                    enumeration.nextElement();
+            return List.of();
+        }
+
+        List<XTextRange> result = new ArrayList<>();
+        while (enumeration.hasMoreElements()) {
+            Object redline;
+            try {
+                redline = enumeration.nextElement();
+            } catch (NoSuchElementException | WrappedTargetException ex) {
+                break;
+            }
+            if (isDeleteRedline(redline)) {
+                getRedlineRange(redline).ifPresent(result::add);
+            }
+        }
+        return result;
+    }
+
+    public static int countDeletedRangesTouching(XTextDocument doc, List<XTextRange> ranges) {
+        int count = 0;
+        for (XTextRange deletedRange : getDeletedRanges(doc)) {
+            for (XTextRange range : ranges) {
+                if (!UnoTextRange.comparables(deletedRange, range)) {
+                    continue;
+                }
+                boolean disjoint = UnoTextRange.compareStarts(deletedRange, range.getEnd()) > 0
+                        || UnoTextRange.compareStarts(range, deletedRange.getEnd()) > 0;
+                if (!disjoint) {
                     count++;
-                } catch (NoSuchElementException | WrappedTargetException ex) {
                     break;
                 }
             }
-            return count;
         }
+        return count;
+    }
+
+    private static boolean isDeleteRedline(Object redline) {
+        Optional<XPropertySet> propertySet = UnoCast.cast(XPropertySet.class, redline);
+        if (propertySet.isEmpty()) {
+            return false;
+        }
+        try {
+            return REDLINE_TYPE_DELETE.equals(propertySet.get().getPropertyValue("RedlineType"));
+        } catch (UnknownPropertyException | WrappedTargetException ex) {
+            return false;
+        }
+    }
+
+    private static Optional<XTextRange> getRedlineRange(Object redline) {
+        Optional<XTextRange> asRange = UnoCast.cast(XTextRange.class, redline);
+        if (asRange.isPresent()) {
+            return asRange;
+        }
+        Optional<XPropertySet> propertySet = UnoCast.cast(XPropertySet.class, redline);
+        if (propertySet.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            return UnoCast.cast(XTextRange.class, propertySet.get().getPropertyValue("RedlineStart"));
+        } catch (UnknownPropertyException | WrappedTargetException ex) {
+            return Optional.empty();
+        }
+    }
+
+    /// Run `action` with change recording switched off, then restore the previous setting.
+    ///
+    /// Refreshing a citation marker means deleting its old text and writing new text. While
+    /// recording is on, the delete only *marks* the old text as deleted, so the old and the new
+    /// marker end up side by side and the citation appears twice. Suspending recording for the
+    /// duration of our own edits is what keeps that from happening.
+    ///
+    /// JabRef's own rewrite operations are not recorded as tracked changes.
+    /// TODO: Add this warning to user documentation
+    public static void withRecordChangesSuspended(XTextDocument doc, RedlineAction action)
+            throws WrappedTargetException {
+
+        boolean wasRecording = getRecordChanges(doc);
+        if (wasRecording) {
+            setRecordChanges(doc, false);
+        }
+        try {
+            action.run();
+        } finally {
+            if (wasRecording) {
+                setRecordChanges(doc, true);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    public interface RedlineAction {
+        void run() throws WrappedTargetException;
     }
 }

--- a/jablib/src/main/java/org/jabref/model/openoffice/uno/UnoRedlines.java
+++ b/jablib/src/main/java/org/jabref/model/openoffice/uno/UnoRedlines.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
+
 import com.sun.star.beans.PropertyVetoException;
 import com.sun.star.beans.UnknownPropertyException;
 import com.sun.star.beans.XPropertySet;
@@ -142,40 +144,30 @@ public class UnoRedlines {
             setRecordChanges(doc, false);
         }
 
-        WrappedTargetException actionException = null;
-        RuntimeException actionRuntimeException = null;
-        TrackChangesRestoreException restoreException = null;
-
         try {
             action.run();
-        } catch (WrappedTargetException ex) {
-            actionException = ex;
-        } catch (RuntimeException ex) {
-            actionRuntimeException = ex;
-        } finally {
-            if (wasRecording) {
-                try {
-                    setRecordChanges(doc, true);
-                } catch (WrappedTargetException | RuntimeException restoreFailure) {
-                    if (actionException != null) {
-                        actionException.addSuppressed(restoreFailure);
-                    } else if (actionRuntimeException != null) {
-                        actionRuntimeException.addSuppressed(restoreFailure);
-                    } else {
-                        restoreException = new TrackChangesRestoreException(restoreFailure);
-                    }
-                }
-            }
+        } catch (WrappedTargetException | RuntimeException actionFailure) {
+            restoreTrackChanges(doc, wasRecording, actionFailure);
+            throw actionFailure;
         }
 
-        if (actionException != null) {
-            throw actionException;
+        restoreTrackChanges(doc, wasRecording, null);
+    }
+
+    private static void restoreTrackChanges(XTextDocument doc, boolean wasRecording, @Nullable Throwable actionFailure)
+            throws WrappedTargetException, TrackChangesRestoreException {
+        if (!wasRecording) {
+            return;
         }
-        if (actionRuntimeException != null) {
-            throw actionRuntimeException;
-        }
-        if (restoreException != null) {
-            throw restoreException;
+
+        try {
+            setRecordChanges(doc, true);
+        } catch (WrappedTargetException | RuntimeException restoreFailure) {
+            if (actionFailure != null) {
+                actionFailure.addSuppressed(restoreFailure);
+                return;
+            }
+            throw new TrackChangesRestoreException(restoreFailure);
         }
     }
 

--- a/jablib/src/main/java/org/jabref/model/openoffice/uno/UnoRedlines.java
+++ b/jablib/src/main/java/org/jabref/model/openoffice/uno/UnoRedlines.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.jspecify.annotations.Nullable;
-
 import com.sun.star.beans.PropertyVetoException;
 import com.sun.star.beans.UnknownPropertyException;
 import com.sun.star.beans.XPropertySet;
@@ -16,6 +14,7 @@ import com.sun.star.document.XRedlinesSupplier;
 import com.sun.star.lang.WrappedTargetException;
 import com.sun.star.text.XTextDocument;
 import com.sun.star.text.XTextRange;
+import org.jspecify.annotations.Nullable;
 
 /// Change tracking and Redlines
 public class UnoRedlines {

--- a/jablib/src/main/java/org/jabref/model/openoffice/uno/UnoRedlines.java
+++ b/jablib/src/main/java/org/jabref/model/openoffice/uno/UnoRedlines.java
@@ -135,18 +135,53 @@ public class UnoRedlines {
     /// JabRef's own rewrite operations are not recorded as tracked changes.
     /// TODO: Add this warning to user documentation
     public static void withRecordChangesSuspended(XTextDocument doc, RedlineAction action)
-            throws WrappedTargetException {
+            throws WrappedTargetException, TrackChangesRestoreException {
 
         boolean wasRecording = getRecordChanges(doc);
         if (wasRecording) {
             setRecordChanges(doc, false);
         }
+
+        WrappedTargetException actionException = null;
+        RuntimeException actionRuntimeException = null;
+        TrackChangesRestoreException restoreException = null;
+
         try {
             action.run();
+        } catch (WrappedTargetException ex) {
+            actionException = ex;
+        } catch (RuntimeException ex) {
+            actionRuntimeException = ex;
         } finally {
             if (wasRecording) {
-                setRecordChanges(doc, true);
+                try {
+                    setRecordChanges(doc, true);
+                } catch (WrappedTargetException | RuntimeException restoreFailure) {
+                    if (actionException != null) {
+                        actionException.addSuppressed(restoreFailure);
+                    } else if (actionRuntimeException != null) {
+                        actionRuntimeException.addSuppressed(restoreFailure);
+                    } else {
+                        restoreException = new TrackChangesRestoreException(restoreFailure);
+                    }
+                }
             }
+        }
+
+        if (actionException != null) {
+            throw actionException;
+        }
+        if (actionRuntimeException != null) {
+            throw actionRuntimeException;
+        }
+        if (restoreException != null) {
+            throw restoreException;
+        }
+    }
+
+    public static final class TrackChangesRestoreException extends Exception {
+        public TrackChangesRestoreException(Throwable cause) {
+            super("Could not restore Track Changes", cause);
         }
     }
 

--- a/jablib/src/main/java/org/jabref/model/openoffice/uno/UnoRedlines.java
+++ b/jablib/src/main/java/org/jabref/model/openoffice/uno/UnoRedlines.java
@@ -31,7 +31,7 @@ public class UnoRedlines {
         try {
             return (boolean) propertySet.getPropertyValue("RecordChanges");
         } catch (UnknownPropertyException ex) {
-            throw new java.lang.IllegalStateException("Caught UnknownPropertyException on 'RecordChanges'");
+            throw new IllegalStateException("Caught UnknownPropertyException on 'RecordChanges'");
         }
     }
 

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -2603,6 +2603,8 @@ Error\ while\ checking\ if\ Writer\ is\ recording\ changes\ or\ has\ recorded\ c
 Recording\ and/or\ Recorded\ changes=Recording and/or Recorded changes
 Citations\ inside\ deletions\ that\ have\ not\ been\ accepted\ yet\ may\ reappear.=Citations inside deletions that have not been accepted yet may reappear.
 Use\ [Edit]/[Track\ Changes]/[Manage]\ to\ resolve\ them\ first.=Use [Edit]/[Track Changes]/[Manage] to resolve them first.
+Track\ changes=Track changes
+JabRef\ updated\ the\ document,\ but\ could\ not\ restore\ Track\ Changes.\ Please\ verify\ [Edit]/[Track\ Changes]/[Record].=JabRef updated the document, but could not restore Track Changes. Please verify [Edit]/[Track Changes]/[Record].
 
 Unable\ to\ find\ valid\ certification\ path\ to\ requested\ target(%0),\ download\ anyway?=Unable to find valid certification path to requested target(%0), download anyway?
 Download\ operation\ canceled.=Download operation canceled.

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -2610,13 +2610,8 @@ The\ %0\ paragraph\ style\ '%1'\ is\ a\ display\ name\ for\ '%2'.=The %0 paragra
 The\ %0\ paragraph\ style\ '%1'\ is\ missing\ from\ the\ document=The %0 paragraph style '%1' is missing from the document
 
 Error\ while\ checking\ if\ Writer\ is\ recording\ changes\ or\ has\ recorded\ changes.=Error while checking if Writer is recording changes or has recorded changes.
-
-Cannot\ work\ with\ [Edit]/[Track\ Changes]/[Record]\ turned\ on.=Cannot work with [Edit]/[Track Changes]/[Record] turned on.
-
-Changes\ by\ JabRef\ could\ result\ in\ unexpected\ interactions\ with\ recorded\ changes.=Changes by JabRef could result in unexpected interactions with recorded changes.
-
 Recording\ and/or\ Recorded\ changes=Recording and/or Recorded changes
-
+Citations\ inside\ deletions\ that\ have\ not\ been\ accepted\ yet\ may\ reappear.=Citations inside deletions that have not been accepted yet may reappear.
 Use\ [Edit]/[Track\ Changes]/[Manage]\ to\ resolve\ them\ first.=Use [Edit]/[Track Changes]/[Manage] to resolve them first.
 
 Unable\ to\ find\ valid\ certification\ path\ to\ requested\ target(%0),\ download\ anyway?=Unable to find valid certification path to requested target(%0), download anyway?


### PR DESCRIPTION
### Summary
Since Track Changes mode was quite popular among our users, this adds support for it in our LibreOffice integration, matching Zotero's behavior* by suspending tracking during citation/bibliography inserts.
\* with one caveat: in the risky case where a citation marker overlaps a pending tracked deletion, JabRef still refuses to rewrite it (hard fail) to preserve document consistency.


https://github.com/user-attachments/assets/877e11ae-6cba-49db-ae56-cd7092aebc71

### Steps to test

1. Enable Track changes in LO
2. Connect to the doc
3. Play around with citing, see that it works.

### Related issues and pull requests

Contributes to https://github.com/JabRef/jabref/issues/7861
Closes https://github.com/JabRef/jabref/issues/9403
Closes https://github.com/JabRef/jabref/issues/14018

### AI usage

Claude Opus 5, Zed, GPT 5.4 (manually driven, reviewed and tweaked).

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
