### PR TITLE
[Experimental] Defer ControlsFX validation decoration to avoid entry editor freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where the entry editor would freeze for some time on first load. [#16343](https://github.com/JabRef/jabref/issues/16343)
-- We fixed an issue where JabRef was unable to save the changed `.bib` file if it was open in TeXstudio on Windows. [#11916](https://github.com/JabRef/jabref/issues/11916)
+- We fixed an issue where opening the entry editor for the first time froze the UI for several seconds. [#16343](https://github.com/JabRef/jabref/issues/16343)
 - We fixed alignment of Journal/JournalTitle info icon in entry editor. [#16425](https://github.com/JabRef/jabref/issues/16425)
 - We fixed an issue in the LibreOffice integration where citations generated via CSL styles were not properly formatted. [#16379](https://github.com/JabRef/jabref/issues/16379)
 - We fixed an issue in the LibreOffice integration where generating bibliography or inserting citations made superscript citations smaller and smaller. [#16351](https://github.com/JabRef/jabref/issues/16351)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where the entry editor would freeze for some time on first load. [#16343](https://github.com/JabRef/jabref/issues/16343)
 - We fixed an issue where JabRef was unable to save the changed `.bib` file if it was open in TeXstudio on Windows. [#11916](https://github.com/JabRef/jabref/issues/11916)
 - We fixed alignment of Journal/JournalTitle info icon in entry editor. [#16425](https://github.com/JabRef/jabref/issues/16425)
 - We fixed an issue in the LibreOffice integration where citations generated via CSL styles were not properly formatted. [#16379](https://github.com/JabRef/jabref/issues/16379)
@@ -182,7 +183,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where the entry editor would freeze for some time on first load. [#16343](https://github.com/JabRef/jabref/issues/16343)
 - We fixed an issue in the LibreOffice integration where the user could insert a CSL citation inside an existing one. [#15701](https://github.com/JabRef/jabref/issues/15701)
 - We fixed an issue where multiple entries are not cited as a single citation for CSL in-text. [#15703](https://github.com/JabRef/jabref/issues/15703)
 - We fixed an issue where the citation key generator did not show the date for child entries due to orphaned crossref links. [#9071](https://github.com/JabRef/jabref/issues/9071)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where the entry editor would freeze for some time on first load. [#16343](https://github.com/JabRef/jabref/issues/16343)
 - We fixed an issue in the LibreOffice integration where the user could insert a CSL citation inside an existing one. [#15701](https://github.com/JabRef/jabref/issues/15701)
 - We fixed an issue where multiple entries are not cited as a single citation for CSL in-text. [#15703](https://github.com/JabRef/jabref/issues/15703)
 - We fixed an issue where the citation key generator did not show the date for child entries due to orphaned crossref links. [#9071](https://github.com/JabRef/jabref/issues/9071)

--- a/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -13,8 +13,10 @@ import javafx.beans.binding.Bindings;
 import javafx.collections.ListChangeListener;
 import javafx.concurrent.Task;
 import javafx.geometry.Rectangle2D;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Region;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
@@ -65,6 +67,9 @@ import com.dlsc.gemsfx.infocenter.InfoCenterPane;
 import com.dlsc.gemsfx.infocenter.InfoCenterViewPos;
 import com.tobiasdiez.easybind.EasyBind;
 import kong.unirest.core.Unirest;
+import org.controlsfx.control.decoration.Decoration;
+import org.controlsfx.control.decoration.Decorator;
+import org.controlsfx.control.decoration.GraphicDecoration;
 import org.controlsfx.dialog.ExceptionDialog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -348,6 +353,17 @@ public class JabRefGUI extends Application {
         powerpane.getInfoCenterPane().autoHideProperty().bind(Bindings.isEmpty(dialogService.getPersistentNotifications()));
 
         Scene scene = new Scene(powerpane);
+
+        // ControlsFX lazily installs its internal DecorationPane as the scene root the
+        // first time any control is decorated (e.g. by a field validator), silently
+        // reparenting the entire scene graph under it. Doing this during normal usage
+        // freezes the UI for several seconds - see #16343. Trigger that one-time
+        // installation now, during startup, by decorating and immediately
+        // un-decorating a throwaway node that is already attached to the scene.
+        Node decorationWarmupTarget = JabRefGUI.mainFrame;
+        Decoration decorationWarmup = new GraphicDecoration(new Region());
+        Decorator.addDecoration(decorationWarmupTarget, decorationWarmup);
+        Decorator.removeDecoration(decorationWarmupTarget, decorationWarmup);
 
         LOGGER.debug("installing CSS");
         themeManager.installCssOnScene(scene);

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/EditorValidator.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/EditorValidator.java
@@ -1,6 +1,5 @@
 package org.jabref.gui.fieldeditors;
 
-import javafx.application.Platform;
 import javafx.scene.control.TextInputControl;
 
 import org.jabref.gui.preferences.GuiPreferences;
@@ -21,7 +20,7 @@ public class EditorValidator {
         if (preferences.getEntryEditorPreferences().shouldEnableValidation()) {
             ControlsFxVisualizer validationVisualizer = new ControlsFxVisualizer();
             validationVisualizer.setDecoration(new IconValidationDecorator());
-            Platform.runLater(() -> validationVisualizer.initVisualization(status, textInput));
+            validationVisualizer.initVisualization(status, textInput);
         }
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/EditorValidator.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/EditorValidator.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.fieldeditors;
 
+import javafx.application.Platform;
 import javafx.scene.control.TextInputControl;
 
 import org.jabref.gui.preferences.GuiPreferences;
@@ -20,7 +21,7 @@ public class EditorValidator {
         if (preferences.getEntryEditorPreferences().shouldEnableValidation()) {
             ControlsFxVisualizer validationVisualizer = new ControlsFxVisualizer();
             validationVisualizer.setDecoration(new IconValidationDecorator());
-            validationVisualizer.initVisualization(status, textInput);
+            Platform.runLater(() -> validationVisualizer.initVisualization(status, textInput));
         }
     }
 }


### PR DESCRIPTION
### Summary
ControlsFX installs its internal `DecorationPane` the first time anything gets decorated. In JabRef that usually happens later, when a validator adds a decoration to a field. That first decoration silently reparents the whole scene under the new pane, and on a large JavaFX scene graph it can fall into the slow CSS/layout path discussed in https://github.com/openjdk/jfx/pull/2225 and the related issues [JDK-8388277](https://bugs.openjdk.org/browse/JDK-8388277) and [JDK-8187955](https://bugs.openjdk.org/browse/JDK-8187955). The result was the several-second UI freeze when first opening the entry editor with "some" entries. After that first hit, later decorations were fine because the one-time setup and CSS helper state were already in place.

Warm-up that one-time ControlsFX setup during startup instead, right after the main scene is created, by decorating and immediately undecorating a throwaway node that is already attached to the scene. That keeps the expensive reparenting and CSS work out of normal interaction, so validation and other later decorations no longer cause the visible freeze.

### Steps to test

Try to open entry editor after JabRef runs.

### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/16343

### AI usage
@Maran23's 🧠, Claude for code exploration and explanation.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
