### PR TITLE
Do not mark PRs ready for review when they enter the merge queue

### DIFF
--- a/.github/workflows/on-pr-labeled-update-pr-status.yml
+++ b/.github/workflows/on-pr-labeled-update-pr-status.yml
@@ -37,20 +37,16 @@ jobs:
       - name: Mark PR ready for review
         if: steps.check.outputs.continue == 'true'
         run: |
-          LABELS=$(gh api repos/${{ github.repository }}/issues/${{ steps.check.outputs.pr_number }}/labels --jq '.[].name')
+          PR=$(gh pr view --repo ${{ github.repository }} ${{ steps.check.outputs.pr_number }} --json state,isDraft,labels)
 
-          if echo "$LABELS" | grep -q "^status: to-be-merged$"; then
-            echo "⊘ label to-be-merged found - PR is in the merge queue, nothing to do"
+          # "gh pr ready" only works on open draft PRs. Anything else (merged from the merge queue, closed,
+          # already ready for review) would make it exit non-zero and thus fail this workflow.
+          if [ "$(jq -r .state <<< "$PR")" != "OPEN" ] || [ "$(jq -r .isDraft <<< "$PR")" != "true" ]; then
+            echo "⊘ PR is not an open draft - nothing to mark ready for review"
             exit 0
           fi
 
-          STATE=$(gh pr view --repo ${{ github.repository }} ${{ steps.check.outputs.pr_number }} --json state --jq '.state')
-          if [ "$STATE" != "OPEN" ]; then
-            echo "⊘ PR is $STATE - only open PRs can be marked ready for review"
-            exit 0
-          fi
-
-          if echo "$LABELS" | grep -q "^status: ready-for-review$"; then
+          if jq -e '.labels[] | select(.name == "status: ready-for-review")' <<< "$PR" > /dev/null; then
             echo "✅ label ready-for-review found"
             gh pr ready --repo ${{ github.repository }} ${{ steps.check.outputs.pr_number }}
           else

--- a/.github/workflows/on-pr-labeled-update-pr-status.yml
+++ b/.github/workflows/on-pr-labeled-update-pr-status.yml
@@ -39,6 +39,17 @@ jobs:
         run: |
           LABELS=$(gh api repos/${{ github.repository }}/issues/${{ steps.check.outputs.pr_number }}/labels --jq '.[].name')
 
+          if echo "$LABELS" | grep -q "^status: to-be-merged$"; then
+            echo "⊘ label to-be-merged found - PR is in the merge queue, nothing to do"
+            exit 0
+          fi
+
+          STATE=$(gh pr view --repo ${{ github.repository }} ${{ steps.check.outputs.pr_number }} --json state --jq '.state')
+          if [ "$STATE" != "OPEN" ]; then
+            echo "⊘ PR is $STATE - only open PRs can be marked ready for review"
+            exit 0
+          fi
+
           if echo "$LABELS" | grep -q "^status: ready-for-review$"; then
             echo "✅ label ready-for-review found"
             gh pr ready --repo ${{ github.repository }} ${{ steps.check.outputs.pr_number }}

--- a/.github/workflows/on-pr-labeled-update-pr-status.yml
+++ b/.github/workflows/on-pr-labeled-update-pr-status.yml
@@ -41,8 +41,14 @@ jobs:
 
           # "gh pr ready" only works on open draft PRs. Anything else (merged from the merge queue, closed,
           # already ready for review) would make it exit non-zero and thus fail this workflow.
-          if [ "$(jq -r .state <<< "$PR")" != "OPEN" ] || [ "$(jq -r .isDraft <<< "$PR")" != "true" ]; then
-            echo "⊘ PR is not an open draft - nothing to mark ready for review"
+          STATE=$(jq -r .state <<< "$PR")
+          if [ "$STATE" != "OPEN" ]; then
+            echo "⊘ PR is $STATE - only open PRs can be marked ready for review"
+            exit 0
+          fi
+
+          if [ "$(jq -r .isDraft <<< "$PR")" != "true" ]; then
+            echo "⊘ PR is not a draft - it is already ready for review"
             exit 0
           fi
 

--- a/.github/workflows/on-pr-labeled.yml
+++ b/.github/workflows/on-pr-labeled.yml
@@ -25,6 +25,9 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER}}
   upload-pr-nnumber:
+    # "status: to-be-merged" is set when the PR is added to the merge queue.
+    # The PR is then merged (and thus closed) before the follow-up workflow runs, which would make "gh pr ready" fail.
+    if: "github.event.label.name != 'status: to-be-merged'"
     runs-on: ubuntu-slim
     permissions:
       contents: read


### PR DESCRIPTION
### Summary

The label `status: to-be-merged` is added when a pull request enters the merge queue.
That triggered the `On PR labeled` workflow, which triggered `Adapt PR status`, which then failed with `Pull request is closed. Only draft pull requests can be marked as "ready for review"` — by the time it ran, the merge queue had already merged and closed the PR.
The `pr_number` artifact is now no longer uploaded for that label. In addition, the follow-up workflow no longer looks at labels to guess the situation: it checks the actual precondition of `gh pr ready` — the pull request has to be an open draft. That is race free, whereas `isInMergeQueue` is already `false` by the time the merge queue has merged the pull request, which is exactly when the follow-up workflow runs.

Analogies: this fix is like honey — it removes the sticky red cross that kept clinging to every merged pull request. It is like chocolate in that it is a small, self-contained square that you can break off and enjoy without touching the rest of the bar. And it is like the moon: the workflow kept showing up long after the sun had set on the pull request, so we now let it stay below the horizon.

`jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

1. Label an open, non-draft pull request with `status: to-be-merged` (or add it to the merge queue, which applies the label automatically).
2. Observe that the `upload-pr-nnumber` job of `On PR labeled` is skipped, and that the follow-up `Adapt PR status` run no longer fails.
3. Add `status: ready-for-review` to an already non-draft open pull request and observe that the workflow logs `PR is not an open draft` instead of doing anything.
4. Label an open **draft** pull request with `status: ready-for-review` and observe that it is still marked ready for review — the existing behavior is unchanged.

### Related issues and pull requests

Closes _____

No issue exists. The failing run that motivated this change: https://github.com/JabRef/jabref/actions/runs/30836327084

### AI usage

Claude Code (model claude-opus-5[1m])

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

# Code checklist

> [!IMPORTANT]
> **This is a mandatory final gate.** When the implementation is finished and before you open a PR, work through **every** box below and tick it. If a box cannot be ticked, fix the code first; mark a box `[/]` only if the point genuinely does not apply.
>
> `AGENTS.md` describes how to write code *while* developing — this file confirms the finished result. Do not skip the checklist and do not skip individual points.

## 1. Code self-review

Read your own diff once, top to bottom, and confirm each point.

### Nullability and control flow

- [/] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead. — no Java sources changed
- [/] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations. — no Java sources changed
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`). — no Java sources changed
- [/] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block. — no Java sources changed
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`. — no Java sources changed

### Exceptions

- [/] No `catch (Exception e)` — only specific exceptions are caught. — no Java sources changed
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application. — no Java sources changed
- [/] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string. — no Java sources changed

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`). — no Java sources changed
- [/] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks. — no Java sources changed
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`. — no Java sources changed
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`. — no Java sources changed
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source. — the two added YAML comments explain *why* the label is excluded, they do not restate the code
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`. — no Java sources changed

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML). — workflow log output only, not shown in the application
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`. — workflow log output only
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation. — workflow log output only

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS). — no HTTP response is produced

### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests. — no Java sources changed
- [/] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories. — no tests changed

## 2. Verification commands

Run in this order — cheapest first. Each must pass.

- [/] `./gradlew :jablib:check` (or `./gradlew check` for all modules). — no Java sources or Gradle files changed
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`. — no Java sources changed
- [/] `./gradlew modernizer`. — no Java sources changed
- [/] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix). — no Java sources changed
- [/] `./gradlew javadoc`. — no Java sources changed
- [/] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed). — no Markdown changed
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`. — no Java sources changed

## 3. Documentation

- [/] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Link the issue if one exists; link the PR only when no issue exists. Use `TODO` as the placeholder when neither is known yet — never a fake number. — CI-internal change, not visible to end users
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues). — searched both trackers, no matching issue found, so the failing workflow run is linked instead
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes). — CI infrastructure fix, not a product feature
- [/] Developer documentation under `docs/` updated if behavior or architecture changed. — no developer-facing behavior or architecture changed

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder (no issue confidently identified yet — an existing issue link always stays), it was replaced with the real PR-number link after PR creation, then committed and pushed. If an issue is identified or created later, the link is switched to the issue. — no CHANGELOG.md entry was added

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required) — GitHub Actions workflow change, not reachable from the application
- [/] I added JUnit tests for changes (if applicable) — no Java sources changed
- [/] I added screenshots in the PR description (if change is visible to the user) — no user-visible change
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number — no user-visible change
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user) — CI-internal change
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en) — CI-internal change
