### PR TITLE
CI: Don't trigger `binaries` on any label, force trigger on right label

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -175,6 +175,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_ACTION: ${{ github.event.action }}
           LABEL_NAME: ${{ github.event.label.name }}
+          HAS_DEV_BINARIES_LABEL_FROM_EVENT: "${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dev: binaries') || 'false' }}"
           NON_WORKFLOW_CHANGES: ${{ steps.changed-non-workflow-files.outputs.any_changed }}
           BINARIES_WORKFLOW_CHANGED: ${{ steps.changed-binaries-workflow.outputs.any_changed }}
           BINARIES_RESOURCE_MARKDOWN_CHANGED: ${{ steps.changed-binaries-resource-markdown.outputs.any_changed }}
@@ -184,13 +185,7 @@ jobs:
           set -x
           PS4='+ ${LINENO}: '
 
-          HAS_DEV_BINARIES_LABEL=false
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            LABELS=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --jq '.[].name')
-            if echo "$LABELS" | grep -q "^dev: binaries$"; then
-              HAS_DEV_BINARIES_LABEL=true
-            fi
-          fi
+          HAS_DEV_BINARIES_LABEL="$HAS_DEV_BINARIES_LABEL_FROM_EVENT"
 
           if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" != "automerge" && "$LABEL_NAME" != "dev: binaries" ]]; then
             echo "⊘ build should be skipped"

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -184,6 +184,14 @@ jobs:
           set -x
           PS4='+ ${LINENO}: '
 
+          HAS_DEV_BINARIES_LABEL=false
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            LABELS=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --jq '.[].name')
+            if echo "$LABELS" | grep -q "^dev: binaries$"; then
+              HAS_DEV_BINARIES_LABEL=true
+            fi
+          fi
+
           if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" != "automerge" && "$LABEL_NAME" != "dev: binaries" ]]; then
             echo "⊘ build should be skipped"
             echo "⊘ build should be skipped" >> $GITHUB_STEP_SUMMARY
@@ -191,15 +199,20 @@ jobs:
             exit 0
           fi
 
-          if [[ "${{ github.event_name }}" == "pull_request" && "$NON_WORKFLOW_CHANGES" != "true" && "$BINARIES_WORKFLOW_CHANGED" != "true" && "$BINARIES_RESOURCE_MARKDOWN_CHANGED" != "true" ]]; then
+          if [[ "$HAS_DEV_BINARIES_LABEL" != "true" && "${{ github.event_name }}" == "pull_request" && "$NON_WORKFLOW_CHANGES" != "true" && "$BINARIES_WORKFLOW_CHANGED" != "true" && "$BINARIES_RESOURCE_MARKDOWN_CHANGED" != "true" ]]; then
             echo "⊘ no build-relevant files changed – skipping build"
             echo "⊘ no build-relevant files changed – skipping build" >> "$GITHUB_STEP_SUMMARY"
             echo "should-build=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "📦 build enabled"
-          echo "📦 build enabled" >> $GITHUB_STEP_SUMMARY
+          if [[ "$HAS_DEV_BINARIES_LABEL" == "true" ]]; then
+            echo "📦 build forced by label 'dev: binaries'"
+            echo "📦 build forced by label 'dev: binaries'" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "📦 build enabled"
+            echo "📦 build enabled" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "should-build=true" >> "$GITHUB_OUTPUT"
 
           if [[ "${{ github.event.inputs.useEaJdk || 'false' }}" == "true" ]]; then
@@ -299,9 +312,7 @@ jobs:
             exit 0
           fi
 
-          LABELS=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --jq '.[].name')
-
-          if echo "$LABELS" | grep -q "^dev: binaries$"; then
+          if [[ "$HAS_DEV_BINARIES_LABEL" == "true" ]]; then
             echo "☁️ Label 'dev: binaries' found – will upload"
             echo "☁️ Label 'dev: binaries' found – will upload" >> $GITHUB_STEP_SUMMARY
             echo "upload-to-builds-jabref-org=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1135,8 +1135,7 @@ jobs:
           if-no-files-found: error
 
   upload-pr-nnumber:
-    needs: conditions
-    if: ${{ github.event_name == 'pull_request' && needs.conditions.outputs.should-build == 'true' }}
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -313,6 +313,7 @@ jobs:
 
   disk-space-check:
     needs: conditions
+    if: needs.conditions.outputs.should-build == 'true'
     runs-on: ubuntu-slim
     outputs:
       available: ${{ steps.diskspace.outputs.available }}
@@ -372,6 +373,7 @@ jobs:
 
   compute-matrix:
     needs: conditions
+    if: needs.conditions.outputs.should-build == 'true'
     runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
@@ -445,6 +447,7 @@ jobs:
 
   pre-build:
     needs: [ conditions, disk-space-check ]
+    if: needs.conditions.outputs.should-build == 'true'
     runs-on: ubuntu-22.04
     outputs:
       AssemblySemVer: ${{ steps.gitversion.outputs.AssemblySemVer }}
@@ -508,6 +511,7 @@ jobs:
 
   build:
     needs: [ compute-matrix, conditions, disk-space-check, pre-build ]
+    if: needs.conditions.outputs.should-build == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -832,6 +836,7 @@ jobs:
 
   jabkit-native:
     needs: [ conditions, disk-space-check, pre-build ]
+    if: needs.conditions.outputs.should-build == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -1119,6 +1124,8 @@ jobs:
           if-no-files-found: error
 
   upload-pr-nnumber:
+    needs: conditions
+    if: ${{ github.event_name == 'pull_request' && needs.conditions.outputs.should-build == 'true' }}
     runs-on: ubuntu-slim
     permissions:
       contents: read


### PR DESCRIPTION
### Summary
I added `awaiting-second-review` label in https://github.com/JabRef/jabref/pull/16492, and a fan-out of some unrelated downstream binary jobs happened in `Binaries` workflow in the CI. The jobs did get skipped eventually after `conditions` (since the label was != `dev: binaries` or `automerge`, so `should_build` turned false down the line), but they got triggered. That was confusing.

1. Don't let unrelated PR labels fan out beyond the `conditions` job in the `Binaries` workflow (currently, `pull_request:labeled` triggers the workflow, and labels other than `automerge` and `dev: binaries` are skipped only after `conditions`).
    ```yml
    if [[ "$EVENT_ACTION" == "labeled" && "$LABEL_NAME" != "automerge" && "$LABEL_NAME" != "dev: binaries" ]]; then
      echo "should-build=false" >> "$GITHUB_OUTPUT"
      exit 0
   fi
    ```

2. Force trigger binaries if `dev: binaries` label is present, even if no related files are changed (currently it is triggered and skipped if relevant files are not changed - developer should have an override if they need).

### Steps to test

Time will tell.

### Related issues and pull requests

Closes NA

### AI usage

Zed + GPT 5.4 + brain

### Checklist


- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
