### PR TITLE
refactor(null): simplify SaveException

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/exporter/SaveException.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/SaveException.java
@@ -2,7 +2,6 @@ package org.jabref.logic.exporter;
 
 import java.util.Optional;
 
-import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
 
 import org.jspecify.annotations.Nullable;
@@ -10,16 +9,7 @@ import org.jspecify.annotations.Nullable;
 /// Exception thrown if saving goes wrong. If caused by a specific
 /// entry, keeps track of which entry caused the problem.
 public class SaveException extends Exception {
-
-    public static final SaveException FILE_LOCKED = new SaveException(
-            "Could not save, file locked by another JabRef instance.",
-            Localization.lang("Could not save, file locked by another JabRef instance."));
-    public static final SaveException BACKUP_CREATION = new SaveException("Unable to create backup",
-            Localization.lang("Unable to create backup"));
-
-    @Nullable private BibEntry entry;
-    private int status;
-    private String localizedMessage;
+    private @Nullable BibEntry entry;
 
     public SaveException(String message) {
         super(message);
@@ -31,26 +21,13 @@ public class SaveException extends Exception {
         entry = null;
     }
 
-    public SaveException(String message, String localizedMessage) {
-        super(message);
-        this.localizedMessage = localizedMessage;
-        entry = null;
-    }
-
-    public SaveException(String message, int status) {
-        super(message);
-        entry = null;
-        this.status = status;
-    }
-
     public SaveException(String message, @Nullable BibEntry entry) {
         super(message);
         this.entry = entry;
     }
 
-    public SaveException(String message, String localizedMessage, @Nullable BibEntry entry, Throwable base) {
+    public SaveException(String message, @Nullable BibEntry entry, Throwable base) {
         super(message, base);
-        this.localizedMessage = localizedMessage;
         this.entry = entry;
     }
 
@@ -59,27 +36,10 @@ public class SaveException extends Exception {
     }
 
     public SaveException(Throwable base, BibEntry entry) {
-        this(base.getMessage(), base.getLocalizedMessage(), entry, base);
-    }
-
-    public int getStatus() {
-        return status;
+        this(base.getMessage(), entry, base);
     }
 
     public Optional<BibEntry> getEntry() {
         return Optional.ofNullable(entry);
-    }
-
-    public boolean specificEntry() {
-        return entry != null;
-    }
-
-    @Override
-    public String getLocalizedMessage() {
-        if (localizedMessage == null) {
-            return getMessage();
-        } else {
-            return localizedMessage;
-        }
     }
 }

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -725,7 +725,6 @@ Saving\ all\ libraries...=Saving all libraries...
 Saving\ library=Saving library
 Library\ saved=Library saved
 Could\ not\ save\ file.=Could not save file.
-Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Could not save, file locked by another JabRef instance.
 Saved\ selected\ to\ '%0'.=Saved selected to '%0'.
 Autosave\ local\ libraries=Autosave local libraries
 Enable\ MSC\ keyword\ descriptions=Enable MSC keyword descriptions
@@ -1082,7 +1081,6 @@ The\ following\ metadata\ changed\:=The following metadata changed:
 
 Red\:\ Removed,\ Blue\:\ Changed,\ Green\:\ Added=Red: Removed, Blue: Changed, Green: Added
 
-Unable\ to\ create\ backup=Unable to create backup
 <b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>All Entries</b> (this group cannot be edited or removed)
 static\ group=static group
 dynamic\ group=dynamic group


### PR DESCRIPTION
### Summary

Just removes somme stuff from `SaveException`. Initially made for removing nullaway issues.

All removed constructures were really used nowhere.

### Steps to test

Everything should be normal as before.

### Related issues and pull requests

Closes NA

### AI usage

NO!

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
