### PR TITLE
Fix macOS ⌥F and ⌥S shortcut conflicts

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
+++ b/jabgui/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
@@ -64,7 +64,7 @@ public enum KeyBinding {
     FILE_LIST_EDITOR_MOVE_ENTRY_UP("File list editor, move entry up", Localization.lang("File list editor, move entry up"), "shortcut+UP", KeyBindingCategory.VIEW),
     FIND_UNLINKED_FILES("Search for unlinked local files", Localization.lang("Search for unlinked local files"), "shift+F7", KeyBindingCategory.QUALITY),
     FOCUS_ENTRY_TABLE("Focus entry table", Localization.lang("Focus entry table"), "alt+1", KeyBindingCategory.VIEW),
-    FOCUS_GROUP_LIST("Focus group list", Localization.lang("Focus group list"), "alt+s", KeyBindingCategory.VIEW),
+    FOCUS_GROUP_LIST("Focus group list", Localization.lang("Focus group list"), "shortcut+alt+G", KeyBindingCategory.VIEW),
     HELP("Help", Localization.lang("Help"), "F1", KeyBindingCategory.FILE),
     IMPORT_INTO_CURRENT_LIBRARY("Import into current library...", Localization.lang("Import into current library..."), "shortcut+I", KeyBindingCategory.FILE),
     IMPORT_INTO_NEW_LIBRARY("Import into new library...", Localization.lang("Import into new library..."), "shortcut+alt+I", KeyBindingCategory.FILE),
@@ -128,7 +128,7 @@ public enum KeyBinding {
     SKIMMED("Set read status to skimmed", Localization.lang("Set read status to skimmed"), "", KeyBindingCategory.EDIT),
     GROUP_RENAME("Rename group", Localization.lang("Rename group"), "F2", KeyBindingCategory.EDIT),
     MERGE_WITH_FETCHED_ENTRY("Get bibliographic data from %0, \"DOI/ISBN/...\"", Localization.lang("Get bibliographic data from %0", "DOI/ISBN/..."), "F5", KeyBindingCategory.EDIT),
-    LOOKUP_DOC_IDENTIFIER("Search document identifier online", Localization.lang("Search document identifier online"), "alt+F", KeyBindingCategory.EDIT),
+    LOOKUP_DOC_IDENTIFIER("Search document identifier online", Localization.lang("Search document identifier online"), "shortcut+alt+F", KeyBindingCategory.EDIT),
     RENAME_FILE_TO_NAME("Rename file(s) to configured filename format pattern", Localization.lang("Rename file(s) to configured filename format pattern"), "shortcut+P", KeyBindingCategory.EDIT);
 
     private final String constant;

--- a/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -267,17 +267,21 @@ public class PreferencesMigrations {
     /// This conflicts with JabRef's keybindings for "Search document identifier online" (alt+F) and
     /// "Focus group list" (alt+S), which both trigger the action AND insert the character in text fields.
     /// Fix: migrate these to `shortcut+alt+letter` which uses Cmd+Alt on macOS (no character conflict).
-    private static void upgradeKeyBindingsMacOSAltConflicts(JabRefCliPreferences prefs) {
+    static void upgradeKeyBindingsMacOSAltConflicts(JabRefCliPreferences prefs) {
         List<String> bindNames = new ArrayList<>(prefs.getStringList(JabRefGuiPreferences.BIND_NAMES));
         List<String> bindings = new ArrayList<>(prefs.getStringList(JabRefGuiPreferences.BINDINGS));
+
+        if (bindNames.isEmpty() || bindings.isEmpty() || bindNames.size() != bindings.size()) {
+            return;
+        }
 
         for (int i = 0; i < bindNames.size(); i++) {
             String name = bindNames.get(i);
             String binding = bindings.get(i);
 
-            if ("LOOKUP_DOC_IDENTIFIER".equals(name) && "alt+F".equals(binding)) {
+            if ("Search document identifier online".equals(name) && "alt+F".equals(binding)) {
                 bindings.set(i, "shortcut+alt+F");
-            } else if ("FOCUS_GROUP_LIST".equals(name) && "alt+s".equals(binding)) {
+            } else if ("Focus group list".equals(name) && "alt+s".equals(binding)) {
                 bindings.set(i, "shortcut+alt+G");
             }
         }

--- a/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -275,18 +275,23 @@ public class PreferencesMigrations {
             return;
         }
 
+        boolean changed = false;
         for (int i = 0; i < bindNames.size(); i++) {
             String name = bindNames.get(i);
             String binding = bindings.get(i);
 
             if ("Search document identifier online".equals(name) && "alt+F".equals(binding)) {
                 bindings.set(i, "shortcut+alt+F");
+                changed = true;
             } else if ("Focus group list".equals(name) && "alt+s".equals(binding)) {
                 bindings.set(i, "shortcut+alt+G");
+                changed = true;
             }
         }
 
-        prefs.putStringList(JabRefGuiPreferences.BINDINGS, bindings);
+        if (changed) {
+            prefs.putStringList(JabRefGuiPreferences.BINDINGS, bindings);
+        }
     }
 
     private static void addCrossRefRelatedFieldsForAutoComplete(JabRefCliPreferences prefs) {

--- a/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -51,6 +51,7 @@ public class PreferencesMigrations {
         upgradeImportFileAndDirePatterns(preferences);
         upgradeStoredBibEntryTypes(preferences, mainPrefsNode, preferences.getCustomEntryTypesRepository());
         upgradeKeyBindingsToJavaFX(preferences);
+        upgradeKeyBindingsMacOSAltConflicts(preferences);
         addCrossRefRelatedFieldsForAutoComplete(preferences);
         upgradePreviewStyle(preferences);
         upgradeBuiltinPreviewName(preferences);
@@ -260,6 +261,28 @@ public class PreferencesMigrations {
         List<String> keys = new ArrayList<>(prefs.getStringList(JabRefGuiPreferences.BINDINGS));
         keys.replaceAll(replaceKeys);
         prefs.putStringList(JabRefGuiPreferences.BINDINGS, keys);
+    }
+
+    /// On macOS, `alt+letter` combinations produce special characters (e.g., alt+F -> ƒ, alt+S -> ß).
+    /// This conflicts with JabRef's keybindings for "Search document identifier online" (alt+F) and
+    /// "Focus group list" (alt+S), which both trigger the action AND insert the character in text fields.
+    /// Fix: migrate these to `shortcut+alt+letter` which uses Cmd+Alt on macOS (no character conflict).
+    private static void upgradeKeyBindingsMacOSAltConflicts(JabRefCliPreferences prefs) {
+        List<String> bindNames = new ArrayList<>(prefs.getStringList(JabRefGuiPreferences.BIND_NAMES));
+        List<String> bindings = new ArrayList<>(prefs.getStringList(JabRefGuiPreferences.BINDINGS));
+
+        for (int i = 0; i < bindNames.size(); i++) {
+            String name = bindNames.get(i);
+            String binding = bindings.get(i);
+
+            if ("LOOKUP_DOC_IDENTIFIER".equals(name) && "alt+F".equals(binding)) {
+                bindings.set(i, "shortcut+alt+F");
+            } else if ("FOCUS_GROUP_LIST".equals(name) && "alt+s".equals(binding)) {
+                bindings.set(i, "shortcut+alt+G");
+            }
+        }
+
+        prefs.putStringList(JabRefGuiPreferences.BINDINGS, bindings);
     }
 
     private static void addCrossRefRelatedFieldsForAutoComplete(JabRefCliPreferences prefs) {

--- a/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
+++ b/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
@@ -303,4 +303,53 @@ class GuiPreferencesMigrationsTest {
 
         verify(workspacePreferences).setTheme(Theme.light());
     }
+
+    @Test
+    void upgradeKeyBindingsMacOSAltConflictsMigratesAltF() {
+        List<String> bindNames = List.of("Search document identifier online", "Focus group list", "Help");
+        List<String> bindings = List.of("alt+F", "alt+s", "F1");
+
+        when(preferences.getStringList(JabRefGuiPreferences.BIND_NAMES)).thenReturn(bindNames);
+        when(preferences.getStringList(JabRefGuiPreferences.BINDINGS)).thenReturn(bindings);
+
+        PreferencesMigrations.upgradeKeyBindingsMacOSAltConflicts(preferences);
+
+        verify(preferences).putStringList(JabRefGuiPreferences.BINDINGS, List.of("shortcut+alt+F", "shortcut+alt+G", "F1"));
+    }
+
+    @Test
+    void upgradeKeyBindingsMacOSAltConflictsSkipsAlreadyMigratedBindings() {
+        List<String> bindNames = List.of("Search document identifier online", "Focus group list");
+        List<String> bindings = List.of("shortcut+alt+F", "shortcut+alt+G");
+
+        when(preferences.getStringList(JabRefGuiPreferences.BIND_NAMES)).thenReturn(bindNames);
+        when(preferences.getStringList(JabRefGuiPreferences.BINDINGS)).thenReturn(bindings);
+
+        PreferencesMigrations.upgradeKeyBindingsMacOSAltConflicts(preferences);
+
+        verify(preferences, never()).putStringList(anyString(), any());
+    }
+
+    @Test
+    void upgradeKeyBindingsMacOSAltConflictsHandlesMismatchedListSizes() {
+        List<String> bindNames = List.of("Search document identifier online");
+        List<String> bindings = List.of("alt+F", "alt+s", "F1");
+
+        when(preferences.getStringList(JabRefGuiPreferences.BIND_NAMES)).thenReturn(bindNames);
+        when(preferences.getStringList(JabRefGuiPreferences.BINDINGS)).thenReturn(bindings);
+
+        PreferencesMigrations.upgradeKeyBindingsMacOSAltConflicts(preferences);
+
+        verify(preferences, never()).putStringList(anyString(), any());
+    }
+
+    @Test
+    void upgradeKeyBindingsMacOSAltConflictsHandlesEmptyLists() {
+        when(preferences.getStringList(JabRefGuiPreferences.BIND_NAMES)).thenReturn(List.of());
+        when(preferences.getStringList(JabRefGuiPreferences.BINDINGS)).thenReturn(List.of());
+
+        PreferencesMigrations.upgradeKeyBindingsMacOSAltConflicts(preferences);
+
+        verify(preferences, never()).putStringList(anyString(), any());
+    }
 }


### PR DESCRIPTION
### Summary

On macOS, pressing Option+F triggers "Search document identifier online" AND inserts 'ƒ' into text fields. Same for Option+S — triggers "Focus group list" AND inserts 'ß'. This happens because macOS processes Option as a character modifier before generating the KeyEvent.

Changed both keybinding defaults from `alt+letter` to `shortcut+alt+letter` (Cmd+Alt on macOS, Ctrl+Alt on Windows/Linux), which doesn't produce character input. Also added a preferences migration to upgrade existing users' stored bindings.

`jabref-contrib-policy:4.2:reviewed​:ok`

### Analogies

This PR is like honey — sticky enough to hold onto the right shortcuts without letting unwanted characters slip through. It's like chocolate — a small, sweet fix that improves the macOS experience. And it's like the moon — quietly fixing things in the background while users focus on their work.

### Steps to test

1. Build JabRef on macOS
2. Open a library with entries
3. Press Option+F in a text field — should NOT insert 'ƒ'
4. Press Option+S in a text field — should NOT insert 'ß'
5. Go to Options > Preferences > Keyboard Shortcuts
6. Verify "Search document identifier online" shows Cmd+Alt+F
7. Verify "Focus group list" shows Cmd+Alt+G

### Related issues and pull requests

Closes #16528

### AI usage

None

### Checklist

- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [ ] I checked the user documentation for up to dateness and submitted a pull request to our user documentation repository
