### PR TITLE
fix(fetchers): fix OpenAlex entry type assignment

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/OpenAlex.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/OpenAlex.java
@@ -7,6 +7,8 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -31,7 +33,10 @@ import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
-import org.jabref.model.entry.types.EntryTypeFactory;
+import org.jabref.model.entry.types.BiblatexNonStandardEntryType;
+import org.jabref.model.entry.types.EntryType;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.entry.types.UnknownEntryType;
 import org.jabref.model.search.query.BaseQueryNode;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -55,6 +60,33 @@ public class OpenAlex implements CustomizableKeyFetcher, SearchBasedParserFetche
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenAlex.class);
 
     private static final String URL_PATTERN = "https://api.openalex.org/works";
+    private static final Map<String, EntryType> OPENALEX_TYPE_TO_ENTRY_TYPE = Map.ofEntries(
+            Map.entry("article", StandardEntryType.Article),
+            Map.entry("other", StandardEntryType.Misc),
+            Map.entry("dataset", StandardEntryType.Dataset),
+            Map.entry("book-chapter", StandardEntryType.InCollection),
+            Map.entry("dissertation", StandardEntryType.Thesis),
+            Map.entry("conference-paper", StandardEntryType.InProceedings),
+            Map.entry("book", StandardEntryType.Book),
+            Map.entry("preprint", StandardEntryType.Online),
+            Map.entry("paratext", StandardEntryType.Misc),
+            Map.entry("conference-abstract", StandardEntryType.InProceedings),
+            Map.entry("report", StandardEntryType.Report),
+            Map.entry("reference-entry", StandardEntryType.InReference),
+            Map.entry("book-review", BiblatexNonStandardEntryType.Review),
+            Map.entry("libguides", StandardEntryType.Online),
+            Map.entry("peer-review", BiblatexNonStandardEntryType.Review),
+            Map.entry("editorial", StandardEntryType.Article),
+            Map.entry("review", StandardEntryType.Article),
+            Map.entry("software", StandardEntryType.Software),
+            Map.entry("supplementary-materials", StandardEntryType.Dataset),
+            Map.entry("letter", StandardEntryType.Article),
+            Map.entry("erratum", StandardEntryType.Article),
+            Map.entry("standard", StandardEntryType.Manual),
+            Map.entry("retraction", StandardEntryType.Article),
+            Map.entry("data-paper", StandardEntryType.Article),
+            Map.entry("software-paper", StandardEntryType.Article)
+    );
 
     private final ImporterPreferences importerPreferences;
 
@@ -65,6 +97,18 @@ public class OpenAlex implements CustomizableKeyFetcher, SearchBasedParserFetche
     @Override
     public String getName() {
         return FETCHER_NAME;
+    }
+
+    @VisibleForTesting
+    EntryType mapOpenAlexTypeToEntryType(String openAlexType) {
+        String normalizedOpenAlexType = openAlexType.toLowerCase(Locale.ENGLISH);
+
+        EntryType entryType = OPENALEX_TYPE_TO_ENTRY_TYPE.get(normalizedOpenAlexType);
+        if (entryType != null) {
+            return entryType;
+        }
+
+        return new UnknownEntryType(openAlexType);
     }
 
     @VisibleForTesting
@@ -178,7 +222,10 @@ public class OpenAlex implements CustomizableKeyFetcher, SearchBasedParserFetche
             DoiCleanup DoiCleanup = new DoiCleanup();
             BibEntry entry = new BibEntry();
 
-            entry.setType(EntryTypeFactory.parse(item.getString("type")));
+            String openAlexType = item.optString("type", null);
+            if (openAlexType != null) {
+                entry.setType(mapOpenAlexTypeToEntryType(openAlexType));
+            }
 
             entry.setField(StandardField.TITLE, item.optString("title"));
 
@@ -289,7 +336,7 @@ public class OpenAlex implements CustomizableKeyFetcher, SearchBasedParserFetche
                     .filter(Objects::nonNull)
                     .map(primaryLocation -> primaryLocation.optString("pdf_url", ""))
                     .filter(StringUtil::isNotBlank)
-                    .map(Unchecked.function(pdfUrl -> URLUtil.create(pdfUrl)));
+                    .map(Unchecked.function(URLUtil::create));
         } catch (RuntimeException e) {
             LOGGER.warn("Malformed URL", e);
             throw (MalformedURLException) e.getCause();
@@ -314,7 +361,7 @@ public class OpenAlex implements CustomizableKeyFetcher, SearchBasedParserFetche
 
     private List<BibEntry> workUrlsToBibEntryList(@Nullable JSONArray workUrlArray) {
         if (workUrlArray == null) {
-            List.of();
+            return List.of();
         }
         // TODO: This could be batched - see https://github.com/JabRef/jabref/pull/15023#issuecomment-3846630255
         return IntStream.range(0, workUrlArray.length())
@@ -351,7 +398,7 @@ public class OpenAlex implements CustomizableKeyFetcher, SearchBasedParserFetche
         }
         return IntStream.range(0, workUrlArray.length())
                         .mapToObj(workUrlArray::getJSONObject)
-                        .map(Unchecked.function(jsonItem -> jsonItemToBibEntry(jsonItem)))
+                        .map(Unchecked.function(this::jsonItemToBibEntry))
                         .toList();
     }
 
@@ -421,7 +468,7 @@ public class OpenAlex implements CustomizableKeyFetcher, SearchBasedParserFetche
         // Instead, we perform a search for works that cite the given work's ID
         try {
             return getWorkObject(entry, List.of("id"))
-                    .map(work -> work.optString("id"))
+                    .map(work -> work.optString("id", null))
                     .filter(Objects::nonNull)
                     .map(Unchecked.function(id ->
                             getUriBuilder("", List.of())

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/OpenAlex.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/OpenAlex.java
@@ -173,8 +173,7 @@ public class OpenAlex implements CustomizableKeyFetcher, SearchBasedParserFetche
         try {
             URIBuilder uriBuilder = new URIBuilder(URL_PATTERN + tail);
             importerPreferences.getApiKey(FETCHER_NAME).ifPresent(apiKey -> uriBuilder.addParameter("api_key", apiKey));
-            String fieldList = fieldsToSelect.stream()
-                                             .collect(Collectors.joining(","));
+            String fieldList = String.join(",", fieldsToSelect);
             if (!fieldList.isEmpty()) {
                 uriBuilder.addParameter("select", fieldList);
             }
@@ -222,8 +221,8 @@ public class OpenAlex implements CustomizableKeyFetcher, SearchBasedParserFetche
             DoiCleanup DoiCleanup = new DoiCleanup();
             BibEntry entry = new BibEntry();
 
-            String openAlexType = item.optString("type", null);
-            if (openAlexType != null) {
+            String openAlexType = item.optString("type");
+            if (StringUtil.isNotBlank(openAlexType)) {
                 entry.setType(mapOpenAlexTypeToEntryType(openAlexType));
             }
 
@@ -246,8 +245,8 @@ public class OpenAlex implements CustomizableKeyFetcher, SearchBasedParserFetche
             }
 
             String url = item.optString("id");
-            if (url != null && !url.isBlank()) {
-                entry.setField(StandardField.URL, item.optString("id"));
+            if (StringUtil.isNotBlank(url)) {
+                entry.setField(StandardField.URL, url);
             }
 
             // Authors
@@ -468,8 +467,8 @@ public class OpenAlex implements CustomizableKeyFetcher, SearchBasedParserFetche
         // Instead, we perform a search for works that cite the given work's ID
         try {
             return getWorkObject(entry, List.of("id"))
-                    .map(work -> work.optString("id", null))
-                    .filter(Objects::nonNull)
+                    .map(work -> work.optString("id"))
+                    .filter(StringUtil::isNotBlank)
                     .map(Unchecked.function(id ->
                             getUriBuilder("", List.of())
                                     .addParameter("filter", "cites:" + id)

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/OpenAlex.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/OpenAlex.java
@@ -64,7 +64,7 @@ public class OpenAlex implements CustomizableKeyFetcher, SearchBasedParserFetche
             Map.entry("article", StandardEntryType.Article),
             Map.entry("other", StandardEntryType.Misc),
             Map.entry("dataset", StandardEntryType.Dataset),
-            Map.entry("book-chapter", StandardEntryType.InCollection),
+            Map.entry("book-chapter", StandardEntryType.InBook),
             Map.entry("dissertation", StandardEntryType.Thesis),
             Map.entry("conference-paper", StandardEntryType.InProceedings),
             Map.entry("book", StandardEntryType.Book),
@@ -79,11 +79,11 @@ public class OpenAlex implements CustomizableKeyFetcher, SearchBasedParserFetche
             Map.entry("editorial", StandardEntryType.Article),
             Map.entry("review", StandardEntryType.Article),
             Map.entry("software", StandardEntryType.Software),
-            Map.entry("supplementary-materials", StandardEntryType.Dataset),
+            Map.entry("supplementary-materials", StandardEntryType.Misc),
             Map.entry("letter", StandardEntryType.Article),
             Map.entry("erratum", StandardEntryType.Article),
-            Map.entry("standard", StandardEntryType.Manual),
-            Map.entry("retraction", StandardEntryType.Article),
+            Map.entry("standard", StandardEntryType.Misc),
+            Map.entry("retraction", StandardEntryType.Misc),
             Map.entry("data-paper", StandardEntryType.Article),
             Map.entry("software-paper", StandardEntryType.Article)
     );

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/OpenAlexFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/OpenAlexFetcherTest.java
@@ -164,16 +164,17 @@ class OpenAlexFetcherTest {
 
     @Test
     void searchByQueryFindsEntry() throws FetcherException {
-        BibEntry master = new BibEntry(StandardEntryType.Article)
+        BibEntry master = new BibEntry(StandardEntryType.InProceedings)
                 .withField(StandardField.AUTHOR, "Matthew Tancik and Vincent Casser and Xinchen Yan and Sabeek Pradhan and Ben Mildenhall and Pratul P. Srinivasan and Jonathan T. Barron and Henrik Kretzschmar")
                 .withField(StandardField.TITLE, "Block-NeRF: Scalable Large Scene Neural View Synthesis")
-                .withField(StandardField.YEAR, "2022")
                 .withField(StandardField.DOI, "10.1109/cvpr52688.2022.00807")
                 .withField(StandardField.URL, "https://openalex.org/W4312280420");
         List<BibEntry> fetchedEntries = fetcher.performSearch("Block-NeRF: Scalable Large Scene Neural View Synthesis");
         fetchedEntries.forEach(entry -> entry.clearField(StandardField.ABSTRACT));
         fetchedEntries.forEach(entry -> entry.clearField(StandardField.PAGES));
         fetchedEntries.forEach(entry -> entry.clearField(StandardField.KEYWORDS));
+        fetchedEntries.forEach(entry -> entry.clearField(StandardField.YEAR));
+        fetchedEntries.forEach(entry -> entry.clearField(StandardField.DATE));
         assertEquals(master, fetchedEntries.getFirst());
     }
 

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/OpenAlexFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/OpenAlexFetcherTest.java
@@ -39,13 +39,6 @@ class OpenAlexFetcherTest {
 
     private OpenAlex fetcher;
 
-    private final BibEntry NERF = new BibEntry(StandardEntryType.Article)
-            .withField(StandardField.AUTHOR, "Haithem Turki and Deva Ramanan and Mahadev Satyanarayanan")
-            .withField(StandardField.YEAR, "2022")
-            .withField(StandardField.DOI, "10.1109/cvpr52688.2022.01258")
-            .withField(StandardField.TITLE, "Mega-NeRF: Scalable Construction of Large-Scale NeRFs for Virtual Fly- Throughs")
-            .withField(StandardField.URL, "https://openalex.org/W4313031684");
-
     @BeforeEach
     void setUp() {
         ImporterPreferences importerPreferences = mock(ImporterPreferences.class);
@@ -168,13 +161,12 @@ class OpenAlexFetcherTest {
                 .withField(StandardField.AUTHOR, "Matthew Tancik and Vincent Casser and Xinchen Yan and Sabeek Pradhan and Ben Mildenhall and Pratul P. Srinivasan and Jonathan T. Barron and Henrik Kretzschmar")
                 .withField(StandardField.TITLE, "Block-NeRF: Scalable Large Scene Neural View Synthesis")
                 .withField(StandardField.DOI, "10.1109/cvpr52688.2022.00807")
+                .withField(StandardField.DATE, "2022-06-01")
                 .withField(StandardField.URL, "https://openalex.org/W4312280420");
         List<BibEntry> fetchedEntries = fetcher.performSearch("Block-NeRF: Scalable Large Scene Neural View Synthesis");
         fetchedEntries.forEach(entry -> entry.clearField(StandardField.ABSTRACT));
         fetchedEntries.forEach(entry -> entry.clearField(StandardField.PAGES));
         fetchedEntries.forEach(entry -> entry.clearField(StandardField.KEYWORDS));
-        fetchedEntries.forEach(entry -> entry.clearField(StandardField.YEAR));
-        fetchedEntries.forEach(entry -> entry.clearField(StandardField.DATE));
         assertEquals(master, fetchedEntries.getFirst());
     }
 
@@ -185,10 +177,17 @@ class OpenAlexFetcherTest {
 
     @Test
     void searchByQuotedQueryFindsEntry() throws FetcherException {
+        BibEntry expected = new BibEntry(StandardEntryType.InProceedings)
+                .withField(StandardField.AUTHOR, "Haithem Turki and Deva Ramanan and Mahadev Satyanarayanan")
+                .withField(StandardField.DATE, "2022-06-01")
+                .withField(StandardField.DOI, "10.1109/cvpr52688.2022.01258")
+                .withField(StandardField.TITLE, "Mega-NeRF: Scalable Construction of Large-Scale NeRFs for Virtual Fly- Throughs")
+                .withField(StandardField.URL, "https://openalex.org/W4313031684");
+
         List<BibEntry> fetchedEntries = fetcher.performSearch("\"Mega-NeRF: Scalable Construction of Large-Scale NeRFs for Virtual Fly- Throughs\"");
         fetchedEntries.forEach(entry -> entry.clearField(StandardField.ABSTRACT));
         fetchedEntries.forEach(entry -> entry.clearField(StandardField.PAGES));
         fetchedEntries.forEach(entry -> entry.clearField(StandardField.KEYWORDS));
-        assertEquals(NERF, fetchedEntries.getFirst());
+        assertEquals(expected, fetchedEntries.getFirst());
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/OpenAlexTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/OpenAlexTest.java
@@ -5,6 +5,9 @@ import java.util.Optional;
 import javafx.collections.FXCollections;
 
 import org.jabref.logic.importer.ImporterPreferences;
+import org.jabref.logic.importer.ParseException;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.types.StandardEntryType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,5 +48,15 @@ class OpenAlexTest {
     })
     void returnsEmptyForInvalid(String url) {
         assertEquals(Optional.empty(), fetcher.extractOpenAlexId(url));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    void parserKeepsDefaultTypeForBlankOpenAlexType(String openAlexType) throws ParseException {
+        BibEntry entry = fetcher.getParser().parseEntries("""
+                {"type":"%s"}
+                """.formatted(openAlexType)).getFirst();
+
+        assertEquals(StandardEntryType.Misc, entry.getType());
     }
 }


### PR DESCRIPTION
### Summary

Just adds a mapping from OpenAlex work type to bibentry type

### Steps to test

Nothing really much. Just fetch a conference paper, and it should be `InProceedings`. For example this:

`ImageNet: A large-scale hierarchical image database`

ID: `W2108598243`

### Related issues and pull requests

Closes NA

### AI usage
I have used Gemini to map the types, and GPT to write the code. The code proposed by AI was edited and analyzed.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
