### PR TITLE
Use Crossref's polite pool for identifier lookups

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -119,6 +119,7 @@ env:
   BiodiversityHeritageApiKey: ${{ secrets.BiodiversityHeritageApiKey}}
   IEEEAPIKey: ${{ secrets.IEEEAPIKey }}
   SpringerNatureAPIKey: ${{ secrets.SpringerNatureAPIKey }}
+  CROSSREF_EMAIL: ${{ secrets.CROSSREF_EMAIL }}
 
 
 concurrency:

--- a/.github/workflows/tests-code-fetchers.yml
+++ b/.github/workflows/tests-code-fetchers.yml
@@ -37,6 +37,7 @@ env:
   MedlineApiKey: ${{ secrets.MedlineApiKey_FOR_TESTS }}
   OpenAlexApiKey: ${{ secrets.OpenAlexApiKey_FOR_TESTS }}
   SpringerNatureAPIKey: ${{ secrets.SPRINGERNATUREAPIKEY_FOR_TESTS }}
+  CROSSREF_EMAIL: ${{ secrets.CROSSREF_EMAIL_FOR_TESTS }}
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -16,6 +16,7 @@ env:
   MedlineAPiKey: ${{ secrets.MedlineApiKey_FOR_TESTS }}
   OpenAlexApiKey: ${{ secrets.OpenAlexApiKey_FOR_TESTS }}
   SpringerNatureAPIKey: ${{ secrets.SPRINGERNATUREAPIKEY_FOR_TESTS }}
+  CROSSREF_EMAIL: ${{ secrets.CROSSREF_EMAIL_FOR_TESTS }}
   GRADLE_OPTS: -Xmx4g
   JAVA_OPTS: -Xmx4g
 

--- a/.gitignore
+++ b/.gitignore
@@ -623,3 +623,6 @@ CHANGELOG.html
 
 # some strange gradle/IntelliJ extension
 extension 'reporting' property 'baseDirectory'
+
+# junie stuff
+.junie

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
+- We now identify Crossref requests with a configured email address, allowing them to use Crossref's polite pool. TODO
 - We improved user experience by making the welcome tab visible when no libraries are open. [#16451](https://github.com/JabRef/jabref/issues/16451)
 - We made it possible to reopen the `Share this library to GitHub` dialog for saved local libraries with an existing Git remote, check a personal access token's push access, and pull from remotes with unrelated histories or no branches. [#16367](https://github.com/JabRef/jabref/pull/16367)
 - We hardened the fetchers and importers against [XML Entity Expansion attacks](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html). [#16359](https://github.com/JabRef/jabref/pull/16359)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
-- We now identify Crossref requests with a configured email address, allowing them to use Crossref's polite pool. TODO
+- We now identify Crossref requests with a configured email address, allowing them to use Crossref's polite pool. [#16535](https://github.com/JabRef/jabref/pull/16535)
 - We improved user experience by making the welcome tab visible when no libraries are open. [#16451](https://github.com/JabRef/jabref/issues/16451)
 - We made it possible to reopen the `Share this library to GitHub` dialog for saved local libraries with an existing Git remote, check a personal access token's push access, and pull from remotes with unrelated histories or no branches. [#16367](https://github.com/JabRef/jabref/pull/16367)
 - We hardened the fetchers and importers against [XML Entity Expansion attacks](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html). [#16359](https://github.com/JabRef/jabref/pull/16359)

--- a/docs/requirements/fetchers.md
+++ b/docs/requirements/fetchers.md
@@ -10,6 +10,20 @@ Fetchers with a documented request limit throttle requests across all fetcher in
 
 Needs: impl
 
+## Use Crossref's polite pool
+`req~fetchers.crossref-polite-pool~1`
+
+When an email address is configured for Crossref, requests include it in the `mailto` parameter to use Crossref's polite pool.
+
+Needs: impl
+
+## Retry identifier lookups after rate limiting
+`req~fetchers.identifier-rate-limit-retries~1`
+
+Identifier fetchers retry a request rejected with HTTP 429 using bounded exponential backoff, while preserving all other client errors.
+
+Needs: impl
+
 ## Retrieve journal information from public sources
 `req~fetchers.journal-information~1`
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -809,7 +809,7 @@ public class CitationRelationsTab extends EntryEditorTab {
         Hyperlink link = new Hyperlink(Localization.lang("Look up a DOI and try again."));
 
         link.setOnAction(_ -> {
-            CrossRef doiFetcher = new CrossRef();
+            CrossRef doiFetcher = new CrossRef(preferences.getImporterPreferences());
 
             BackgroundTask.wrap(() -> doiFetcher.findIdentifier(citationComponents.entry()))
                           .onRunning(() -> {

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationsRelationsTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationsRelationsTabViewModel.java
@@ -176,7 +176,7 @@ public class CitationsRelationsTabViewModel {
     }
 
     public void lookUpDoi(BibEntry entry) {
-        CrossRef doiFetcher = new CrossRef();
+        CrossRef doiFetcher = new CrossRef(preferences.getImporterPreferences());
 
         BackgroundTask.wrap(() -> doiFetcher.findIdentifier(entry))
                       .onRunning(() -> {

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/identifier/DoiIdentifierEditorViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/identifier/DoiIdentifierEditorViewModel.java
@@ -41,7 +41,7 @@ public class DoiIdentifierEditorViewModel extends BaseIdentifierEditorViewModel<
 
     @Override
     public void lookupIdentifier(BibEntry bibEntry) {
-        CrossRef doiFetcher = new CrossRef();
+        CrossRef doiFetcher = new CrossRef(preferences.getImporterPreferences());
 
         BackgroundTask.wrap(() -> doiFetcher.findIdentifier(entry))
                       .onRunning(() -> identifierLookupInProgress.setValue(true))

--- a/jabgui/src/main/java/org/jabref/gui/frame/MainMenu.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/MainMenu.java
@@ -289,7 +289,7 @@ public class MainMenu extends MenuBar {
         );
 
         Menu lookupIdentifiers = factory.createSubMenu(StandardActions.LOOKUP_DOC_IDENTIFIER);
-        for (IdFetcher<?> fetcher : WebFetchers.getIdFetchers(preferences.getImportFormatPreferences())) {
+        for (IdFetcher<?> fetcher : WebFetchers.getIdFetchers(preferences.getImportFormatPreferences(), preferences.getImporterPreferences())) {
             LookupIdentifierAction<?> identifierAction = new LookupIdentifierAction<>(fetcher, stateManager, undoManager, dialogService, taskExecutor);
             lookupIdentifiers.getItems().add(factory.createMenuItem(identifierAction.getAction(), identifierAction));
         }

--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -62,7 +62,7 @@ import org.jabref.gui.util.UiTaskExecutor;
 import org.jabref.gui.util.ViewModelTableRowFactory;
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.citationstyle.CitationStyleOutputFormat;
-import org.jabref.logic.importer.WebFetchers;
+import org.jabref.logic.importer.fetcher.CrossRef;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.TaskExecutor;
@@ -424,7 +424,7 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
         OpenUrlAction openUrlAction = new OpenUrlAction(dialogService, stateManager, preferences);
         OpenSelectedEntriesFilesAction openSelectedEntriesFilesActionFileAction = new OpenSelectedEntriesFilesAction(dialogService, stateManager, preferences, taskExecutor);
         MergeWithFetchedEntryAction mergeWithFetchedEntryAction = new MergeWithFetchedEntryAction(dialogService, stateManager, taskExecutor, preferences, undoManager);
-        LookupIdentifierAction<DOI> lookupIdentifierAction = new LookupIdentifierAction<>(WebFetchers.getIdFetcherForIdentifier(DOI.class), stateManager, undoManager, dialogService, taskExecutor);
+        LookupIdentifierAction<DOI> lookupIdentifierAction = new LookupIdentifierAction<>(new CrossRef(preferences.getImporterPreferences()), stateManager, undoManager, dialogService, taskExecutor);
 
         this.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             if (event.getCode() == KeyCode.ENTER) {

--- a/jabgui/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
@@ -33,7 +33,7 @@ import org.jabref.gui.preview.PreviewPreferences;
 import org.jabref.gui.relatedwork.RelatedWorkAction;
 import org.jabref.gui.specialfields.SpecialFieldMenuItemFactory;
 import org.jabref.logic.citationstyle.CitationStyleOutputFormat;
-import org.jabref.logic.importer.WebFetchers;
+import org.jabref.logic.importer.fetcher.CrossRef;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.preview.CitationStylePreviewLayout;
@@ -43,7 +43,6 @@ import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.SpecialField;
-import org.jabref.model.entry.identifier.DOI;
 
 import com.tobiasdiez.easybind.EasyBind;
 
@@ -105,7 +104,7 @@ public class RightClickMenu {
 
                 new ChangeEntryTypeMenu(libraryTab.getSelectedEntries(), libraryTab.getBibDatabaseContext(), undoManager, entryTypesManager).asSubMenu(),
                 factory.createMenuItem(StandardActions.MERGE_WITH_FETCHED_ENTRY, new MergeWithFetchedEntryAction(dialogService, stateManager, taskExecutor, preferences, undoManager)),
-                factory.createMenuItem(StandardActions.LOOKUP_DOC_IDENTIFIER, new LookupIdentifierAction<>(WebFetchers.getIdFetcherForIdentifier(DOI.class), stateManager, undoManager, dialogService, taskExecutor))
+                factory.createMenuItem(StandardActions.LOOKUP_DOC_IDENTIFIER, new LookupIdentifierAction<>(new CrossRef(preferences.getImporterPreferences()), stateManager, undoManager, dialogService, taskExecutor))
         );
 
         EasyBind.subscribe(preferences.getGrobidPreferences().grobidEnabledProperty(), enabled -> {

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/DoiToBibtex.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/DoiToBibtex.java
@@ -35,7 +35,7 @@ class DoiToBibtex implements Callable<Integer> {
 
     @Override
     public Integer call() throws ExportServiceException {
-        CrossRef fetcher = new CrossRef();
+        CrossRef fetcher = new CrossRef(argumentProcessor.cliPreferences.getImporterPreferences());
         List<BibEntry> entries = new ArrayList<>(dois.length);
 
         for (String doiString : dois) {

--- a/jablib/build.gradle.kts
+++ b/jablib/build.gradle.kts
@@ -196,6 +196,7 @@ val semanticScholarApiKey = providers.environmentVariable("SemanticScholarApiKey
 val springerNatureAPIKey = providers.environmentVariable("SpringerNatureAPIKey").orElse("")
 val unpaywallEmail = providers.environmentVariable("UNPAYWALL_EMAIL").orElse("")
 val wileyTdmApiKey = providers.environmentVariable("WileyTdmApiKey").orElse("")
+val crossRefEmail = providers.environmentVariable("CROSSREF_EMAIL").orElse("")
 
 tasks.named<ProcessResources>("processResources") {
     dependsOn(extractMaintainers)
@@ -219,6 +220,7 @@ tasks.named<ProcessResources>("processResources") {
     inputs.property("semanticScholarApiKey", semanticScholarApiKey)
     inputs.property("unpaywallEmail", unpaywallEmail)
     inputs.property("wileyTdmApiKey", wileyTdmApiKey)
+    inputs.property("crossRefEmail", crossRefEmail)
 
     filesMatching("build.properties") {
         expand(
@@ -238,6 +240,7 @@ tasks.named<ProcessResources>("processResources") {
                 "springerNatureAPIKey" to inputs.properties["springerNatureAPIKey"],
                 "unpaywallEmail" to inputs.properties["unpaywallEmail"],
                 "wileyTdmApiKey" to inputs.properties["wileyTdmApiKey"],
+                "crossRefEmail" to inputs.properties["crossRefEmail"],
             )
         )
     }

--- a/jablib/src/main/java/org/jabref/logic/importer/FetcherException.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/FetcherException.java
@@ -15,8 +15,8 @@ import org.slf4j.LoggerFactory;
 
 public class FetcherException extends JabRefException {
     private static final Logger LOGGER = LoggerFactory.getLogger(FetcherException.class);
-    private static final String API_KEY_PARAM_NAME = "apiKeyParamName";
-    private static final Pattern API_KEY_PATTERN = Pattern.compile("(?i)(?<" + API_KEY_PARAM_NAME + ">api|key|api[-_]?key)=[^&]*");
+    private static final String SENSITIVE_PARAM_NAME = "sensitiveParamName";
+    private static final Pattern SENSITIVE_PARAM_PATTERN = Pattern.compile("(?i)(?<" + SENSITIVE_PARAM_NAME + ">api|key|api[-_]?key|mailto|email)=[^&]*");
     private static final Pattern USERINFO_PATTERN = Pattern.compile("(?<=://)[^/@]+@");
     private static final String REDACTED_STRING = "[REDACTED]";
 
@@ -97,7 +97,7 @@ public class FetcherException extends JabRefException {
 
     public static String getRedactedUrl(String source) {
         String withoutUserInfo = USERINFO_PATTERN.matcher(source).replaceAll("");
-        return API_KEY_PATTERN.matcher(withoutUserInfo).replaceAll("${" + API_KEY_PARAM_NAME + "}=" + REDACTED_STRING);
+        return SENSITIVE_PARAM_PATTERN.matcher(withoutUserInfo).replaceAll("${" + SENSITIVE_PARAM_NAME + "}=" + REDACTED_STRING);
     }
 
     private String getPrefix() {

--- a/jablib/src/main/java/org/jabref/logic/importer/FetcherRetry.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/FetcherRetry.java
@@ -1,0 +1,62 @@
+package org.jabref.logic.importer;
+
+import java.time.Duration;
+
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@NullMarked
+final class FetcherRetry {
+
+    static final int MAX_RATE_LIMIT_RETRIES = 2;
+    static final int HTTP_TOO_MANY_REQUESTS = 429;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FetcherRetry.class);
+    private static final Duration INITIAL_BACKOFF = Duration.ofSeconds(1);
+
+    private FetcherRetry() {
+    }
+
+    // [impl->req~fetchers.identifier-rate-limit-retries~1]
+    static <T> T executeWithRateLimitRetry(FetcherOperation<T> operation) throws FetcherException {
+        return executeWithRateLimitRetry(operation, Thread::sleep);
+    }
+
+    static <T> T executeWithRateLimitRetry(FetcherOperation<T> operation, Backoff backoff) throws FetcherException {
+        for (int retryAttempt = 0; ; retryAttempt++) {
+            try {
+                return operation.execute();
+            } catch (FetcherClientException exception) {
+                if (!isRateLimited(exception) || retryAttempt == MAX_RATE_LIMIT_RETRIES) {
+                    throw exception;
+                }
+
+                Duration delay = INITIAL_BACKOFF.multipliedBy(1L << retryAttempt);
+                LOGGER.info("Received HTTP 429. Retrying after {}", delay);
+                try {
+                    backoff.waitFor(delay);
+                } catch (InterruptedException interruptedException) {
+                    Thread.currentThread().interrupt();
+                    throw new FetcherException("Interrupted while waiting to retry a rate-limited request", interruptedException);
+                }
+            }
+        }
+    }
+
+    private static boolean isRateLimited(FetcherClientException exception) {
+        return exception.getHttpResponse()
+                        .map(response -> response.statusCode() == HTTP_TOO_MANY_REQUESTS)
+                        .orElse(false);
+    }
+
+    @FunctionalInterface
+    interface FetcherOperation<T> {
+        T execute() throws FetcherException;
+    }
+
+    @FunctionalInterface
+    interface Backoff {
+        void waitFor(Duration delay) throws InterruptedException;
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/importer/FulltextFetchers.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/FulltextFetchers.java
@@ -15,7 +15,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiPredicate;
 
-import org.jabref.logic.importer.fetcher.CrossRef;
 import org.jabref.logic.net.URLDownload;
 import org.jabref.logic.util.HeadlessExecutorService;
 import org.jabref.model.entry.BibEntry;
@@ -88,7 +87,8 @@ public class FulltextFetchers {
 
     private void findDoiForEntry(BibEntry clonedEntry) {
         try {
-            new CrossRef(importerPreferences).findIdentifier(clonedEntry)
+            WebFetchers.getIdFetcherForIdentifier(DOI.class, importerPreferences)
+                       .findIdentifier(clonedEntry)
                        .ifPresent(e -> clonedEntry.setField(StandardField.DOI, e.asString()));
         } catch (FetcherException e) {
             LOGGER.debug("Failed to find DOI", e);

--- a/jablib/src/main/java/org/jabref/logic/importer/FulltextFetchers.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/FulltextFetchers.java
@@ -15,6 +15,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiPredicate;
 
+import org.jabref.logic.importer.fetcher.CrossRef;
 import org.jabref.logic.net.URLDownload;
 import org.jabref.logic.util.HeadlessExecutorService;
 import org.jabref.model.entry.BibEntry;
@@ -39,6 +40,7 @@ public class FulltextFetchers {
     private static final int FETCHER_TIMEOUT = 120;
 
     private final Set<FulltextFetcher> fetchers;
+    private final ImporterPreferences importerPreferences;
 
     private final BiPredicate<String, Map<String, String>> isPDF = (url, headers) -> {
         try {
@@ -52,12 +54,17 @@ public class FulltextFetchers {
     };
 
     public FulltextFetchers(ImportFormatPreferences importFormatPreferences, ImporterPreferences importerPreferences) {
-        this(WebFetchers.getFullTextFetchers(importFormatPreferences, importerPreferences));
+        this(WebFetchers.getFullTextFetchers(importFormatPreferences, importerPreferences), importerPreferences);
     }
 
     @VisibleForTesting
     FulltextFetchers(Set<FulltextFetcher> fetchers) {
+        this(fetchers, ImporterPreferences.getDefault());
+    }
+
+    private FulltextFetchers(Set<FulltextFetcher> fetchers, ImporterPreferences importerPreferences) {
         this.fetchers = new HashSet<>(fetchers);
+        this.importerPreferences = importerPreferences;
     }
 
     public Optional<FetcherResult> findFullTextPDF(BibEntry entry) {
@@ -76,14 +83,12 @@ public class FulltextFetchers {
                      .filter(Optional::isPresent)
                      .map(Optional::get)
                      .filter(res -> (res.source()) != null)
-                     .sorted(Comparator.comparingInt((FetcherResult res) -> res.trust().getTrustScore()).reversed())
-                     .findFirst();
+                     .max(Comparator.comparingInt((FetcherResult res) -> res.trust().getTrustScore()));
     }
 
     private void findDoiForEntry(BibEntry clonedEntry) {
         try {
-            WebFetchers.getIdFetcherForIdentifier(DOI.class)
-                       .findIdentifier(clonedEntry)
+            new CrossRef(importerPreferences).findIdentifier(clonedEntry)
                        .ifPresent(e -> clonedEntry.setField(StandardField.DOI, e.asString()));
         } catch (FetcherException e) {
             LOGGER.debug("Failed to find DOI", e);

--- a/jablib/src/main/java/org/jabref/logic/importer/IdParserFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/IdParserFetcher.java
@@ -1,9 +1,8 @@
 package org.jabref.logic.importer;
 
-import java.io.BufferedInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -47,7 +46,21 @@ public interface IdParserFetcher<T extends Identifier> extends IdFetcher<T>, Par
         } catch (URISyntaxException | MalformedURLException e) {
             throw new FetcherException("Search URL is malformed", e);
         }
-        try (InputStream stream = new BufferedInputStream(urlForEntry.openStream())) {
+
+        try {
+            return FetcherRetry.executeWithRateLimitRetry(() -> fetchIdentifier(entry, urlForEntry));
+        } catch (FetcherClientException exception) {
+            if (exception.getHttpResponse()
+                         .map(response -> response.statusCode() == HttpURLConnection.HTTP_NOT_FOUND)
+                         .orElse(false)) {
+                return Optional.empty();
+            }
+            throw exception;
+        }
+    }
+
+    private Optional<T> fetchIdentifier(BibEntry entry, URL urlForEntry) throws FetcherException {
+        try (InputStream stream = getUrlDownload(urlForEntry).asInputStream()) {
             List<BibEntry> fetchedEntries = getParser().parseEntries(stream);
 
             if (fetchedEntries.isEmpty()) {
@@ -58,14 +71,7 @@ public interface IdParserFetcher<T extends Identifier> extends IdFetcher<T>, Par
             fetchedEntries.forEach(this::doPostCleanup);
 
             return extractIdentifier(entry, fetchedEntries);
-        } catch (FileNotFoundException e) {
-            LOGGER.debug("Id not found");
-            return Optional.empty();
         } catch (IOException e) {
-            // check for the case where we already have a FetcherException from UrlDownload
-            if (e.getCause() instanceof FetcherException fe) {
-                throw fe;
-            }
             throw new FetcherException(urlForEntry, "An I/O exception occurred", e);
         } catch (ParseException e) {
             throw new FetcherException(urlForEntry, "An internal parser error occurred", e);

--- a/jablib/src/main/java/org/jabref/logic/importer/ImporterPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ImporterPreferences.java
@@ -21,6 +21,7 @@ import javafx.collections.ObservableSet;
 import org.jabref.logic.importer.fetcher.ACMPortalFetcher;
 import org.jabref.logic.importer.fetcher.AstrophysicsDataSystem;
 import org.jabref.logic.importer.fetcher.BiodiversityLibrary;
+import org.jabref.logic.importer.fetcher.CrossRef;
 import org.jabref.logic.importer.fetcher.DBLPFetcher;
 import org.jabref.logic.importer.fetcher.IEEE;
 import org.jabref.logic.importer.fetcher.Scopus;
@@ -108,6 +109,7 @@ public class ImporterPreferences {
         return Map.of(
                 AstrophysicsDataSystem.FETCHER_NAME, buildInfo.astrophysicsDataSystemAPIKey,
                 BiodiversityLibrary.FETCHER_NAME, buildInfo.biodiversityHeritageApiKey,
+                CrossRef.FETCHER_NAME, buildInfo.crossRefEmail,
                 Scopus.FETCHER_NAME, buildInfo.scopusApiKey,
                 SemanticScholarCitationFetcher.FETCHER_NAME, buildInfo.semanticScholarApiKey,
                 // SpringerLink uses the same key and fetcher name as SpringerFetcher

--- a/jablib/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -138,7 +138,7 @@ public class WebFetchers {
 
     public static Optional<IdFetcher<? extends Identifier>> getIdFetcherForField(Field field) {
         if (field == StandardField.DOI) {
-            return Optional.of(new CrossRef());
+            return Optional.of(new CrossRef(ImporterPreferences.getDefault()));
         }
         return Optional.empty();
     }

--- a/jablib/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -128,9 +128,9 @@ public class WebFetchers {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T extends Identifier> IdFetcher<T> getIdFetcherForIdentifier(Class<T> clazz) {
+    public static <T extends Identifier> IdFetcher<T> getIdFetcherForIdentifier(Class<T> clazz, ImporterPreferences importerPreferences) {
         if (clazz == DOI.class) {
-            return (IdFetcher<T>) new CrossRef();
+            return (IdFetcher<T>) new CrossRef(importerPreferences);
         } else {
             throw new IllegalArgumentException("No fetcher found for identifier" + clazz.getCanonicalName());
         }
@@ -165,7 +165,7 @@ public class WebFetchers {
         // set.add(new GoogleScholar(importFormatPreferences));
         searchBasedFetchers.add(new DBLPFetcher(importFormatPreferences));
         searchBasedFetchers.add(new SpringerNatureWebFetcher(importerPreferences));
-        searchBasedFetchers.add(new CrossRef());
+        searchBasedFetchers.add(new CrossRef(importerPreferences));
         searchBasedFetchers.add(new OpenAlex(importerPreferences));
         searchBasedFetchers.add(new DOAJFetcher(importFormatPreferences));
         searchBasedFetchers.add(new IEEE(importFormatPreferences, importerPreferences));
@@ -202,10 +202,10 @@ public class WebFetchers {
         set.add(new SsrnFetcher(importFormatPreferences));
         set.add(new EuropePmcFetcher());
         set.add(new MedlineFetcher(importerPreferences));
-        set.add(new TitleFetcher(importFormatPreferences));
+        set.add(new TitleFetcher(importFormatPreferences, importerPreferences));
         set.add(new MathSciNet(importFormatPreferences));
         set.add(new ZbMATH(importFormatPreferences));
-        set.add(new CrossRef());
+        set.add(new CrossRef(importerPreferences));
         set.add(new LibraryOfCongress(importFormatPreferences));
         set.add(new LOBIDFetcher());
         set.add(new IacrEprintFetcher(importFormatPreferences));
@@ -222,7 +222,7 @@ public class WebFetchers {
         SortedSet<EntryBasedFetcher> set = new TreeSet<>(Comparator.comparing(WebFetcher::getName, String.CASE_INSENSITIVE_ORDER));
 
         set.add(new AstrophysicsDataSystem(importFormatPreferences, importerPreferences));
-        set.add(new CrossRef());
+        set.add(new CrossRef(importerPreferences));
         set.add(new DoiFetcher(importFormatPreferences));
         set.add(new INSPIREFetcher(importFormatPreferences));
         set.add(new IsbnFetcher(importFormatPreferences));
@@ -247,10 +247,14 @@ public class WebFetchers {
 
     /// @return sorted set containing id fetchers
     public static SortedSet<IdFetcher<? extends Identifier>> getIdFetchers(ImportFormatPreferences importFormatPreferences) {
+        return getIdFetchers(importFormatPreferences, ImporterPreferences.getDefault());
+    }
+
+    public static SortedSet<IdFetcher<? extends Identifier>> getIdFetchers(ImportFormatPreferences importFormatPreferences, ImporterPreferences importerPreferences) {
         SortedSet<IdFetcher<?>> set = new TreeSet<>(Comparator.comparing(WebFetcher::getName, String.CASE_INSENSITIVE_ORDER));
 
         set.add(new ArXivFetcher(importFormatPreferences));
-        set.add(new CrossRef());
+        set.add(new CrossRef(importerPreferences));
 
         return set;
     }
@@ -290,6 +294,7 @@ public class WebFetchers {
         Set<CustomizableKeyFetcher> fetchers = Set.of(
                 new AstrophysicsDataSystem(importFormatPreferences, importerPreferences),
                 new BiodiversityLibrary(importerPreferences),
+                new CrossRef(importerPreferences),
                 new IEEE(importFormatPreferences, importerPreferences),
                 new MedlineFetcher(importerPreferences),
                 new OpenAlex(importerPreferences),

--- a/jablib/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -136,9 +136,9 @@ public class WebFetchers {
         }
     }
 
-    public static Optional<IdFetcher<? extends Identifier>> getIdFetcherForField(Field field) {
+    public static Optional<IdFetcher<? extends Identifier>> getIdFetcherForField(Field field, ImporterPreferences importerPreferences) {
         if (field == StandardField.DOI) {
-            return Optional.of(new CrossRef(ImporterPreferences.getDefault()));
+            return Optional.of(new CrossRef(importerPreferences));
         }
         return Optional.empty();
     }

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
@@ -18,6 +18,7 @@ import org.jabref.logic.importer.EntryBasedParserFetcher;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.IdBasedParserFetcher;
 import org.jabref.logic.importer.IdParserFetcher;
+import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.SearchBasedParserFetcher;
@@ -44,9 +45,12 @@ import org.jspecify.annotations.NonNull;
 /// A class for fetching DOIs from CrossRef
 ///
 /// See <a href="https://github.com/CrossRef/rest-api-doc">their GitHub page</a> for documentation.
-public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, SearchBasedParserFetcher, IdBasedParserFetcher {
+public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, SearchBasedParserFetcher, IdBasedParserFetcher, CustomizableKeyFetcher {
+
+    public static final String FETCHER_NAME = "Crossref";
 
     private static final String API_URL = "https://api.crossref.org/works";
+    private static final String MAILTO_PARAMETER = "mailto";
 
     /// Rate limit for the CrossRef REST API public pool.
     /// CrossRef's public pool defaults to 50 req/s, as measured via X-Rate-Limit-Interval/X-Rate-Limit-Limit
@@ -55,9 +59,19 @@ public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, 
 
     private static final RemoveEnclosingBracesFormatter REMOVE_BRACES_FORMATTER = new RemoveEnclosingBracesFormatter();
 
+    private final ImporterPreferences importerPreferences;
+
+    public CrossRef() {
+        this(ImporterPreferences.getDefault());
+    }
+
+    public CrossRef(ImporterPreferences importerPreferences) {
+        this.importerPreferences = importerPreferences;
+    }
+
     @Override
     public String getName() {
-        return "Crossref";
+        return FETCHER_NAME;
     }
 
     @Override
@@ -102,6 +116,7 @@ public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, 
         );
         uriBuilder.addParameter("rows", "20");  // = API default
         uriBuilder.addParameter("offset", "0"); // start at the beginning
+        addMailtoParameter(uriBuilder);
         return uriBuilder.build().toURL();
     }
 
@@ -109,12 +124,14 @@ public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, 
     public URL getURLForQuery(BaseQueryNode queryNode) throws URISyntaxException, MalformedURLException {
         URIBuilder uriBuilder = new URIBuilder(API_URL);
         uriBuilder.addParameter("query", new DefaultQueryTransformer().transformSearchQuery(queryNode).orElse(""));
+        addMailtoParameter(uriBuilder);
         return uriBuilder.build().toURL();
     }
 
     @Override
     public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException {
         URIBuilder uriBuilder = new URIBuilder(API_URL + "/" + URLEncoder.encode(identifier, StandardCharsets.UTF_8));
+        addMailtoParameter(uriBuilder);
         return uriBuilder.build().toURL();
     }
 
@@ -237,6 +254,11 @@ public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, 
     @Override
     public String getIdentifierName() {
         return "DOI";
+    }
+
+    // [impl->req~fetchers.crossref-polite-pool~1]
+    private void addMailtoParameter(URIBuilder uriBuilder) {
+        importerPreferences.getApiKey(FETCHER_NAME).ifPresent(email -> uriBuilder.addParameter(MAILTO_PARAMETER, email));
     }
 
     private String getKeywords(JSONArray jsonArray) {

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
@@ -1,5 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -24,6 +26,7 @@ import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.SearchBasedParserFetcher;
 import org.jabref.logic.importer.fetcher.transformers.DefaultQueryTransformer;
 import org.jabref.logic.importer.util.JsonReader;
+import org.jabref.logic.net.URLDownload;
 import org.jabref.logic.util.strings.StringSimilarity;
 import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.model.entry.Author;
@@ -36,6 +39,8 @@ import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.search.query.BaseQueryNode;
 import org.jabref.model.util.OptionalUtil;
 
+import com.google.common.annotations.VisibleForTesting;
+import kong.unirest.core.UnirestException;
 import kong.unirest.core.json.JSONArray;
 import kong.unirest.core.json.JSONException;
 import kong.unirest.core.json.JSONObject;
@@ -77,6 +82,22 @@ public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, 
     @Override
     public Optional<HelpFile> getHelpPage() {
         return Optional.of(HelpFile.FETCHER_CROSSREF);
+    }
+
+    @VisibleForTesting
+    String getTestUrl(String apiKey) {
+        return API_URL + "?query=test&rows=1&" + MAILTO_PARAMETER + "=" + URLEncoder.encode(apiKey, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public boolean isValidKey(@NonNull String apiKey) {
+        try {
+            URLDownload urlDownload = new URLDownload(getTestUrl(apiKey));
+            int statusCode = ((HttpURLConnection) urlDownload.getSource().openConnection()).getResponseCode();
+            return (statusCode >= 200) && (statusCode < 300);
+        } catch (IOException | UnirestException e) {
+            return false;
+        }
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/TitleFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/TitleFetcher.java
@@ -6,6 +6,7 @@ import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.IdBasedFetcher;
 import org.jabref.logic.importer.ImportFormatPreferences;
+import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.importer.WebFetchers;
 import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.model.entry.BibEntry;
@@ -15,9 +16,15 @@ import org.jabref.model.entry.identifier.DOI;
 public class TitleFetcher implements IdBasedFetcher {
 
     private final ImportFormatPreferences preferences;
+    private final ImporterPreferences importerPreferences;
 
     public TitleFetcher(ImportFormatPreferences preferences) {
+        this(preferences, ImporterPreferences.getDefault());
+    }
+
+    public TitleFetcher(ImportFormatPreferences preferences, ImporterPreferences importerPreferences) {
         this.preferences = preferences;
+        this.importerPreferences = importerPreferences;
     }
 
     @Override
@@ -38,7 +45,7 @@ public class TitleFetcher implements IdBasedFetcher {
 
         BibEntry entry = new BibEntry().withField(StandardField.TITLE, identifier);
 
-        Optional<DOI> doi = WebFetchers.getIdFetcherForIdentifier(DOI.class).findIdentifier(entry);
+        Optional<DOI> doi = WebFetchers.getIdFetcherForIdentifier(DOI.class, importerPreferences).findIdentifier(entry);
         if (doi.isEmpty()) {
             return Optional.empty();
         }

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/UnpaywallFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/UnpaywallFetcher.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
-/// Fetcher for <https://unpaywall.org/>
+/// Fetcher for [Unpaywall](https://unpaywall.org/)
 ///
 /// Currently only used for storing an "API key" to be able to cope with URLs appearing at web server answers such as `Paper or abstract available at https://api.unpaywall.org/v2/10.47397/tb/44-3/tb138kopp-jabref?email=<INSERT_YOUR_EMAIL>`
 public class UnpaywallFetcher implements SearchBasedFetcher, CustomizableKeyFetcher, FulltextFetcher {
@@ -69,11 +69,11 @@ public class UnpaywallFetcher implements SearchBasedFetcher, CustomizableKeyFetc
             LOGGER.atDebug()
                   .addKeyValue("payload", node)
                   .log("Received JSON");
-            String pdfUrl = node.at("/best_oa_location/url_for_pdf").asText();
+            String pdfUrl = node.at("/best_oa_location/url_for_pdf").asString();
             if (pdfUrl == null) {
                 return Optional.empty();
             }
-            return Optional.ofNullable(URLUtil.create(pdfUrl));
+            return Optional.of(URLUtil.create(pdfUrl));
         }
     }
 

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/citation/crossref/CrossRefCitationFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/citation/crossref/CrossRefCitationFetcher.java
@@ -14,7 +14,6 @@ import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ImporterPreferences;
-import org.jabref.logic.importer.WebFetchers;
 import org.jabref.logic.importer.fetcher.CrossRef;
 import org.jabref.logic.importer.fetcher.citation.CitationFetcher;
 import org.jabref.logic.importer.plaincitation.PlainCitationParser;
@@ -54,7 +53,7 @@ public class CrossRefCitationFetcher implements CitationFetcher {
 
     private final ObjectMapper mapper = new ObjectMapper();
 
-    private CrossRef crossRefForDoi = new CrossRef();
+    private final CrossRef crossRefForDoi;
 
     public CrossRefCitationFetcher(
             ImporterPreferences importerPreferences,
@@ -69,6 +68,7 @@ public class CrossRefCitationFetcher implements CitationFetcher {
         this.grobidPreferences = grobidPreferences;
         this.aiPreferences = aiPreferences;
         this.chatModel = chatModel;
+        this.crossRefForDoi = new CrossRef(importerPreferences);
     }
 
     @Override
@@ -114,9 +114,9 @@ public class CrossRefCitationFetcher implements CitationFetcher {
                                                  .withField(StandardField.NOTE, "Could not retrieve reference information from CrossRef")
                                                  .withChanged(true);
                                      }
-                                     return getBibEntryFromText(parser, unstructured.asText());
+                                     return getBibEntryFromText(parser, unstructured.asString());
                                  } else {
-                                     return getBibEntryFromDoi(doiNode.asText(), unstructured);
+                                     return getBibEntryFromDoi(doiNode.asString(), unstructured);
                                  }
                              }))
                              .toList();
@@ -148,7 +148,7 @@ public class CrossRefCitationFetcher implements CitationFetcher {
     private void setField(BibEntry bibEntry, Field field, JsonNode reference, String path) {
         JsonNode node = reference.at(path);
         if (!node.isMissingNode()) {
-            bibEntry.setField(field, node.asText());
+            bibEntry.setField(field, node.asString());
         }
     }
 
@@ -196,8 +196,7 @@ public class CrossRefCitationFetcher implements CitationFetcher {
     // Clone of org.jabref.logic.importer.FulltextFetchers.findDoiForEntry
     private void findDoiForEntry(BibEntry clonedEntry) {
         try {
-            WebFetchers.getIdFetcherForIdentifier(DOI.class)
-                       .findIdentifier(clonedEntry)
+            crossRefForDoi.findIdentifier(clonedEntry)
                        .ifPresent(e -> clonedEntry.setField(StandardField.DOI, e.asString()));
         } catch (FetcherException e) {
             LOGGER.debug("Failed to find DOI", e);

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/citation/crossref/CrossRefCitationFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/citation/crossref/CrossRefCitationFetcher.java
@@ -197,7 +197,7 @@ public class CrossRefCitationFetcher implements CitationFetcher {
     private void findDoiForEntry(BibEntry clonedEntry) {
         try {
             crossRefForDoi.findIdentifier(clonedEntry)
-                       .ifPresent(e -> clonedEntry.setField(StandardField.DOI, e.asString()));
+                          .ifPresent(e -> clonedEntry.setField(StandardField.DOI, e.asString()));
         } catch (FetcherException e) {
             LOGGER.debug("Failed to find DOI", e);
         }

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/citation/opencitations/OpenCitationsFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/citation/opencitations/OpenCitationsFetcher.java
@@ -33,10 +33,11 @@ public class OpenCitationsFetcher implements CitationFetcher {
     private static final Gson GSON = new Gson();
 
     private final ImporterPreferences importerPreferences;
-    private final CrossRef crossRefFetcher = new CrossRef();
+    private final CrossRef crossRefFetcher;
 
     public OpenCitationsFetcher(ImporterPreferences importerPreferences) {
         this.importerPreferences = importerPreferences;
+        this.crossRefFetcher = new CrossRef(importerPreferences);
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/util/BuildInfo.java
+++ b/jablib/src/main/java/org/jabref/logic/util/BuildInfo.java
@@ -47,6 +47,7 @@ public final class BuildInfo {
     public final String springerNatureAPIKey;
     public final String unpaywallEmail;
     public final String wileyTdmApiKey;
+    public final String crossRefEmail;
 
     public BuildInfo() {
         this("/build.properties");
@@ -79,6 +80,7 @@ public final class BuildInfo {
         springerNatureAPIKey = BuildInfo.getValue(properties, "springerNatureAPIKey", "118d90a519d0fc2a01ee9715400054d4");
         unpaywallEmail = BuildInfo.getValue(properties, "unpaywallEmail", "");
         wileyTdmApiKey = BuildInfo.getValue(properties, "wileyTdmApiKey", "");
+        crossRefEmail = BuildInfo.getValue(properties, "crossRefEmail", "");
     }
 
     private static String getValue(Properties properties, String key, String defaultValue) {

--- a/jablib/src/main/resources/build.properties
+++ b/jablib/src/main/resources/build.properties
@@ -10,4 +10,5 @@ medlineApiKey=${medlineApiKey}
 openAlexApiKey=${openAlexApiKey}
 semanticScholarApiKey=${semanticScholarApiKey}
 springerNatureAPIKey=${springerNatureAPIKey}
+crossRefEmail=${crossRefEmail}
 wileyTdmApiKey=${wileyTdmApiKey}

--- a/jablib/src/test/java/org/jabref/logic/importer/FetcherExceptionTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/FetcherExceptionTest.java
@@ -12,6 +12,8 @@ class FetcherExceptionTest {
             "https://api.springernature.com/meta/v1/json?q=anything&api_key=abc&s=1&p=20, https://api.springernature.com/meta/v1/json?q=anything&api_key=[REDACTED]&s=1&p=20",
             "https://api.springernature.com/meta/v1/json?q=anything&API_KEY=abc, https://api.springernature.com/meta/v1/json?q=anything&API_KEY=[REDACTED]",
             "https://api.springernature.com/meta/v1/json?q=anything&apikey=abc123ABC, https://api.springernature.com/meta/v1/json?q=anything&apikey=[REDACTED]",
+            "https://api.crossref.org/works?query=example&mailto=user%40example.org, https://api.crossref.org/works?query=example&mailto=[REDACTED]",
+            "https://api.unpaywall.org/v2/10.1000/example?email=user%40example.org, https://api.unpaywall.org/v2/10.1000/example?email=[REDACTED]",
             "https://api.springernature.com/meta/v1/json?q=anything, https://api.springernature.com/meta/v1/json?q=anything",
             "https://api.springernature.com/meta/v1/json, https://api.springernature.com/meta/v1/json",
             "https://user:pass@example.com/references.bib, https://example.com/references.bib"

--- a/jablib/src/test/java/org/jabref/logic/importer/FetcherRetryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/FetcherRetryTest.java
@@ -1,0 +1,94 @@
+package org.jabref.logic.importer;
+
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jabref.logic.util.URLUtil;
+import org.jabref.model.http.SimpleHttpResponse;
+
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@NullMarked
+class FetcherRetryTest {
+
+    @Test
+    void retriesRateLimitedOperation() throws FetcherException, MalformedURLException {
+        AtomicInteger attempts = new AtomicInteger();
+        List<Duration> delays = new ArrayList<>();
+        FetcherClientException rateLimited = fetcherClientException(FetcherRetry.HTTP_TOO_MANY_REQUESTS);
+
+        String result = FetcherRetry.executeWithRateLimitRetry(() -> {
+            if (attempts.incrementAndGet() == 1) {
+                throw rateLimited;
+            }
+            return "success";
+        }, delays::add);
+
+        assertEquals("success", result);
+        assertEquals(2, attempts.get());
+        assertEquals(List.of(Duration.ofSeconds(1)), delays);
+    }
+
+    @Test
+    void doesNotRetryOtherClientErrors() throws MalformedURLException {
+        AtomicInteger attempts = new AtomicInteger();
+        List<Duration> delays = new ArrayList<>();
+        FetcherClientException badRequest = fetcherClientException(HttpURLConnection.HTTP_BAD_REQUEST);
+
+        assertThrows(FetcherClientException.class, () -> FetcherRetry.executeWithRateLimitRetry(() -> {
+            attempts.incrementAndGet();
+            throw badRequest;
+        }, delays::add));
+
+        assertEquals(1, attempts.get());
+        assertEquals(List.of(), delays);
+    }
+
+    @Test
+    void stopsAfterMaximumRateLimitRetries() throws MalformedURLException {
+        AtomicInteger attempts = new AtomicInteger();
+        List<Duration> delays = new ArrayList<>();
+        FetcherClientException rateLimited = fetcherClientException(FetcherRetry.HTTP_TOO_MANY_REQUESTS);
+
+        assertThrows(FetcherClientException.class, () -> FetcherRetry.executeWithRateLimitRetry(() -> {
+            attempts.incrementAndGet();
+            throw rateLimited;
+        }, delays::add));
+
+        assertEquals(FetcherRetry.MAX_RATE_LIMIT_RETRIES + 1, attempts.get());
+        assertEquals(List.of(Duration.ofSeconds(1), Duration.ofSeconds(2)), delays);
+    }
+
+    @Test
+    void restoresInterruptStatusWhenBackoffIsInterrupted() throws MalformedURLException {
+        FetcherClientException rateLimited = fetcherClientException(FetcherRetry.HTTP_TOO_MANY_REQUESTS);
+        try {
+            assertThrows(FetcherException.class, () -> FetcherRetry.executeWithRateLimitRetry(
+                    () -> {
+                        throw rateLimited;
+                    },
+                    delay -> {
+                        throw new InterruptedException();
+                    }));
+
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    private FetcherClientException fetcherClientException(int statusCode) throws MalformedURLException {
+        return new FetcherClientException(
+                URLUtil.create("https://example.org"),
+                new SimpleHttpResponse(statusCode, "Error", ""));
+    }
+}

--- a/jablib/src/test/java/org/jabref/logic/importer/IdParserFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/IdParserFetcherTest.java
@@ -1,0 +1,68 @@
+package org.jabref.logic.importer;
+
+import java.io.ByteArrayInputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+import java.util.Optional;
+
+import org.jabref.logic.net.ProgressInputStream;
+import org.jabref.logic.net.URLDownload;
+import org.jabref.logic.util.URLUtil;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.identifier.DOI;
+import org.jabref.model.http.SimpleHttpResponse;
+
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@NullMarked
+class IdParserFetcherTest {
+
+    @Test
+    void usesUrlDownloadForIdentifierLookups() throws FetcherException, MalformedURLException, URISyntaxException, ParseException {
+        URL url = URLUtil.create("https://example.org");
+        URLDownload urlDownload = mock(URLDownload.class);
+        Parser parser = mock(Parser.class);
+        ProgressInputStream stream = new ProgressInputStream(new ByteArrayInputStream(new byte[0]), 0);
+        BibEntry fetchedEntry = new BibEntry();
+        fetchedEntry.setField(StandardField.DOI, "10.1000/example");
+        when(urlDownload.asInputStream()).thenReturn(stream);
+        when(parser.parseEntries(stream)).thenReturn(List.of(fetchedEntry));
+        IdParserFetcher<DOI> fetcher = mockFetcher(url, urlDownload, parser);
+        when(fetcher.extractIdentifier(any(BibEntry.class), eq(List.of(fetchedEntry)))).thenReturn(DOI.parse("10.1000/example"));
+
+        assertEquals(DOI.parse("10.1000/example"), fetcher.findIdentifier(new BibEntry()));
+    }
+
+    @Test
+    void returnsEmptyWhenIdentifierLookupReturnsNotFound() throws FetcherException, MalformedURLException, URISyntaxException {
+        URL url = URLUtil.create("https://example.org");
+        URLDownload urlDownload = mock(URLDownload.class);
+        when(urlDownload.asInputStream()).thenThrow(new FetcherClientException(
+                url,
+                new SimpleHttpResponse(HttpURLConnection.HTTP_NOT_FOUND, "Not Found", "")));
+        IdParserFetcher<DOI> fetcher = mockFetcher(url, urlDownload, mock(Parser.class));
+
+        assertEquals(Optional.empty(), fetcher.findIdentifier(new BibEntry()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private IdParserFetcher<DOI> mockFetcher(URL url, URLDownload urlDownload, Parser parser) throws MalformedURLException, URISyntaxException, FetcherException {
+        IdParserFetcher<DOI> fetcher = mock(IdParserFetcher.class, Answers.CALLS_REAL_METHODS);
+        when(fetcher.getURLForEntry(any(BibEntry.class))).thenReturn(url);
+        when(fetcher.getParser()).thenReturn(parser);
+        when(fetcher.getUrlDownload(url)).thenReturn(urlDownload);
+        return fetcher;
+    }
+}

--- a/jablib/src/test/java/org/jabref/logic/importer/IdParserFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/IdParserFetcherTest.java
@@ -36,7 +36,7 @@ class IdParserFetcherTest {
         Parser parser = mock(Parser.class);
         ProgressInputStream stream = new ProgressInputStream(new ByteArrayInputStream(new byte[0]), 0);
         BibEntry fetchedEntry = new BibEntry();
-        fetchedEntry.setField(StandardField.DOI, "10.1000/example");
+        fetchedEntry.withField(StandardField.DOI, "10.1000/example");
         when(urlDownload.asInputStream()).thenReturn(stream);
         when(parser.parseEntries(stream)).thenReturn(List.of(fetchedEntry));
         IdParserFetcher<DOI> fetcher = mockFetcher(url, urlDownload, parser);

--- a/jablib/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
@@ -1,10 +1,14 @@
 package org.jabref.logic.importer;
 
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -12,6 +16,7 @@ import java.util.stream.Collectors;
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.importer.fetcher.AbstractIsbnFetcher;
 import org.jabref.logic.importer.fetcher.CollectionOfComputerScienceBibliographiesFetcher;
+import org.jabref.logic.importer.fetcher.CrossRef;
 import org.jabref.logic.importer.fetcher.GoogleScholar;
 import org.jabref.logic.importer.fetcher.GvkFetcher;
 import org.jabref.logic.importer.fetcher.IssnFetcher;
@@ -23,6 +28,8 @@ import org.jabref.logic.importer.fetcher.isbntobibtex.OpenLibraryIsbnFetcher;
 import org.jabref.logic.importer.plaincitation.GrobidPlainCitationParser;
 import org.jabref.logic.importer.plaincitation.LlmPlainCitationParser;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
 
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfoList;
@@ -35,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class WebFetchersTest {
 
@@ -182,6 +190,17 @@ class WebFetchersTest {
 
             assertEquals(expected, getClasses(idFetchers));
         }
+    }
+
+    @Test
+    void getIdFetcherForFieldPassesImporterPreferencesToCrossref() throws URISyntaxException, MalformedURLException {
+        ImporterPreferences importerPreferences = mock(ImporterPreferences.class);
+        when(importerPreferences.getApiKey(CrossRef.FETCHER_NAME)).thenReturn(Optional.of("user@example.org"));
+
+        CrossRef fetcher = (CrossRef) WebFetchers.getIdFetcherForField(StandardField.DOI, importerPreferences).orElseThrow();
+        URL url = fetcher.getURLForEntry(new BibEntry().withField(StandardField.TITLE, "A title"));
+
+        assertEquals("query.bibliographic=A%20title&rows=20&offset=0&mailto=user%40example.org", url.getQuery());
     }
 
     private Set<? extends Class<?>> getClasses(Collection<?> objects) {

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/CrossRefUrlTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/CrossRefUrlTest.java
@@ -42,4 +42,11 @@ class CrossRefUrlTest {
 
         assertEquals("query.bibliographic=A%20title&rows=20&offset=0", url.getQuery());
     }
+
+    @Test
+    void testUrlIncludesApiKey() {
+        CrossRef fetcher = new CrossRef(mock(ImporterPreferences.class));
+
+        assertEquals("https://api.crossref.org/works?query=test&rows=1&mailto=user%40example.org", fetcher.getTestUrl("user@example.org"));
+    }
 }

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/CrossRefUrlTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/CrossRefUrlTest.java
@@ -44,7 +44,7 @@ class CrossRefUrlTest {
     }
 
     @Test
-    void testUrlIncludesApiKey() {
+    void urlIncludesApiKey() {
         CrossRef fetcher = new CrossRef(mock(ImporterPreferences.class));
 
         assertEquals("https://api.crossref.org/works?query=test&rows=1&mailto=user%40example.org", fetcher.getTestUrl("user@example.org"));

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/CrossRefUrlTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/CrossRefUrlTest.java
@@ -1,0 +1,45 @@
+package org.jabref.logic.importer.fetcher;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Optional;
+
+import org.jabref.logic.importer.ImporterPreferences;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@NullMarked
+class CrossRefUrlTest {
+
+    @Test
+    void addsConfiguredEmailToEntrySearchUrl() throws URISyntaxException, MalformedURLException {
+        ImporterPreferences importerPreferences = mock(ImporterPreferences.class);
+        when(importerPreferences.getApiKey(CrossRef.FETCHER_NAME)).thenReturn(Optional.of("user@example.org"));
+        CrossRef fetcher = new CrossRef(importerPreferences);
+        BibEntry entry = new BibEntry().withField(StandardField.TITLE, "A title");
+
+        URL url = fetcher.getURLForEntry(entry);
+
+        assertEquals("query.bibliographic=A%20title&rows=20&offset=0&mailto=user%40example.org", url.getQuery());
+    }
+
+    @Test
+    void omitsMailtoParameterWithoutConfiguredEmail() throws URISyntaxException, MalformedURLException {
+        ImporterPreferences importerPreferences = mock(ImporterPreferences.class);
+        when(importerPreferences.getApiKey(CrossRef.FETCHER_NAME)).thenReturn(Optional.empty());
+        CrossRef fetcher = new CrossRef(importerPreferences);
+        BibEntry entry = new BibEntry().withField(StandardField.TITLE, "A title");
+
+        URL url = fetcher.getURLForEntry(entry);
+
+        assertEquals("query.bibliographic=A%20title&rows=20&offset=0", url.getQuery());
+    }
+}

--- a/jablib/src/test/java/org/jabref/logic/util/BuildInfoTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/BuildInfoTest.java
@@ -16,5 +16,6 @@ class BuildInfoTest {
     void fileImport() {
         BuildInfo buildInfo = new BuildInfo("/org/jabref/util/build.properties");
         assertEquals("42", buildInfo.version.getFullVersion());
+        assertEquals("crossref@example.org", buildInfo.crossRefEmail);
     }
 }

--- a/jablib/src/test/resources/org/jabref/util/build.properties
+++ b/jablib/src/test/resources/org/jabref/util/build.properties
@@ -1,1 +1,2 @@
 version=42
+crossRefEmail=crossref@example.org


### PR DESCRIPTION
### Summary

Crossref requests now use the configured contact email across application, command-line, and identifier lookup paths, allowing JabRef to use Crossref's polite pool. Identifier lookups also receive their caller's importer preferences explicitly, and temporary rate-limit failures are retried with bounded backoff.

jabref-contrib-policy:4.2:reviewed​:ok

### Analogies

This is like adding a return address to honey sent through the post: Crossref can recognize the sender and handle the request more thoughtfully. The bounded retries are a small square of chocolate rather than an unlimited box, and the shared configuration keeps the request paths aligned like phases of the moon.

### Steps to test

1. Set `CROSSREF_EMAIL` to a valid contact email and run the JabRef application.
2. Select an entry without a DOI and invoke the title-to-DOI lookup.
3. Confirm that the lookup succeeds and Crossref requests include the configured `mailto` query parameter.

Automated verification completed:

- `./gradlew :jablib:check`
- `./gradlew checkstyleMain checkstyleTest checkstyleJmh`
- `./gradlew modernizer`
- `./gradlew --no-configuration-cache :rewriteDryRun`
- `./gradlew javadoc`
- Focused `WebFetchersTest`, `CrossRefUrlTest`, `BuildInfoTest`, `FetcherRetryTest`, and `IdParserFetcherTest`

Before marking ready for review: complete a manual JabRef run using a configured Crossref email. The repository-wide Markdown command is blocked only by an unrelated untracked Markdown file; the changed Markdown files pass linting.

### Related issues and pull requests

No related issue identified after searching JabRef/jabref and JabRef/jabref-koppor.

### AI usage

Codex (model GPT-5). I reviewed, understand, and take full ownership of the changes.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

# Code checklist

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [x] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [x] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [x] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [x] No `catch (Exception e)` — only specific exceptions are caught.
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [x] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [x] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [x] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [x] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [x] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [x] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [x] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [x] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

### Security

- [x] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [x] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [x] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.

## 2. Verification commands

Run in this order — cheapest first. Each must pass.

- [x] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [x] `./gradlew modernizer`.
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [x] `./gradlew javadoc`.
- [ ] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed). The complete command is blocked by an unrelated untracked Markdown file; changed Markdown files pass.
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.

## 3. Documentation

- [x] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Link the issue if one exists; link the PR only when no issue exists. Use `TODO` as the placeholder when neither is known yet — never a fake number.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [x] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [x] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [x] If `CHANGELOG.md` used a `TODO` placeholder (no issue confidently identified yet — an existing issue link always stays), it was replaced with the real PR-number link after PR creation, then committed and pushed. If an issue is identified or created later, the link is switched to the issue.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
