### PR TITLE
Bring back all Ikonli icons for groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where only a reduced set of icons was available for groups. The broader group icon set is available again. [#16557](https://github.com/JabRef/jabref/issues/16557)
 - We fixed an issue where empty values in the merge entries dialog could not be selected to clear the merged entry field. [#15014](https://github.com/JabRef/jabref/issues/15014)
 - We fixed an issue where switching the citation provider in the "Citations" tab froze the user interface while the results were matched against the library. [#16270](https://github.com/JabRef/jabref/issues/16270)
 - We fixed an issue where reference mark expands onto the text when cursor is at the end of the mark. [#16515](https://github.com/JabRef/jabref/issues/16515)

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogView.java
@@ -63,7 +63,6 @@ import org.controlsfx.control.GridView;
 import org.controlsfx.control.PopOver;
 import org.controlsfx.control.textfield.CustomTextField;
 import org.jspecify.annotations.Nullable;
-import org.kordamp.ikonli.Ikon;
 
 public class GroupDialogView extends BaseDialog<AbstractGroup> {
 
@@ -292,12 +291,12 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
                                                                       ikon.name()))
                                                               .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
         IkonliIcon.allIcons().stream()
-                 .filter(ikon -> !(ikon instanceof JabRefMaterialDesignIcon))
-                 .map(ikon -> new GroupIconPickerItem(
-                         new IkonliIcon(ikon),
-                         ikon.getDescription(),
-                         "%s %s".formatted(ikon, ikon.getDescription())))
-                 .forEach(pickerItems::add);
+                  .filter(ikon -> !(ikon instanceof JabRefMaterialDesignIcon))
+                  .map(ikon -> new GroupIconPickerItem(
+                          new IkonliIcon(ikon),
+                          ikon.getDescription(),
+                          "%s %s".formatted(ikon, ikon.getDescription())))
+                  .forEach(pickerItems::add);
 
         ObservableList<GroupIconPickerItem> ikonList = FXCollections.observableArrayList(pickerItems);
         FilteredList<GroupIconPickerItem> filteredList = new FilteredList<>(ikonList);

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogView.java
@@ -1,8 +1,10 @@
 package org.jabref.gui.groups;
 
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.ServiceLoader;
 
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
@@ -33,6 +35,8 @@ import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.help.HelpAction;
 import org.jabref.gui.icon.IconTheme;
+import org.jabref.gui.icon.IkonliIcon;
+import org.jabref.gui.icon.JabRefIconProvider;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.IconValidationDecorator;
@@ -57,6 +61,8 @@ import org.controlsfx.control.GridView;
 import org.controlsfx.control.PopOver;
 import org.controlsfx.control.textfield.CustomTextField;
 import org.jspecify.annotations.Nullable;
+import org.kordamp.ikonli.Ikon;
+import org.kordamp.ikonli.IkonProvider;
 
 public class GroupDialogView extends BaseDialog<AbstractGroup> {
 
@@ -278,16 +284,22 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
 
     @FXML
     private void openIconPicker() {
-        ObservableList<IconTheme.JabRefIcons> ikonList = FXCollections.observableArrayList(IconTheme.JabRefIcons.values());
-        FilteredList<IconTheme.JabRefIcons> filteredList = new FilteredList<>(ikonList);
+        ObservableList<Ikon> ikonList = FXCollections.observableArrayList();
+        FilteredList<Ikon> filteredList = new FilteredList<>(ikonList);
+
+        for (IkonProvider provider : ServiceLoader.load(IkonProvider.class.getModule().getLayer(), IkonProvider.class)) {
+            if (provider.getClass() != JabRefIconProvider.class) {
+                ikonList.addAll(EnumSet.allOf(provider.getIkon()));
+            }
+        }
 
         CustomTextField searchBox = new CustomTextField();
         searchBox.setPromptText(Localization.lang("Search..."));
         searchBox.setLeft(IconTheme.JabRefIcons.SEARCH.getGraphicNode());
         searchBox.textProperty().addListener((_, _, newValue) ->
-                filteredList.setPredicate(icon -> newValue.isEmpty() || icon.name().toLowerCase().contains(newValue.toLowerCase())));
+                filteredList.setPredicate(ikon -> newValue.isEmpty() || ikon.getDescription().toLowerCase().contains(newValue.toLowerCase())));
 
-        GridView<IconTheme.JabRefIcons> ikonGridView = new GridView<>(FXCollections.observableArrayList());
+        GridView<Ikon> ikonGridView = new GridView<>(FXCollections.observableArrayList());
         ikonGridView.setCellFactory(gridView -> new IkonliCell());
         ikonGridView.setPrefWidth(520);
         ikonGridView.setPrefHeight(400);
@@ -310,21 +322,21 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
         popOver.show(iconPickerButton);
     }
 
-    public class IkonliCell extends GridCell<IconTheme.JabRefIcons> {
+    public class IkonliCell extends GridCell<Ikon> {
         @Override
-        protected void updateItem(IconTheme.JabRefIcons ikon, boolean empty) {
+        protected void updateItem(Ikon ikon, boolean empty) {
             super.updateItem(ikon, empty);
             if (empty || (ikon == null)) {
                 setText(null);
                 setGraphic(null);
             } else {
-                setGraphic(ikon.withSize(22).getGraphicNode());
+                setGraphic(new IkonliIcon(ikon).withSize(22).getGraphicNode());
                 setAlignment(Pos.BASELINE_CENTER);
                 setPadding(new Insets(1));
                 setBorder(new Border(new BorderStroke(Color.BLACK, BorderStrokeStyle.SOLID, CornerRadii.EMPTY, BorderStroke.THIN)));
 
                 setOnMouseClicked(event -> {
-                    iconField.textProperty().setValue(ikon.name());
+                    iconField.textProperty().setValue(ikon.toString());
                     PopOver stage = (PopOver) this.getGridView().getParent().getScene().getWindow();
                     stage.hide();
                 });

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogView.java
@@ -2,10 +2,12 @@ package org.jabref.gui.groups;
 
 import java.util.Arrays;
 import java.util.EnumMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.SequencedSet;
+import java.util.stream.Collectors;
 
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
@@ -284,21 +286,7 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
 
     @FXML
     private void openIconPicker() {
-        SequencedSet<GroupIconPickerItem> pickerItems = Arrays.stream(IconTheme.JabRefIcons.values())
-                                                              .map(ikon -> new GroupIconPickerItem(
-                                                                      ikon,
-                                                                      ikon.name(),
-                                                                      ikon.name()))
-                                                              .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
-        IkonliIcon.allIcons().stream()
-                  .filter(ikon -> !(ikon instanceof JabRefMaterialDesignIcon))
-                  .map(ikon -> new GroupIconPickerItem(
-                          new IkonliIcon(ikon),
-                          ikon.getDescription(),
-                          "%s %s".formatted(ikon, ikon.getDescription())))
-                  .forEach(pickerItems::add);
-
-        ObservableList<GroupIconPickerItem> ikonList = FXCollections.observableArrayList(pickerItems);
+        ObservableList<GroupIconPickerItem> ikonList = FXCollections.observableArrayList(GroupIconPickerItems.ALL);
         FilteredList<GroupIconPickerItem> filteredList = new FilteredList<>(ikonList);
 
         CustomTextField searchBox = new CustomTextField();
@@ -335,6 +323,27 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
     private record GroupIconPickerItem(JabRefIcon icon, String persistedIdentifier, String searchText) {
         private GroupIconPickerItem {
             searchText = searchText.toLowerCase(Locale.ENGLISH);
+        }
+    }
+
+    private static final class GroupIconPickerItems {
+        private static final List<GroupIconPickerItem> ALL = load();
+
+        private static List<GroupIconPickerItem> load() {
+            SequencedSet<GroupIconPickerItem> pickerItems = Arrays.stream(IconTheme.JabRefIcons.values())
+                                                                  .map(ikon -> new GroupIconPickerItem(
+                                                                          ikon,
+                                                                          ikon.name(),
+                                                                          ikon.name()))
+                                                                  .collect(Collectors.toCollection(LinkedHashSet::new));
+            IkonliIcon.allIcons().stream()
+                      .filter(ikon -> !(ikon instanceof JabRefMaterialDesignIcon))
+                      .map(ikon -> new GroupIconPickerItem(
+                              new IkonliIcon(ikon),
+                              ikon.getDescription(),
+                              "%s %s".formatted(ikon, ikon.getDescription())))
+                      .forEach(pickerItems::add);
+            return List.copyOf(pickerItems);
         }
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogView.java
@@ -37,6 +37,7 @@ import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.help.HelpAction;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.icon.IkonliIcon;
+import org.jabref.gui.icon.JabRefIcon;
 import org.jabref.gui.icon.JabRefMaterialDesignIcon;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.util.BaseDialog;

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogView.java
@@ -1,11 +1,11 @@
 package org.jabref.gui.groups;
 
+import java.util.Arrays;
 import java.util.EnumMap;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.ServiceLoader;
+import java.util.SequencedSet;
 
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
@@ -37,7 +37,7 @@ import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.help.HelpAction;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.icon.IkonliIcon;
-import org.jabref.gui.icon.JabRefIconProvider;
+import org.jabref.gui.icon.JabRefMaterialDesignIcon;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.IconValidationDecorator;
@@ -63,7 +63,6 @@ import org.controlsfx.control.PopOver;
 import org.controlsfx.control.textfield.CustomTextField;
 import org.jspecify.annotations.Nullable;
 import org.kordamp.ikonli.Ikon;
-import org.kordamp.ikonli.IkonProvider;
 
 public class GroupDialogView extends BaseDialog<AbstractGroup> {
 
@@ -285,26 +284,32 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
 
     @FXML
     private void openIconPicker() {
-        ObservableList<Ikon> ikonList = FXCollections.observableArrayList();
-        FilteredList<Ikon> filteredList = new FilteredList<>(ikonList);
+        SequencedSet<GroupIconPickerItem> pickerItems = Arrays.stream(IconTheme.JabRefIcons.values())
+                                                              .map(ikon -> new GroupIconPickerItem(
+                                                                      ikon,
+                                                                      ikon.name(),
+                                                                      ikon.name()))
+                                                              .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
+        IkonliIcon.allIcons().stream()
+                 .filter(ikon -> !(ikon instanceof JabRefMaterialDesignIcon))
+                 .map(ikon -> new GroupIconPickerItem(
+                         new IkonliIcon(ikon),
+                         ikon.getDescription(),
+                         "%s %s".formatted(ikon, ikon.getDescription())))
+                 .forEach(pickerItems::add);
 
-        for (IkonProvider provider : ServiceLoader.load(IkonProvider.class.getModule().getLayer(), IkonProvider.class)) {
-            if (provider.getClass() != JabRefIconProvider.class) {
-                ikonList.addAll(EnumSet.allOf(provider.getIkon()));
-            }
-        }
+        ObservableList<GroupIconPickerItem> ikonList = FXCollections.observableArrayList(pickerItems);
+        FilteredList<GroupIconPickerItem> filteredList = new FilteredList<>(ikonList);
 
         CustomTextField searchBox = new CustomTextField();
         searchBox.setPromptText(Localization.lang("Search..."));
         searchBox.setLeft(IconTheme.JabRefIcons.SEARCH.getGraphicNode());
         searchBox.textProperty().addListener((_, _, newValue) -> {
             String normalizedQuery = newValue.toLowerCase(Locale.ENGLISH);
-            filteredList.setPredicate(ikon -> normalizedQuery.isEmpty()
-                    || ikon.toString().toLowerCase(Locale.ENGLISH).contains(normalizedQuery)
-                    || ikon.getDescription().toLowerCase(Locale.ENGLISH).contains(normalizedQuery));
+            filteredList.setPredicate(ikon -> normalizedQuery.isEmpty() || ikon.searchText().contains(normalizedQuery));
         });
 
-        GridView<Ikon> ikonGridView = new GridView<>(FXCollections.observableArrayList());
+        GridView<GroupIconPickerItem> ikonGridView = new GridView<>(FXCollections.observableArrayList());
         ikonGridView.setCellFactory(gridView -> new IkonliCell());
         ikonGridView.setPrefWidth(520);
         ikonGridView.setPrefHeight(400);
@@ -327,21 +332,27 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
         popOver.show(iconPickerButton);
     }
 
-    public class IkonliCell extends GridCell<Ikon> {
+    private record GroupIconPickerItem(JabRefIcon icon, String persistedIdentifier, String searchText) {
+        private GroupIconPickerItem {
+            searchText = searchText.toLowerCase(Locale.ENGLISH);
+        }
+    }
+
+    public class IkonliCell extends GridCell<GroupIconPickerItem> {
         @Override
-        protected void updateItem(Ikon ikon, boolean empty) {
+        protected void updateItem(GroupIconPickerItem ikon, boolean empty) {
             super.updateItem(ikon, empty);
             if (empty || (ikon == null)) {
                 setText(null);
                 setGraphic(null);
             } else {
-                setGraphic(new IkonliIcon(ikon).withSize(22).getGraphicNode());
+                setGraphic(ikon.icon().withSize(22).getGraphicNode());
                 setAlignment(Pos.BASELINE_CENTER);
                 setPadding(new Insets(1));
                 setBorder(new Border(new BorderStroke(Color.BLACK, BorderStrokeStyle.SOLID, CornerRadii.EMPTY, BorderStroke.THIN)));
 
                 setOnMouseClicked(event -> {
-                    iconField.textProperty().setValue(ikon.toString());
+                    iconField.textProperty().setValue(ikon.persistedIdentifier());
                     PopOver stage = (PopOver) this.getGridView().getParent().getScene().getWindow();
                     stage.hide();
                 });

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogView.java
@@ -3,6 +3,7 @@ package org.jabref.gui.groups;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.ServiceLoader;
 
@@ -296,8 +297,12 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
         CustomTextField searchBox = new CustomTextField();
         searchBox.setPromptText(Localization.lang("Search..."));
         searchBox.setLeft(IconTheme.JabRefIcons.SEARCH.getGraphicNode());
-        searchBox.textProperty().addListener((_, _, newValue) ->
-                filteredList.setPredicate(ikon -> newValue.isEmpty() || ikon.getDescription().toLowerCase().contains(newValue.toLowerCase())));
+        searchBox.textProperty().addListener((_, _, newValue) -> {
+            String normalizedQuery = newValue.toLowerCase(Locale.ENGLISH);
+            filteredList.setPredicate(ikon -> normalizedQuery.isEmpty()
+                    || ikon.toString().toLowerCase(Locale.ENGLISH).contains(normalizedQuery)
+                    || ikon.getDescription().toLowerCase(Locale.ENGLISH).contains(normalizedQuery));
+        });
 
         GridView<Ikon> ikonGridView = new GridView<>(FXCollections.observableArrayList());
         ikonGridView.setCellFactory(gridView -> new IkonliCell());

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
@@ -263,7 +263,7 @@ public class GroupNodeViewModel {
     }
 
     private Optional<JabRefIcon> parseIcon(String iconCode) {
-        return IconTheme.findJabRefIcon(iconCode)
+        return IconTheme.findGroupIcon(iconCode)
                         .map(icon -> icon.withColor(getColor()));
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/icon/IconTheme.java
+++ b/jabgui/src/main/java/org/jabref/gui/icon/IconTheme.java
@@ -91,6 +91,11 @@ public class IconTheme {
         }
     }
 
+    public static Optional<JabRefIcon> findGroupIcon(String iconCode) {
+        return findJabRefIcon(iconCode)
+                .or(() -> IkonliIcon.findIcon(iconCode));
+    }
+
     private static URL getIconUrl(String name) {
         if (!KEY_TO_ICON.containsKey(name)) {
             LOGGER.warn("Could not find icon url by name {}, so falling back on default icon {}", name, DEFAULT_ICON_PATH);

--- a/jabgui/src/main/java/org/jabref/gui/icon/IconTheme.java
+++ b/jabgui/src/main/java/org/jabref/gui/icon/IconTheme.java
@@ -93,6 +93,7 @@ public class IconTheme {
 
     public static Optional<JabRefIcon> findGroupIcon(String iconCode) {
         return findJabRefIcon(iconCode)
+                .or(() -> IkonliIcon.findIconByDescription(iconCode))
                 .or(() -> IkonliIcon.findIcon(iconCode));
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/icon/IkonliIcon.java
+++ b/jabgui/src/main/java/org/jabref/gui/icon/IkonliIcon.java
@@ -1,13 +1,13 @@
 package org.jabref.gui.icon;
 
 import java.util.EnumSet;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SequencedSet;
 import java.util.ServiceLoader;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import javafx.scene.Node;
@@ -54,30 +54,41 @@ public final class IkonliIcon implements JabRefIcon {
         this.size = size;
     }
 
-    /// Finds the Ikonli icon whose name matches {@code code} (case-insensitive).
+    /// Finds the Ikonli icon whose name matches `code` (case-insensitive).
     public static Optional<JabRefIcon> findIcon(String code) {
         return Optional.ofNullable(IkonliIcons.BY_NAME.get(code.toUpperCase(Locale.ENGLISH)))
                        .map(IkonliIcon::new);
     }
 
+    /// Finds the Ikonli icon whose pack-qualified description matches `description` (case-insensitive).
+    public static Optional<JabRefIcon> findIconByDescription(String description) {
+        return Optional.ofNullable(IkonliIcons.BY_DESCRIPTION.get(description.toUpperCase(Locale.ENGLISH)))
+                       .map(IkonliIcon::new);
+    }
+
+    public static List<Ikon> allIcons() {
+        return IkonliIcons.ALL;
+    }
+
     /// Holds every {@link Ikon} discovered via the {@link IkonProvider} service loader. Initialization on first
     /// access guaranteed by JVM.
     private static final class IkonliIcons {
-        private static final Set<Ikon> ALL = load();
-        private static final Map<String, Ikon> BY_NAME = loadMap();
+        private static final List<Ikon> ALL = load();
+        private static final Map<String, Ikon> BY_NAME = loadMap(Ikon::toString);
+        private static final Map<String, Ikon> BY_DESCRIPTION = loadMap(Ikon::getDescription);
 
-        private static Set<Ikon> load() {
-            Set<Ikon> all = new HashSet<>();
+        private static List<Ikon> load() {
+            SequencedSet<Ikon> all = new LinkedHashSet<>();
             for (IkonProvider provider : ServiceLoader.load(IkonProvider.class)) {
                 all.addAll(EnumSet.allOf(provider.getIkon()));
             }
-            return Set.copyOf(all);
+            return List.copyOf(all);
         }
 
-        private static Map<String, Ikon> loadMap() {
+        private static Map<String, Ikon> loadMap(java.util.function.Function<Ikon, String> keyMapper) {
             return ALL.stream()
                       .collect(Collectors.toUnmodifiableMap(
-                              Ikon::toString,
+                              ikon -> keyMapper.apply(ikon).toUpperCase(Locale.ENGLISH),
                               ikon -> ikon,
                               (existing, duplicate) -> existing
                       ));

--- a/jabgui/src/main/java/org/jabref/gui/icon/IkonliIcon.java
+++ b/jabgui/src/main/java/org/jabref/gui/icon/IkonliIcon.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.icon;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.SequencedSet;
 import java.util.ServiceLoader;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javafx.scene.Node;
@@ -66,26 +68,26 @@ public final class IkonliIcon implements JabRefIcon {
                        .map(IkonliIcon::new);
     }
 
-    public static List<Ikon> allIcons() {
+    public static SequencedSet<Ikon> allIcons() {
         return IkonliIcons.ALL;
     }
 
     /// Holds every {@link Ikon} discovered via the {@link IkonProvider} service loader. Initialization on first
     /// access guaranteed by JVM.
     private static final class IkonliIcons {
-        private static final List<Ikon> ALL = load();
+        private static final SequencedSet<Ikon> ALL = load();
         private static final Map<String, Ikon> BY_NAME = loadMap(Ikon::toString);
         private static final Map<String, Ikon> BY_DESCRIPTION = loadMap(Ikon::getDescription);
 
-        private static List<Ikon> load() {
+        private static SequencedSet<Ikon> load() {
             SequencedSet<Ikon> all = new LinkedHashSet<>();
             for (IkonProvider provider : ServiceLoader.load(IkonProvider.class)) {
                 all.addAll(EnumSet.allOf(provider.getIkon()));
             }
-            return List.copyOf(all);
+            return Collections.unmodifiableSequencedSet(all);
         }
 
-        private static Map<String, Ikon> loadMap(java.util.function.Function<Ikon, String> keyMapper) {
+        private static Map<String, Ikon> loadMap(Function<Ikon, String> keyMapper) {
             return ALL.stream()
                       .collect(Collectors.toUnmodifiableMap(
                               ikon -> keyMapper.apply(ikon).toUpperCase(Locale.ENGLISH),

--- a/jabgui/src/main/java/org/jabref/gui/icon/IkonliIcon.java
+++ b/jabgui/src/main/java/org/jabref/gui/icon/IkonliIcon.java
@@ -54,10 +54,10 @@ public final class IkonliIcon implements JabRefIcon {
         this.size = size;
     }
 
-    /// Finds the Ikonli icon whose name matches {@code code} (case-insensitive), tinted with {@code color}.
-    public static Optional<JabRefIcon> findIcon(String code, Color color) {
+    /// Finds the Ikonli icon whose name matches {@code code} (case-insensitive).
+    public static Optional<JabRefIcon> findIcon(String code) {
         return Optional.ofNullable(IkonliIcons.BY_NAME.get(code.toUpperCase(Locale.ENGLISH)))
-                       .map(ikon -> new IkonliIcon(ikon).withColor(color));
+                       .map(IkonliIcon::new);
     }
 
     /// Holds every {@link Ikon} discovered via the {@link IkonProvider} service loader. Initialization on first

--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -251,7 +251,7 @@ public class MainTableColumnFactory {
     private Node createGroupIconRegion(BibEntryTableViewModel entry, List<AbstractGroup> matchedGroups) {
         List<JabRefIcon> groupIcons = matchedGroups.stream()
                                                    .filter(abstractGroup -> abstractGroup.getIconName().isPresent())
-                                                   .flatMap(group -> IconTheme.findJabRefIcon(group.getIconName().get())
+                                                   .flatMap(group -> IconTheme.findGroupIcon(group.getIconName().get())
                                                                               .map(icon -> icon.withColor(group.getColor()
                                                                                                                .map(Color::valueOf)
                                                                                                                .orElse(IconTheme.DEFAULT_GROUP_COLOR)))

--- a/jabgui/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
@@ -211,6 +211,16 @@ class GroupNodeViewModelTest {
         assertEquals("CLOSE_CIRCLE", model.getIcon().name());
     }
 
+    @Test
+    void getIconResolvesPersistedProviderIkonliName() {
+        ExplicitGroup group = new ExplicitGroup("group", GroupHierarchyType.INDEPENDENT, ',');
+        group.setIconName("TRENDING_UP");
+
+        GroupNodeViewModel model = getViewModelForGroup(group);
+
+        assertEquals("TRENDING_UP", model.getIcon().name());
+    }
+
     private GroupNodeViewModel getViewModelForGroup(AbstractGroup group) {
         return new GroupNodeViewModel(databaseContext, stateManager, taskExecutor, group, new CustomLocalDragboard(), preferences);
     }

--- a/jabgui/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
@@ -221,6 +221,16 @@ class GroupNodeViewModelTest {
         assertEquals("TRENDING_UP", model.getIcon().name());
     }
 
+    @Test
+    void getIconResolvesPersistedProviderIkonliDescription() {
+        ExplicitGroup group = new ExplicitGroup("group", GroupHierarchyType.INDEPENDENT, ',');
+        group.setIconName("mdi2m-math-integral-box");
+
+        GroupNodeViewModel model = getViewModelForGroup(group);
+
+        assertEquals("MATH_INTEGRAL_BOX", model.getIcon().name());
+    }
+
     private GroupNodeViewModel getViewModelForGroup(AbstractGroup group) {
         return new GroupNodeViewModel(databaseContext, stateManager, taskExecutor, group, new CustomLocalDragboard(), preferences);
     }


### PR DESCRIPTION
### Summary

Restore ikonli group icons

### Steps to test

1. Create a group
2. Select icon list

Before:
<img width="754" height="630" alt="image" src="https://github.com/user-attachments/assets/7e966a3d-208c-4bdf-bc56-9c2d31463d84" />

After:
<img width="745" height="632" alt="image" src="https://github.com/user-attachments/assets/9c179b8c-d96d-4e2c-983d-215bf530a003" />


### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/16557

### AI usage

Zed + GPT 5.4

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
