### PR TITLE
Close stale PRs based on the age of the stale label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -77,7 +77,15 @@ jobs:
           IFS=',' read -ra exempt_labels <<< "$EXEMPT_LABELS"
 
           for pr in $candidates; do
+            # Re-read the labels: they can have been removed since the candidate list was built.
             labels="$(gh pr view "$pr" --repo "$REPO" --json labels --jq '.labels[].name')"
+            for required in "$STALE_LABEL" "$CHANGES_REQUIRED_LABEL"; do
+              if ! printf '%s\n' "$labels" | grep -Fxq "$required"; then
+                echo "#$pr: label '$required' is gone, skipping"
+                continue 2
+              fi
+            done
+
             exempt=""
             for label in "${exempt_labels[@]}"; do
               if printf '%s\n' "$labels" | grep -Fxq "$label"; then

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,9 @@ jobs:
       DAYS_BEFORE_PR_CLOSE: 7
       STALE_LABEL: "status: stale"
       CHANGES_REQUIRED_LABEL: "status: changes-required"
-      EXEMPT_LABELS: "📌 Pinned,dev: no-bot-comments"
+      # "dev: no-bot-comments" is deliberately not exempt: it usually stays on a PR even after
+      # "status: changes-required" was set, so exempting it would take most PRs out of the process.
+      EXEMPT_LABELS: "📌 Pinned"
     steps:
       # Marking only. Closing is done below, because actions/stale measures
       # days-before-close against the GitHub field `updated_at`, which is bumped by any

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,18 +20,25 @@ jobs:
     env:
       DAYS_BEFORE_PR_STALE: 3
       DAYS_BEFORE_PR_CLOSE: 7
+      STALE_LABEL: "status: stale"
+      CHANGES_REQUIRED_LABEL: "status: changes-required"
+      EXEMPT_LABELS: "📌 Pinned,dev: no-bot-comments"
     steps:
+      # Marking only. Closing is done below, because actions/stale measures
+      # days-before-close against the GitHub field `updated_at`, which is bumped by any
+      # activity on the pull request - including activity that is not the contributor's.
+      # PRs whose `updated_at` keeps moving therefore never reach the close threshold.
       - uses: actions/stale@v11
         id: stale
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          exempt-pr-labels: "📌 Pinned,dev: no-bot-comments"
+          exempt-pr-labels: ${{ env.EXEMPT_LABELS }}
 
           days-before-issue-stale: -1
           days-before-issue-close: -1
 
-          only-pr-labels: "status: changes-required"
-          stale-pr-label: "status: stale"
+          only-pr-labels: ${{ env.CHANGES_REQUIRED_LABEL }}
+          stale-pr-label: ${{ env.STALE_LABEL }}
           remove-pr-stale-when-updated: false
 
           days-before-pr-stale: ${{ env.DAYS_BEFORE_PR_STALE }}
@@ -40,41 +47,98 @@ jobs:
             Please follow-up in the next ${{ env.DAYS_BEFORE_PR_CLOSE }} days or your PR will be automatically closed.
             You can check the [contributing guidelines](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md#pull-request-process) for hints on the pull request process.
 
-          days-before-pr-close: ${{ env.DAYS_BEFORE_PR_CLOSE }}
-          close-pr-message: >
-            This PR is being closed due to continued inactivity.
-      - uses: actions/checkout@v7
-        if: ${{ steps.stale.outputs.closed-issues-prs != '[]' }}
-      - name: Process closed issues/PRs
-        if: ${{ steps.stale.outputs.closed-issues-prs != '[]' }}
+          days-before-pr-close: -1
+
+      - name: Close PRs labeled stale for more than ${{ env.DAYS_BEFORE_PR_CLOSE }} days
+        id: close
         env:
-          CLOSED_JSON: ${{ steps.stale.outputs.closed-issues-prs }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # This workflow also runs on pull requests that touch it - those runs must not
+          # close anything for real.
+          DRY_RUN: ${{ github.event_name == 'pull_request' }}
+        run: |
+          set -euo pipefail
+
+          # The moment the stale label was applied is a fixed point in time, unlike `updated_at`.
+          cutoff="$(date -u -d "-${DAYS_BEFORE_PR_CLOSE} days" +%Y-%m-%dT%H:%M:%SZ)"
+          echo "Closing PRs labeled '$STALE_LABEL' before $cutoff"
+
+          closed=""
+          # Both labels are required, mirroring the only-pr-labels of the marking step above:
+          # a PR whose requested changes were addressed is no longer a candidate.
+          candidates="$(gh pr list --repo "$REPO" --state open --limit 100 \
+            --label "$STALE_LABEL" --label "$CHANGES_REQUIRED_LABEL" \
+            --json number --jq '.[].number')"
+
+          IFS=',' read -ra exempt_labels <<< "$EXEMPT_LABELS"
+
+          for pr in $candidates; do
+            labels="$(gh pr view "$pr" --repo "$REPO" --json labels --jq '.labels[].name')"
+            exempt=""
+            for label in "${exempt_labels[@]}"; do
+              if printf '%s\n' "$labels" | grep -Fxq "$label"; then
+                exempt="$label"
+                break
+              fi
+            done
+            if [ -n "$exempt" ]; then
+              echo "#$pr: exempted by label '$exempt'"
+              continue
+            fi
+
+            # The label can have been applied, removed and applied again - the last one counts.
+            # --paginate applies the filter per page, hence the trailing tail.
+            labeled_at="$(gh api "repos/$REPO/issues/$pr/events?per_page=100" --paginate \
+              --jq "[.[] | select(.event == \"labeled\" and .label.name == \"$STALE_LABEL\") | .created_at] | last" \
+              | grep -v '^null$' | tail -n 1 || true)"
+
+            if [ -z "$labeled_at" ]; then
+              echo "#$pr: no '$STALE_LABEL' label event found, skipping"
+              continue
+            fi
+            if [ "$labeled_at" \> "$cutoff" ]; then
+              echo "#$pr: labeled stale at $labeled_at, not old enough yet"
+              continue
+            fi
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "#$pr: labeled stale at $labeled_at, would be closed (dry run)"
+              continue
+            fi
+
+            echo "#$pr: labeled stale at $labeled_at, closing"
+            gh pr comment "$pr" --repo "$REPO" --body "This PR is being closed due to continued inactivity."
+            gh pr close "$pr" --repo "$REPO"
+            closed="$closed $pr"
+          done
+
+          echo "closed_prs=${closed# }" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v7
+        if: ${{ steps.close.outputs.closed_prs != '' }}
+      - name: Process closed PRs
+        if: ${{ steps.close.outputs.closed_prs != '' }}
+        env:
+          CLOSED_PRS: ${{ steps.close.outputs.closed_prs }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          set -x
-          PS4='+ ${LINENO}: '
-          echo "Raw payload:"
-          cat <<EOF
-          ${{ steps.stale.outputs.closed-issues-prs }}
-          EOF
-
-          echo "PR numbers:"
-          echo "$CLOSED_JSON" | jq -r '.[] | select(.pull_request != null) | .number' | while read -r n; do
-            [ -n "$n" ] || continue
+          for n in $CLOSED_PRS; do
             echo "Handling #$n"
             gh workflow run "On PR closed" --ref main --field pr_number="$n"
           done
       - name: Write closed PR URLs to summary
         if: always()
         env:
-          CLOSED_JSON: ${{ steps.stale.outputs.closed-issues-prs }}
+          CLOSED_PRS: ${{ steps.close.outputs.closed_prs }}
+          REPO: ${{ github.repository }}
         run: |
           {
             echo "## Closed PRs"
             echo
-            echo "$CLOSED_JSON" \
-              | jq -r '.[] | select(.pull_request != null) | "- [#\(.number)](\(.pull_request.html_url))"' \
-              || true
+            for n in ${CLOSED_PRS:-}; do
+              echo "- [#$n](https://github.com/$REPO/pull/$n)"
+            done
             echo
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -113,6 +113,30 @@ jobs:
               continue
             fi
 
+            # Real activity after the label: a push or a comment by a human. Nothing removes the
+            # stale label in that case (pr-comment.yml only does so for pull requests from forks),
+            # so it is checked here - and the label is dropped, which lets the marking step above
+            # start a new round if the pull request falls idle again.
+            last_commit="$(gh pr view "$pr" --repo "$REPO" --json commits --jq '.commits[-1].committedDate')"
+            human_comments="$(gh api "repos/$REPO/issues/$pr/comments?per_page=100" --paginate \
+              --jq "[.[] | select(.created_at > \"$labeled_at\" and .user.type != \"Bot\" and .user.login != \"jabref-machine\") | .user.login] | .[]" \
+              | wc -l)"
+
+            if [ -n "$last_commit" ] && [ "$last_commit" \> "$labeled_at" ]; then
+              activity="pushed at $last_commit"
+            elif [ "$human_comments" -gt 0 ]; then
+              activity="$human_comments comment(s) by a human"
+            else
+              activity=""
+            fi
+            if [ -n "$activity" ]; then
+              echo "#$pr: $activity after the stale label, removing the label"
+              if [ "$DRY_RUN" != "true" ]; then
+                gh issue edit "$pr" --repo "$REPO" --remove-label "$STALE_LABEL"
+              fi
+              continue
+            fi
+
             if [ "$DRY_RUN" = "true" ]; then
               echo "#$pr: labeled stale at $labeled_at, would be closed (dry run)"
               continue

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -64,7 +64,7 @@ jobs:
 
           # The moment the stale label was applied is a fixed point in time, unlike `updated_at`.
           cutoff="$(date -u -d "-${DAYS_BEFORE_PR_CLOSE} days" +%Y-%m-%dT%H:%M:%SZ)"
-          echo "Closing PRs labeled '$STALE_LABEL' before $cutoff"
+          echo "Assessing PRs labeled '$STALE_LABEL' on or before $cutoff"
 
           closed=""
           # Both labels are required, mirroring the only-pr-labels of the marking step above:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -76,6 +76,13 @@ jobs:
 
           IFS=',' read -ra exempt_labels <<< "$EXEMPT_LABELS"
 
+          # Events by a human after $labeled_at, one line each. $1: API path, $2: timestamp field
+          # ($2 is null for pending reviews; jq sorts null before strings, so they never count).
+          human_events() {
+            gh api "repos/$REPO/$1?per_page=100" --paginate \
+              --jq "[.[] | select(.$2 > \"$labeled_at\" and .user.type != \"Bot\" and .user.login != \"jabref-machine\") | .user.login] | .[]"
+          }
+
           for pr in $candidates; do
             # Re-read the labels: they can have been removed since the candidate list was built.
             labels="$(gh pr view "$pr" --repo "$REPO" --json labels --jq '.labels[].name')"
@@ -113,19 +120,20 @@ jobs:
               continue
             fi
 
-            # Real activity after the label: a push or a comment by a human. Nothing removes the
-            # stale label in that case (pr-comment.yml only does so for pull requests from forks),
-            # so it is checked here - and the label is dropped, which lets the marking step above
-            # start a new round if the pull request falls idle again.
-            last_commit="$(gh pr view "$pr" --repo "$REPO" --json commits --jq '.commits[-1].committedDate')"
-            human_comments="$(gh api "repos/$REPO/issues/$pr/comments?per_page=100" --paginate \
-              --jq "[.[] | select(.created_at > \"$labeled_at\" and .user.type != \"Bot\" and .user.login != \"jabref-machine\") | .user.login] | .[]" \
-              | wc -l)"
+            # Real activity after the label: a push, or a comment/review by a human. Nothing
+            # removes the stale label in that case (pr-comment.yml only does so for pull requests
+            # from forks), so it is checked here - and the label is dropped, which lets the marking
+            # step above start a new round if the pull request falls idle again.
+            last_commit="$(gh pr view "$pr" --repo "$REPO" --json commits --jq '.commits[-1].committedDate' \
+              | grep -v '^null$' || true)"
+            human_comments="$( { human_events "issues/$pr/comments" created_at
+                human_events "pulls/$pr/comments" created_at
+                human_events "pulls/$pr/reviews" submitted_at; } | wc -l)"
 
             if [ -n "$last_commit" ] && [ "$last_commit" \> "$labeled_at" ]; then
               activity="pushed at $last_commit"
             elif [ "$human_comments" -gt 0 ]; then
-              activity="$human_comments comment(s) by a human"
+              activity="$human_comments comment(s)/review(s) by a human"
             else
               activity=""
             fi

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -69,7 +69,8 @@ jobs:
           closed=""
           # Both labels are required, mirroring the only-pr-labels of the marking step above:
           # a PR whose requested changes were addressed is no longer a candidate.
-          candidates="$(gh pr list --repo "$REPO" --state open --limit 100 \
+          # gh paginates internally up to --limit, so this is not a page size.
+          candidates="$(gh pr list --repo "$REPO" --state open --limit 1000 \
             --label "$STALE_LABEL" --label "$CHANGES_REQUIRED_LABEL" \
             --json number --jq '.[].number')"
 


### PR DESCRIPTION
## Why

Stale PRs are marked, but never closed. Example: [#16066](https://github.com/JabRef/jabref/pull/16066) was marked stale on **2026-07-31**, `days-before-pr-close` is **7** — it is still open on 2026-08-13.

The reason is in the action's own log ([run 31664964110](https://github.com/JabRef/jabref/actions/runs/31664964110)):

```
[#16066] Pull request marked stale on: 2026-07-31T04:09:22Z
[#16066] Comments that are not the stale comment or another bot: 0
[#16066] Pull request has been updated in the last 7 days: true
[#16066] Stale pull request is not old enough to close yet (hasComments? false, hasUpdate? true)
```

`days-before-close` is **not** counted from the stale label. Per the [actions/stale documentation](https://github.com/actions/stale#days-before-close), it is counted from the GitHub field `updated_at`: *"The issues or the pull requests will be closed if the last update (based on GitHub issue field `updated_at`) is older than the idle number of days."* The action discards its own and other bots' **comments** (hence `Comments that are not the stale comment or another bot: 0`), but it does not discard **updates**. Any bump of `updated_at` restarts the 7-day clock.

And `updated_at` keeps being bumped. What the last three scheduled runs saw for #16066:

| stale run | `updated_at` it read |
|---|---|
| 2026-08-11 | `2026-08-10T03:42:26Z` |
| 2026-08-12 | `2026-08-10T03:42:26Z` |
| 2026-08-13 | `2026-08-12T03:51:04Z` |

Those timestamps fall inside the nightly cron window (`0 3 * * *`; the runs start between 03:33 and 03:47). Meanwhile the PR has **no timeline event and no edited comment since 2026-07-31**, and the last human activity was on 2026-07-16. So `updated_at` moves without any contributor activity, roughly every other day, and the PR can never reach 7 quiet days.

`ignore-pr-updates: true` does not help: per the documentation it only changes the clock used for **marking** (`created_at` instead of `updated_at`); the close decision keeps using `updated_at`.

This is not specific to #16066. A dry run of the new logic against the current repository state:

```
Closing PRs labeled 'status: stale' before 2026-08-06T16:56:35Z
#16408: labeled stale at 2026-08-13T03:47:16Z, not old enough yet
#16222: labeled stale at 2026-08-12T03:45:13Z, not old enough yet
#16186: pushed at 2026-08-03T07:18:09Z after the stale label, removing the label
#16074: 1 comment(s) by a human after the stale label, removing the label
#16066: labeled stale at 2026-07-31T04:09:22Z, would be closed
#15378: labeled stale at 2026-06-14T04:33:29Z, would be closed
#15295: 1 comment(s) by a human after the stale label, removing the label
```

## What this PR does

`actions/stale` now only **marks** (`days-before-pr-close: -1`). The closing is done in a following step from the timestamp of the `status: stale` **label event**, which is a fixed point in time and immune to `updated_at` churn.

The closing step keeps the semantics of the marking step:

- both `status: stale` and `status: changes-required` must be present, mirroring `only-pr-labels` — a PR whose requested changes were addressed is no longer a candidate,
- `📌 Pinned` is still exempt,
- the last `labeled` event counts, so a label that was removed and re-applied restarts the clock,
- the close message is unchanged.

**Activity after the label is honoured.** Nothing removes `status: stale` when a pull request from a branch of this repository is pushed to: [`pr-comment.yml`](https://github.com/JabRef/jabref/blob/main/.github/workflows/pr-comment.yml#L193-L197) only does that for pull requests from forks (`isCrossRepository == 'true'`), and a comment by a human never removes it. Closing purely by label age would therefore have closed active pull requests — three of the five candidates above. The closing step now checks for a push or a comment by a human (bots and `jabref-machine` excluded, mirroring what `actions/stale` does for comments) after the label, and in that case removes the label instead of closing, so the marking step can start a new round once the pull request falls idle again.

`dev: no-bot-comments` is no longer an exempt label, neither for marking nor for closing: it usually stays on a pull request even after `status: changes-required` was set, so exempting it took most pull requests out of the process. Consequence: the stale comment is now posted on those pull requests as well.

The downstream steps ("On PR closed" dispatch, job summary) now consume the list of PRs closed by that step instead of `steps.stale.outputs.closed-issues-prs`.

The new step is a no-op on `pull_request` events (this workflow triggers on changes to itself), so testing a change to this file cannot close PRs for real. Note that the `actions/stale` step itself has no such guard, before or after this PR — it can be added via `debug-only` if wanted.

The shell of the closing step was dry-run against the live repository (read-only, `DRY_RUN=true`); the output above is that run.
