### PR TITLE
Dispose Source tab listeners

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditorTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditorTab.java
@@ -70,6 +70,10 @@ public abstract class EntryEditorTab extends Tab {
 
     protected abstract void bindToEntry(BibEntry entry);
 
+    /// Releases listeners owned by this tab before it is discarded.
+    protected void dispose() {
+    }
+
     /// Override to perform a special action on focus (like selecting the first field in the editor).
     protected void handleFocus() {
     }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditorViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditorViewModel.java
@@ -214,6 +214,7 @@ public class EntryEditorViewModel extends AbstractViewModel {
     private void disposeTabs() {
         shouldShowSubscriptions.forEach(Subscription::unsubscribe);
         shouldShowSubscriptions.clear();
+        allPossibleTabs.forEach(EntryEditorTab::dispose);
         allPossibleTabs.forEach(tab -> tab.currentEntryProperty().unbind());
         allPossibleTabs.clear();
     }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -50,6 +50,7 @@ import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.model.util.Range;
 
 import com.tobiasdiez.easybind.EasyBind;
+import com.tobiasdiez.easybind.Subscription;
 import de.saxsys.mvvmfx.utils.validation.ObservableRuleBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
 import io.github.kusoroadeolu.veneer.BibTeXSyntaxHighlighter;
@@ -65,6 +66,10 @@ public class SourceTab extends EntryEditorTab {
     private final FieldPreferences fieldPreferences;
     private final UndoManager undoManager;
     private final ObjectProperty<ValidationMessage> validationMessage = new SimpleObjectProperty<>();
+    private final InvalidationListener entryTypeListener = _ -> updateCodeArea();
+    private final InvalidationListener entryFieldsListener = _ -> updateCodeArea();
+    private final Subscription activeTabSubscription;
+    private final Subscription searchQuerySubscription;
     private final ObservableRuleBasedValidator sourceValidator = new ObservableRuleBasedValidator();
     private final ImportFormatPreferences importFormatPreferences;
     private final FileUpdateMonitor fileMonitor;
@@ -97,7 +102,7 @@ public class SourceTab extends EntryEditorTab {
         this.entryTypesManager = entryTypesManager;
         this.keyBindingRepository = keyBindingRepository;
 
-        EasyBind.subscribe(stateManager.activeTabProperty(), library -> {
+        activeTabSubscription = EasyBind.subscribe(stateManager.activeTabProperty(), library -> {
             if (library.isEmpty()) {
                 this.setText(Localization.lang("Source"));
                 this.setTooltip(new Tooltip(Localization.lang("Show/edit source")));
@@ -108,7 +113,7 @@ public class SourceTab extends EntryEditorTab {
                 this.setTooltip(new Tooltip(Localization.lang("Show/edit %0 source", mode.getFormattedName())));
             }
         });
-        EasyBind.subscribe(stateManager.searchQueryProperty(), _ -> Platform.runLater(this::refreshCodeAreaDecorator));
+        searchQuerySubscription = EasyBind.subscribe(stateManager.searchQueryProperty(), _ -> Platform.runLater(this::refreshCodeAreaDecorator));
     }
 
     private void refreshCodeAreaDecorator() {
@@ -198,15 +203,33 @@ public class SourceTab extends EntryEditorTab {
 
     @Override
     protected void bindToEntry(BibEntry entry) {
-        if ((previousEntry != null) && (codeArea != null)) {
-            storeSource(previousEntry, codeArea.getText());
+        if (previousEntry != null) {
+            removeEntryListeners(previousEntry);
+            if (codeArea != null) {
+                storeSource(previousEntry, codeArea.getText());
+            }
         }
         this.previousEntry = entry;
 
         updateCodeArea();
 
-        entry.typeProperty().addListener(_ -> updateCodeArea());
-        entry.getFieldsObservable().addListener((InvalidationListener) _ -> updateCodeArea());
+        entry.typeProperty().addListener(entryTypeListener);
+        entry.getFieldsObservable().addListener(entryFieldsListener);
+    }
+
+    @Override
+    protected void dispose() {
+        if (previousEntry != null) {
+            removeEntryListeners(previousEntry);
+            previousEntry = null;
+        }
+        activeTabSubscription.unsubscribe();
+        searchQuerySubscription.unsubscribe();
+    }
+
+    private void removeEntryListeners(BibEntry entry) {
+        entry.typeProperty().removeListener(entryTypeListener);
+        entry.getFieldsObservable().removeListener(entryFieldsListener);
     }
 
     private void storeSource(BibEntry outOfFocusEntry, String text) {
@@ -348,4 +371,3 @@ public class SourceTab extends EntryEditorTab {
         }
     }
 }
-

--- a/jabgui/src/test/java/org/jabref/gui/entryeditor/SourceTabTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/entryeditor/SourceTabTest.java
@@ -32,6 +32,7 @@ import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -108,5 +109,28 @@ class SourceTabTest {
 
         // No exception should be thrown
         robot.interrupt(100);
+    }
+
+    @Test
+    void updatingPreviouslyBoundEntryDoesNotResetCurrentSource(FxRobot robot) {
+        BibEntry firstEntry = new BibEntry().withField(new UnknownField("title"), "First entry");
+        BibEntry secondEntry = new BibEntry().withField(new UnknownField("title"), "Second entry");
+
+        robot.interact(() -> {
+            pane.getSelectionModel().select(sourceTab);
+            sourceTab.currentEntryProperty().set(firstEntry);
+            sourceTab.notifyAboutFocus(firstEntry);
+
+            sourceTab.currentEntryProperty().set(secondEntry);
+            sourceTab.notifyAboutFocus(secondEntry);
+
+            jfx.incubator.scene.control.richtext.CodeArea sourceArea =
+                    (jfx.incubator.scene.control.richtext.CodeArea) sourceTab.getContent();
+            sourceArea.clear();
+            sourceArea.appendText("Unsaved source for the second entry");
+
+            firstEntry.setField(new UnknownField("author"), "Author");
+            assertEquals("Unsaved source for the second entry", sourceArea.getText());
+        });
     }
 }


### PR DESCRIPTION
### Summary

Detach Source tab listeners when its selected entry changes or the tab is discarded. This prevents entries and state-manager observables from retaining old tabs, and stops edits to a previously selected entry from resetting unsaved source text for the current entry.

Analogies: this is like letting honey leave a spoon instead of keeping every spoon attached to the jar, like removing a chocolate wrapper after eating it, and like ensuring an old moon orbit does not keep pulling a new spacecraft off course.

jabref-contrib-policy:4.2:reviewed​:ok

### Steps to test

Run `./gradlew :jabgui:test --tests org.jabref.gui.entryeditor.SourceTabTest`. The regression test switches from one entry to another, changes the previously selected entry, and verifies that unsaved source text for the current entry is unchanged.

### Related issues and pull requests

None. The listener lifecycle fix is internal and does not claim to resolve an existing issue.

### AI usage

Codex (model GPT-5). The maintainer requested and authorized this draft PR.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [x] No new `== null` / `!= null` checks; the existing `previousEntry` lifecycle guard remains unchanged in intent.
- [x] No `Objects.requireNonNull(...)` added.
- [/] No new classes.
- [/] No Optional consumption added or changed.
- [/] No blank-string checks added or changed.

### Exceptions

- [x] No `catch (Exception e)` added.
- [x] No unchecked exceptions added.
- [/] No logging changes.

### Style and idioms

- [x] The new test builds `BibEntry` instances with withers.
- [/] No applicable modern-collection or path construction changes.
- [/] No regex changes.
- [x] No `new Thread()` added.
- [x] No commented-out code, trivial comments, or AI disclosure comments added to source.
- [x] The new `///` documentation uses Markdown syntax.

### User-facing text

- [/] No user-facing text added or changed.

### Security

- [/] No HTML response or user-controlled HTML output is involved.

### Tests

- [/] No behavior in `org.jabref.model` or `org.jabref.logic` changed.
- [x] The GUI regression test uses plain JUnit `assertEquals`, has no `@DisplayName`, and catches no exceptions.

## 2. Verification commands

- [ ] `./gradlew :jablib:check` is left for CI; a local run was still in progress when this draft was requested.
- [ ] `./gradlew checkstyleMain checkstyleTest checkstyleJmh` is left for CI; the focused GUI main/test style checks passed locally.
- [ ] `./gradlew modernizer` is left for CI.
- [ ] `./gradlew --no-configuration-cache :rewriteDryRun` is left for CI.
- [ ] `./gradlew javadoc` is left for CI.
- [/] No Markdown files changed.
- [/] No formatting issue remained after the focused checks.

## 3. Documentation

- [/] This internal listener lifecycle fix is not user-visible; no CHANGELOG entry is needed.
- [/] No issue is confidently related to this internal fix.
- [/] This is a minor internal fix, not a new feature or significant behavior change.
- [/] No developer documentation is needed.

## 4. Pull request

- [x] PR body is built from `.github/PULL_REQUEST_TEMPLATE.md` and all sections are filled.
- [x] All PR checklist items are retained and marked.
- [x] HTML comments are removed.
- [x] PR is created with `gh pr create --body-file`.
- [/] No CHANGELOG `TODO` placeholder was used.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
