### PR TITLE
Fix regex exception when highlighting special search characters

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/search/Highlighter.java
+++ b/jabgui/src/main/java/org/jabref/gui/search/Highlighter.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.logic.search.query.SearchQueryConversion;
@@ -66,12 +68,17 @@ public class Highlighter {
     }
 
     private static String highlightNode(String text, String searchPattern) {
-        if (!shouldUsePostgresSearch()) {
+            if (!shouldUsePostgresSearch()) {
+        try {
             return text.replaceAll(
                     "(?i)(" + searchPattern + ")",
                     "<mark style=\"background: orange\">$1</mark>"
             );
+        } catch (PatternSyntaxException e) {
+            LOGGER.debug("Invalid regex: {}", searchPattern, e);
+            return text;
         }
+    }
         if (connection == null) {
             connection = Injector.instantiateModelOrService(PostgresServer.class).getConnection();
         }
@@ -149,9 +156,15 @@ public class Highlighter {
         return searchQuery.isValid() ? SearchQueryConversion.extractSearchTerms(searchQuery) : List.of();
     }
 
-    public static Optional<String> buildSearchPattern(List<String> terms) {
-        return terms.isEmpty() ? Optional.empty() : Optional.of(String.join("|", terms));
-    }
+public static Optional<String> buildSearchPattern(List<String> terms) {
+    return terms.isEmpty()
+            ? Optional.empty()
+            : Optional.of(
+                    terms.stream()
+                         .map(Pattern::quote)
+                         .collect(Collectors.joining("|"))
+            );
+}
 
     private static boolean shouldUsePostgresSearch() {
         if (guiPreferences == null) {


### PR DESCRIPTION
Fixes #16539

Search terms containing regex special characters such as *, (, [, +, and ?
caused regex errors during highlighting.

This change escapes search terms using Pattern.quote before building
the highlight regex, preventing PatternSyntaxException and allowing
special characters to be searched safely.

Testing:
- Built successfully with Gradle
- Tested searches containing *, [, +, and (
- Verified no PatternSyntaxException occurs

<img width="962" height="1002" alt="Screenshot 2026-08-15 130754" src="https://github.com/user-attachments/assets/995feec9-3d42-4f24-b94e-b1ac2946c4fc" /
<img width="962" height="1023" alt="Screenshot 2026-08-15 130732" src="https://github.com/user-attachments/assets/20afdb2f-62e0-4ca7-a9a1-4382e629d60a" />
<img width="958" height="991" alt="Screenshot 2026-08-15 130713" src="https://github.com/user-attachments/assets/cd03dba6-dcef-4b05-af31-a8f4fa3b670c" />
<img width="1919" height="1059" alt="Screenshot 2026-08-15 130636" src="https://github.com/user-attachments/assets/c98e61af-9f44-4401-9d28-356a16050bf9" />
>
