### PR TITLE
Fix group hit count refresh concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where adding JabRef suggested groups immediately after a library loads caused an error. [#16552](https://github.com/JabRef/jabref/pull/16552)
 - We fixed an issue where only a reduced set of icons was available for groups. The broader group icon set is available again. [#16557](https://github.com/JabRef/jabref/issues/16557)
 - We fixed an issue where empty values in the merge entries dialog could not be selected to clear the merged entry field. [#15014](https://github.com/JabRef/jabref/issues/15014)
-- We fixed an issue where `Update with bibliographic information via entry data` could fail with an exception while the merge dialog was open.
+- We fixed an issue where `Update with bibliographic information via entry data` could fail with an exception while the merge dialog was open. [#16583](https://github.com/JabRef/jabref/pull/16583)
 - We fixed an issue where switching the citation provider in the "Citations" tab froze the user interface while the results were matched against the library. [#16270](https://github.com/JabRef/jabref/issues/16270)
 - We fixed an issue where reference mark expands onto the text when cursor is at the end of the mark. [#16515](https://github.com/JabRef/jabref/issues/16515)
 - We fixed an issue where the exception message would show in the notification. [#14886](https://github.com/JabRef/jabref/issues/14886)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - We fixed an issue where only a reduced set of icons was available for groups. The broader group icon set is available again. [#16557](https://github.com/JabRef/jabref/issues/16557)
 - We fixed an issue where empty values in the merge entries dialog could not be selected to clear the merged entry field. [#15014](https://github.com/JabRef/jabref/issues/15014)
+- We fixed an issue where `Update with bibliographic information via entry data` could fail with an exception while the merge dialog was open.
 - We fixed an issue where switching the citation provider in the "Citations" tab froze the user interface while the results were matched against the library. [#16270](https://github.com/JabRef/jabref/issues/16270)
 - We fixed an issue where reference mark expands onto the text when cursor is at the end of the mark. [#16515](https://github.com/JabRef/jabref/issues/16515)
 - We fixed an issue where the exception message would show in the notification. [#14886](https://github.com/JabRef/jabref/issues/14886)

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
@@ -1,7 +1,9 @@
 package org.jabref.gui.groups;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -10,12 +12,12 @@ import javafx.beans.WeakInvalidationListener;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.IntegerBinding;
+import javafx.beans.property.ReadOnlyIntegerWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
-import javafx.collections.ObservableSet;
 import javafx.scene.input.Dragboard;
 import javafx.scene.paint.Color;
 
@@ -77,7 +79,9 @@ public class GroupNodeViewModel {
     private final StateManager stateManager;
     private final GroupTreeNode groupNode;
     @ADR(38)
-    private final ObservableSet<String> matchedEntries = FXCollections.observableSet();
+    private final Set<String> matchedEntries = new HashSet<>();
+    private final Object matchedEntriesLock = new Object();
+    private final ReadOnlyIntegerWrapper matchedEntriesCount = new ReadOnlyIntegerWrapper(0);
     private final SimpleBooleanProperty hasChildren;
     private final SimpleBooleanProperty expandedProperty = new SimpleBooleanProperty();
     private final BooleanBinding anySelectedEntriesMatched;
@@ -208,7 +212,7 @@ public class GroupNodeViewModel {
     }
 
     public IntegerBinding getHits() {
-        return Bindings.size(matchedEntries);
+        return Bindings.createIntegerBinding(matchedEntriesCount::get, matchedEntriesCount.getReadOnlyProperty());
     }
 
     void ensureMatchedEntriesLoaded() {
@@ -289,21 +293,21 @@ public class GroupNodeViewModel {
                 for (BibEntry changedEntry : change.getList().subList(change.getFrom(), change.getTo())) {
                     if (isMatchEffective(this, changedEntry)) {
                         // ADR-0038
-                        matchedEntries.add(changedEntry.getId());
+                        addMatchedEntry(changedEntry.getId());
                     } else {
                         // ADR-0038
-                        matchedEntries.remove(changedEntry.getId());
+                        removeMatchedEntry(changedEntry.getId());
                     }
                 }
             } else {
                 for (BibEntry removedEntry : change.getRemoved()) {
                     // ADR-0038
-                    matchedEntries.remove(removedEntry.getId());
+                    removeMatchedEntry(removedEntry.getId());
                 }
                 for (BibEntry addedEntry : change.getAddedSubList()) {
                     if (isMatchEffective(this, addedEntry)) {
                         // ADR-0038
-                        matchedEntries.add(addedEntry.getId());
+                        addMatchedEntry(addedEntry.getId());
                     }
                 }
             }
@@ -327,7 +331,7 @@ public class GroupNodeViewModel {
             // A skipped recompute leaves the cache stale: force a reload when counts are re-enabled,
             // and clear now so rebinding never briefly shows the outdated number
             matchedEntriesInitialized = false;
-            matchedEntries.clear();
+            clearMatchedEntries();
             return;
         }
 
@@ -342,9 +346,7 @@ public class GroupNodeViewModel {
                                            .filter(e -> isMatchEffective(this, e))
                                            .toList())
                 .onSuccess(entries -> {
-                    matchedEntries.clear();
-                    // ADR-0038
-                    entries.forEach(entry -> matchedEntries.add(entry.getId()));
+                    replaceMatchedEntries(entries);
                     matchedEntriesInitialized = true;
                     completeMatchedEntriesUpdate();
                 })
@@ -362,6 +364,41 @@ public class GroupNodeViewModel {
         if (matchedEntriesUpdatePending) {
             matchedEntriesUpdatePending = false;
             updateMatchedEntries();
+        }
+    }
+
+    private void addMatchedEntry(String entryId) {
+        synchronized (matchedEntriesLock) {
+            if (matchedEntries.add(entryId)) {
+                matchedEntriesCount.set(matchedEntries.size());
+            }
+        }
+    }
+
+    private void removeMatchedEntry(String entryId) {
+        synchronized (matchedEntriesLock) {
+            if (matchedEntries.remove(entryId)) {
+                matchedEntriesCount.set(matchedEntries.size());
+            }
+        }
+    }
+
+    private void clearMatchedEntries() {
+        synchronized (matchedEntriesLock) {
+            if (!matchedEntries.isEmpty()) {
+                matchedEntries.clear();
+                matchedEntriesCount.set(0);
+            }
+        }
+    }
+
+    private void replaceMatchedEntries(List<BibEntry> entries) {
+        synchronized (matchedEntriesLock) {
+            matchedEntries.clear();
+            entries.stream()
+                   .map(BibEntry::getId)
+                   .forEach(matchedEntries::add);
+            matchedEntriesCount.set(matchedEntries.size());
         }
     }
 
@@ -692,9 +729,9 @@ public class GroupNodeViewModel {
                 }).onFinished(() -> {
                     for (BibEntry entry : event.entries()) {
                         if (GroupNodeViewModel.this.isMatchEffective(GroupNodeViewModel.this, entry)) {
-                            matchedEntries.add(entry.getId());
+                            addMatchedEntry(entry.getId());
                         } else {
-                            matchedEntries.remove(entry.getId());
+                            removeMatchedEntry(entry.getId());
                         }
                     }
                     databaseContext.getMetaData().groupsBinding().invalidate();
@@ -707,7 +744,7 @@ public class GroupNodeViewModel {
             if (groupNode.getGroup() instanceof SearchGroup searchGroup) {
                 for (BibEntry entry : event.entries()) {
                     searchGroup.updateMatches(entry, false);
-                    matchedEntries.remove(entry.getId());
+                    removeMatchedEntry(entry.getId());
                 }
                 databaseContext.getMetaData().groupsBinding().invalidate();
             }

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
@@ -78,9 +78,16 @@ public class GroupNodeViewModel {
     private final BibDatabaseContext databaseContext;
     private final StateManager stateManager;
     private final GroupTreeNode groupNode;
+    /// Internal cache of matched entry IDs.
+    ///
+    /// Kept as a plain `Set` instead of an `ObservableSet`, because group refreshes and search-index updates can
+    /// overlap while the UI stays responsive (for example inside modal dialogs). Exposing collection change events
+    /// for this cache made bulk refreshes re-entrant and could trigger `ConcurrentModificationException`.
     @ADR(38)
     private final Set<String> matchedEntries = new HashSet<>();
+    /// Guards both the matched-entry cache and the derived hit-count property so readers observe a consistent pair.
     private final Object matchedEntriesLock = new Object();
+    /// UI-facing count derived from [#matchedEntries]. The sidebar binds to this property instead of the cache itself.
     private final ReadOnlyIntegerWrapper matchedEntriesCount = new ReadOnlyIntegerWrapper(0);
     private final SimpleBooleanProperty hasChildren;
     private final SimpleBooleanProperty expandedProperty = new SimpleBooleanProperty();
@@ -239,6 +246,12 @@ public class GroupNodeViewModel {
 
     @Override
     public String toString() {
+        Set<String> matchedEntriesSnapshot;
+        // Snapshot under the same lock used by writers so debug output never iterates the live set mid-mutation.
+        synchronized (matchedEntriesLock) {
+            matchedEntriesSnapshot = Set.copyOf(matchedEntries);
+        }
+
         return "GroupNodeViewModel{" +
                 "displayName='" + displayName + '\'' +
                 ", isRoot=" + isRoot +
@@ -246,7 +259,7 @@ public class GroupNodeViewModel {
                 ", children=" + children +
                 ", databaseContext=" + databaseContext +
                 ", groupNode=" + groupNode +
-                ", matchedEntries=" + matchedEntries +
+                ", matchedEntries=" + matchedEntriesSnapshot +
                 '}';
     }
 

--- a/jabgui/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
@@ -3,6 +3,7 @@ package org.jabref.gui.groups;
 import java.util.Arrays;
 import java.util.EnumSet;
 
+import javafx.beans.binding.IntegerBinding;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
@@ -314,5 +315,24 @@ class GroupNodeViewModelTest {
         databaseContext.getDatabase().removeEntry(firstEntry);
 
         assertEquals(1, vm.getHits().getValue().intValue());
+    }
+
+    @Test
+    void refreshingMatchedEntriesHandlesReentrantDatabaseChange() {
+        BibEntry firstEntry = new BibEntry().withField(StandardField.TITLE, "search");
+        BibEntry secondEntry = new BibEntry().withField(StandardField.TITLE, "search");
+        databaseContext.getDatabase().insertEntries(firstEntry, secondEntry);
+
+        GroupNodeViewModel vm = getViewModelForGroup(
+                new WordKeywordGroup("Test group", GroupHierarchyType.INDEPENDENT, StandardField.TITLE, "search", true, ',', false));
+        vm.ensureMatchedEntriesLoaded();
+        IntegerBinding hits = vm.getHits();
+        assertEquals(2, hits.getValue().intValue());
+
+        hits.addListener(_ -> databaseContext.getDatabase().removeEntry(secondEntry));
+
+        vm.updateMatchedEntries();
+
+        assertEquals(2, hits.getValue().intValue());
     }
 }

--- a/jabgui/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
@@ -299,4 +299,20 @@ class GroupNodeViewModelTest {
         vm.ensureMatchedEntriesLoaded();
         assertEquals(1, vm.getHits().getValue().intValue());
     }
+
+    @Test
+    void hitsAreUpdatedWhenMatchingEntryIsRemoved() {
+        BibEntry firstEntry = new BibEntry().withField(StandardField.TITLE, "search");
+        BibEntry secondEntry = new BibEntry().withField(StandardField.TITLE, "search");
+        databaseContext.getDatabase().insertEntries(firstEntry, secondEntry);
+
+        GroupNodeViewModel vm = getViewModelForGroup(
+                new WordKeywordGroup("Test group", GroupHierarchyType.INDEPENDENT, StandardField.TITLE, "search", true, ',', false));
+        vm.ensureMatchedEntriesLoaded();
+        assertEquals(2, vm.getHits().getValue().intValue());
+
+        databaseContext.getDatabase().removeEntry(firstEntry);
+
+        assertEquals(1, vm.getHits().getValue().intValue());
+    }
 }


### PR DESCRIPTION
### Summary

Replace the internal observable matched-entry cache with a synchronized plain ID set and count property to avoid re-entrant refresh failures.
RCA provided in linked issue.

### Steps to test

May not be concretely reproducible (see issue), but the concurrency flaw existed in code.

### Related issues and pull requests

Tries to fix https://github.com/JabRef/jabref-issue-melting-pot/issues/1275

### AI usage

Zed + GPT 5.4

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
