### PR TITLE
Fix dark theme notification contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed unreadable notification text and icons when using the dark theme. [#16475](https://github.com/JabRef/jabref/issues/16475)
 - We fixed an issue where removing filtered entries from a group could cause JabRef to throw an exception. [#16541](https://github.com/JabRef/jabref/issues/16541)
 - We fixed an issue where adding JabRef suggested groups immediately after a library loads caused an error. [#16552](https://github.com/JabRef/jabref/pull/16552)
 - We fixed an issue where only a reduced set of icons was available for groups. The broader group icon set is available again. [#16557](https://github.com/JabRef/jabref/issues/16557)

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -2468,31 +2468,31 @@ journalInfo .grid-cell-b {
 }
 
 .info-center-view .notification-view > .content > .text-container > .title-time-box > .title-label {
-    -fx-text-fill: -fx-dark-text-color;
+    -fx-text-fill: -fx-text-background-color;
 }
 
 .info-center-view .notification-view > .content > .close-icon-wrapper > .ikonli-font-icon {
-    -fx-icon-color: -fx-dark-text-color;
+    -fx-icon-color: -fx-text-background-color;
 }
 
 .info-center-view .notification-view > .content > .text-container > .title-time-box > .upper-right-pane > .time-label {
-    -fx-text-fill: -fx-dark-text-color;
+    -fx-text-fill: -fx-text-background-color;
 }
 
 .info-center-view .notification-view > .content > .text-container > .description-label {
-    -fx-text-fill: -fx-dark-text-color;
+    -fx-text-fill: -fx-text-background-color;
 }
 
 .info-center-view .notification-view .default-icon {
-    -fx-icon-color: -fx-dark-text-color;
+    -fx-icon-color: -fx-text-background-color;
 }
 
 .info-center-view .notification-view > .content > .text-container > .title-time-box > .upper-right-pane > .arrow-pane .ikonli-font-icon {
-    -fx-icon-color: -fx-dark-text-color;
+    -fx-icon-color: -fx-text-background-color;
 }
 
 .info-center-view .notification-view:expanded > .content > .text-container > .title-time-box > .upper-right-pane > .arrow-pane .ikonli-font-icon {
-    -fx-icon-color: -fx-dark-text-color;
+    -fx-icon-color: -fx-text-background-color;
 }
 
 .info-center-view .notification-view > .content > .text-container > .actions-box .button {


### PR DESCRIPTION
### Summary

Notification text and icons now use the theme-aware `-fx-text-background-color` instead of the permanently black `-fx-dark-text-color`. This restores readable notification contrast in JabRef's dark theme while preserving the normal light-theme appearance.

The existing GemsFX notification selectors overrode GemsFX's theme-aware foreground styles with JabRef's fixed black token. This change restores a foreground that responds to the active theme.


<img width="912" height="266" alt="grafik" src="https://github.com/user-attachments/assets/48e29c7d-f4d7-4f2f-9eb4-20435bd483c7" />



jabref-contrib-policy:4.2:reviewed​:ok

### Steps to test

1. Start JabRef and select the dark theme.
2. Save a library to show an info notification.
3. Confirm that the notification title, message, timestamp, and icons are readable against its dark background.

### Related issues and pull requests

Closes #16475

### AI usage

OpenAI Codex (model GPT-5).

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [/] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [x] No `catch (Exception e)` — only specific exceptions are caught.
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [x] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [/] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, and `[ClassName]` instead of `{@link}`.

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [x] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [/] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.

## 2. Verification commands

- [x] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [/] `./gradlew modernizer`.
- [/] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [/] `./gradlew javadoc`.
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.

## 3. Documentation

- [x] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Link the issue if one exists; link the PR only when no issue exists. Use `TODO` as the placeholder when neither is known yet — never a fake number.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [/] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder (no issue confidently identified yet — an existing issue link always stays), it was replaced with the real PR-number link after PR creation, then committed and pushed. If an issue is identified or created later, the link is switched to the issue.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
