### PR TITLE
Fix UX issues in "Search for unlinked local files" dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the button shape changed when hovering over it. [#16188](https://github.com/JabRef/jabref/issues/16188)
 - We fixed handling of `exit` in the LSP server. [#16268](https://github.com/JabRef/jabref/pull/16268)
 - We fixed an issue where `LinkedFile.isOnlineLink()` did not recognize `ftp://` links as online links. [#16400](https://github.com/JabRef/jabref/issues/16400)
+- We fixed several UX issues in the "Search for unlinked local files" dialog: it now uses JabRef's theme, no longer shows an unrelated default icon, hides the header text while scanning, and the sort dropdown label was corrected. [#16158](https://github.com/JabRef/jabref/issues/16158)
 
 ### Removed
 

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/FileSelectionPage.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/FileSelectionPage.java
@@ -55,7 +55,6 @@ public class FileSelectionPage extends WizardPane {
         this.viewModel = viewModel;
         this.stateManager = stateManager;
 
-        setHeaderText(Localization.lang("Select files to import"));
         setGraphic(null);
         setupUI();
         setupBindings();
@@ -115,6 +114,14 @@ public class FileSelectionPage extends WizardPane {
     private void setupBindings() {
         progressPane.managedProperty().bind(viewModel.taskActiveProperty());
         progressPane.visibleProperty().bind(viewModel.taskActiveProperty());
+
+        EasyBind.subscribe(viewModel.taskActiveProperty(), active -> {
+            if (active) {
+                setHeaderText(null);
+            } else {
+                setHeaderText(Localization.lang("Select files to import"));
+            }
+        });
 
         unlinkedFilesList.rootProperty().bind(EasyBind.map(viewModel.treeRootProperty(), fileNode -> fileNode.map(fileNodeViewModel -> new RecursiveTreeItem<>(fileNodeViewModel, FileNodeViewModel::getChildren)).orElse(null)));
 

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/SearchConfigurationPage.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/SearchConfigurationPage.java
@@ -56,6 +56,7 @@ public class SearchConfigurationPage extends WizardPane {
         this.validationVisualizer = new ControlsFxVisualizer();
 
         setHeaderText(Localization.lang("Configure search"));
+        setGraphic(null);
         setupUI(bibDatabaseContext, preferences);
         setupValidation();
     }

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesWizard.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesWizard.java
@@ -11,6 +11,7 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.preferences.GuiPreferences;
+import org.jabref.gui.theme.ThemeManager;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseContext;
@@ -26,6 +27,7 @@ public class UnlinkedFilesWizard {
     @Inject private UndoManager undoManager;
     @Inject private TaskExecutor taskExecutor;
     @Inject private FileUpdateMonitor fileUpdateMonitor;
+    @Inject private ThemeManager themeManager;
 
     private UnlinkedFilesDialogViewModel viewModel;
     private BibDatabaseContext bibDatabaseContext;
@@ -49,6 +51,7 @@ public class UnlinkedFilesWizard {
                 stage.setWidth(650);
                 stage.setHeight(550);
                 stage.getIcons().addAll(IconTheme.getLogoSet());
+                themeManager.installCssOnScene(page1.getScene());
             }
         });
 

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -2573,3 +2573,7 @@ journalInfo .grid-cell-b {
     -fx-fill: black !important;
     -fx-text-fill: black !important;
 }
+
+.wizard-pane {
+    -fx-graphic: none !important;
+}

--- a/jablib/src/main/java/org/jabref/logic/externalfiles/ExternalFileSorter.java
+++ b/jablib/src/main/java/org/jabref/logic/externalfiles/ExternalFileSorter.java
@@ -3,7 +3,7 @@ package org.jabref.logic.externalfiles;
 import org.jabref.logic.l10n.Localization;
 
 public enum ExternalFileSorter {
-    DEFAULT(Localization.lang("Default")),
+    DEFAULT(Localization.lang("Grouped by directory")),
     DATE_ASCENDING(Localization.lang("Newest first")),
     DATE_DESCENDING(Localization.lang("Oldest first"));
 

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -176,6 +176,8 @@ Library\ properties=Library properties
 
 Default=Default
 
+Grouped\ by\ directory=Grouped by directory
+
 Character\ encoding\ UTF-8\ is\ not\ supported.=Character encoding UTF-8 is not supported.
 UTF-8\ could\ not\ be\ used\ to\ encode\ the\ following\ characters\:\ %0=UTF-8 could not be used to encode the following characters: %0
 The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=The chosen encoding '%0' could not encode the following characters:


### PR DESCRIPTION
### Summary
Fixes several UX issues in the "Search for unlinked local files" dialog: the sort dropdown label didn't match its behavior, the header text remained visible during an in-progress scan, a default ControlsFX help icon was showing with no actual help link behind it, and the dialog wasn't picking up JabRef's theme CSS at all.

### Steps to test
1. Open or create a library.
2. Go to Lookup → Search for unlinked local files (or Shift+F7).
3. Observe the dialog now matches JabRef's theme instead of default JavaFX styling, and the help icon is gone.
4. Select a directory and start a scan — notice the "Select files to import" header is hidden while scanning, then reappears once results load.
5. Check the "Sort by" dropdown on page 1 — it now reads "Grouped by directory" instead of "Default".

<img width="1919" height="1007" alt="image" src="https://github.com/user-attachments/assets/9317781b-97bf-45ff-84f5-f0e650f259ea" />

<img width="798" height="679" alt="image" src="https://github.com/user-attachments/assets/dd017a96-a8bb-43e6-af9c-9f9124018192" />

<img width="811" height="722" alt="image" src="https://github.com/user-attachments/assets/2d8db781-e6d4-4979-90a9-1841ca579806" />


### Related issues and pull requests
Fixes #16158

(Not fully closing since sub-issue #5 — spacebar checkbox navigation — is intentionally out of scope; see note below.)

### AI usage
Claude (model claude-sonnet-4-6) — used as a debugging and pair-programming aid: helping trace the root cause of the default help icon (ControlsFX's built-in wizard.css) and diagnosing that the wizard's scene wasn't receiving JabRef's theme stylesheet via ThemeManager. All code was written, reviewed, and is owned by me.

### Checklist
- [ ] I own the copyright...
- [x] If AI tools were used, I disclosed them...
- [x] I manually tested my changes in running JabRef
- [/] I added JUnit tests (not applicable — UI/visual fixes)
- [x] I added screenshots in the PR description
- [x] I added a screenshot showing a library with a single entry with me as author and issue number as title
- [x] I described the change in CHANGELOG.md
- [ ] I checked the user documentation for up-to-dateness