### PR TITLE
Enable full-text search without Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where full-text search in linked files was not workikng when the experimental Postgres search backend is disabled. [#16591](https://github.com/JabRef/jabref/pull/16591)
+- We fixed an issue where full-text search in linked files was not working when the experimental Postgres search backend is disabled. [#16591](https://github.com/JabRef/jabref/pull/16591)
 - We fixed unreadable notification text and icons when using the dark theme. [#16475](https://github.com/JabRef/jabref/issues/16475)
 - We fixed an issue where removing filtered entries from a group could cause JabRef to throw an exception. [#16541](https://github.com/JabRef/jabref/issues/16541)
 - We fixed an issue where adding JabRef suggested groups immediately after a library loads caused an error. [#16552](https://github.com/JabRef/jabref/pull/16552)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed full-text search in linked files when the experimental Postgres search backend is disabled. TODO
 - We fixed unreadable notification text and icons when using the dark theme. [#16475](https://github.com/JabRef/jabref/issues/16475)
 - We fixed an issue where removing filtered entries from a group could cause JabRef to throw an exception. [#16541](https://github.com/JabRef/jabref/issues/16541)
 - We fixed an issue where adding JabRef suggested groups immediately after a library loads caused an error. [#16552](https://github.com/JabRef/jabref/pull/16552)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed full-text search in linked files when the experimental Postgres search backend is disabled. [#16591](https://github.com/JabRef/jabref/pull/16591)
+- We fixed an issue where full-text search in linked files was not workikng when the experimental Postgres search backend is disabled. [#16591](https://github.com/JabRef/jabref/pull/16591)
 - We fixed unreadable notification text and icons when using the dark theme. [#16475](https://github.com/JabRef/jabref/issues/16475)
 - We fixed an issue where removing filtered entries from a group could cause JabRef to throw an exception. [#16541](https://github.com/JabRef/jabref/issues/16541)
 - We fixed an issue where adding JabRef suggested groups immediately after a library loads caused an error. [#16552](https://github.com/JabRef/jabref/pull/16552)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed full-text search in linked files when the experimental Postgres search backend is disabled. TODO
+- We fixed full-text search in linked files when the experimental Postgres search backend is disabled. [#16591](https://github.com/JabRef/jabref/pull/16591)
 - We fixed unreadable notification text and icons when using the dark theme. [#16475](https://github.com/JabRef/jabref/issues/16475)
 - We fixed an issue where removing filtered entries from a group could cause JabRef to throw an exception. [#16541](https://github.com/JabRef/jabref/issues/16541)
 - We fixed an issue where adding JabRef suggested groups immediately after a library loads caused an error. [#16552](https://github.com/JabRef/jabref/pull/16552)

--- a/docs/requirements/search-within-library.md
+++ b/docs/requirements/search-within-library.md
@@ -52,4 +52,11 @@ Enable to quickly search for a citation key.
 > Currently, no implementation is linked
 {: .prompt-note}
 
+## Full-text search without Postgres
+`req~jabgui.search.fulltext.lucene-without-postgres~1`
+
+When linked-file full-text indexing is enabled, users must be able to search the contents of linked files without enabling the experimental Postgres search backend.
+
+Needs: impl, utest
+
 <!-- markdownlint-disable-file MD022 -->

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -65,7 +65,7 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.pdf.FileAnnotationCache;
 import org.jabref.logic.search.SearchBackend;
 import org.jabref.logic.search.SearchContext;
-import org.jabref.logic.search.inmemory.InMemorySearchBackend;
+import org.jabref.logic.search.inmemory.InMemoryLuceneSearchBackend;
 import org.jabref.logic.search.sqlbased.IndexManager;
 import org.jabref.logic.search.sqlbased.PostgresServer;
 import org.jabref.logic.search.sqlbased.SqlSearchBackend;
@@ -329,7 +329,7 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
         Supplier<SearchBackend> sqlFactory = () ->
                 new SqlSearchBackend(new IndexManager(bibDatabaseContext, taskExecutor, preferences, Injector.instantiateModelOrService(PostgresServer.class)));
         Supplier<SearchBackend> inMemoryFactory = () ->
-                new InMemorySearchBackend(bibDatabaseContext, preferences.getBibEntryPreferences());
+                new InMemoryLuceneSearchBackend(bibDatabaseContext, preferences.getBibEntryPreferences(), preferences.getFilePreferences(), taskExecutor);
         searchContext = new SearchContext(
                 preferences.getSearchPreferences().usePostgresSearchProperty(),
                 sqlFactory,

--- a/jablib/src/main/java/org/jabref/logic/search/LinkedFilesIndexManager.java
+++ b/jablib/src/main/java/org/jabref/logic/search/LinkedFilesIndexManager.java
@@ -55,7 +55,7 @@ public class LinkedFilesIndexManager {
         try {
             indexer = new DefaultLinkedFilesIndexer(databaseContext, filePreferences);
         } catch (IOException e) {
-            LOGGER.debug("Error initializing linked files index - using read only index");
+            LOGGER.debug("Error initializing linked files index - using read only index", e);
             indexer = new ReadOnlyLinkedFilesIndexer(databaseContext);
         }
         linkedFilesIndexer = indexer;
@@ -74,6 +74,8 @@ public class LinkedFilesIndexManager {
                 }
             }.executeWith(taskExecutor);
         } else {
+            indexUpdateThrottler.cancel();
+            pendingFileValuesByEntry.clear();
             linkedFilesIndexer.removeAllFromIndex();
         }
     }
@@ -128,7 +130,7 @@ public class LinkedFilesIndexManager {
         });
 
         indexUpdateThrottler.schedule(() -> {
-            if (closed.get()) {
+            if (closed.get() || !shouldIndexLinkedFiles.get()) {
                 return;
             }
 

--- a/jablib/src/main/java/org/jabref/logic/search/LinkedFilesIndexManager.java
+++ b/jablib/src/main/java/org/jabref/logic/search/LinkedFilesIndexManager.java
@@ -25,6 +25,7 @@ import org.jabref.model.search.query.SearchQuery;
 import org.jabref.model.search.query.SearchResults;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,8 +126,8 @@ public class LinkedFilesIndexManager {
         String entryId = entry.getId();
         pendingFileValuesByEntry.compute(entryId, (_, existing) -> {
             return Optional.ofNullable(existing)
-                           .map(fileDelta -> new FileDelta(fileDelta.oldValue(), event.getNewValue()))
-                           .orElseGet(() -> new FileDelta(event.getOldValue(), event.getNewValue()));
+                           .map(fileDelta -> new FileDelta(fileDelta.oldValue(), normalizeNullToEmpty(event.getNewValue())))
+                           .orElseGet(() -> new FileDelta(normalizeNullToEmpty(event.getOldValue()), normalizeNullToEmpty(event.getNewValue())));
         });
 
         indexUpdateThrottler.schedule(() -> {
@@ -144,6 +145,10 @@ public class LinkedFilesIndexManager {
                 }.executeWith(taskExecutor);
             });
         });
+    }
+
+    private static String normalizeNullToEmpty(@Nullable String value) {
+        return Optional.ofNullable(value).orElse("");
     }
 
     public void rebuildIndex() {

--- a/jablib/src/main/java/org/jabref/logic/search/LinkedFilesIndexManager.java
+++ b/jablib/src/main/java/org/jabref/logic/search/LinkedFilesIndexManager.java
@@ -1,4 +1,4 @@
-package org.jabref.logic.search.sqlbased;
+package org.jabref.logic.search;
 
 import java.io.IOException;
 import java.util.List;
@@ -10,6 +10,7 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.value.ChangeListener;
 
 import org.jabref.logic.FilePreferences;
+import org.jabref.logic.search.sqlbased.LuceneIndexer;
 import org.jabref.logic.search.sqlbased.indexing.DefaultLinkedFilesIndexer;
 import org.jabref.logic.search.sqlbased.indexing.ReadOnlyLinkedFilesIndexer;
 import org.jabref.logic.search.sqlbased.retrieval.LinkedFilesSearcher;

--- a/jablib/src/main/java/org/jabref/logic/search/SearchBackend.java
+++ b/jablib/src/main/java/org/jabref/logic/search/SearchBackend.java
@@ -12,7 +12,9 @@ import org.jabref.model.search.query.SearchResults;
 ///
 /// Concrete implementors plug into [SearchContext] (the Abstraction) and provide
 /// the actual search + indexing behavior. Today: [org.jabref.logic.search.sqlbased.SqlSearchBackend]
-/// (Postgres metadata index + Lucene linked-file index) and
+/// (Postgres metadata index + Lucene linked-file index),
+/// [org.jabref.logic.search.inmemory.InMemorySearchBackend] (grammar walk
+/// against in-memory entries, no fulltext), and
 /// [org.jabref.logic.search.inmemory.InMemoryLuceneSearchBackend] (grammar walk
 /// against in-memory entries plus a Lucene linked-file index).
 public interface SearchBackend {

--- a/jablib/src/main/java/org/jabref/logic/search/SearchBackend.java
+++ b/jablib/src/main/java/org/jabref/logic/search/SearchBackend.java
@@ -13,8 +13,8 @@ import org.jabref.model.search.query.SearchResults;
 /// Concrete implementors plug into [SearchContext] (the Abstraction) and provide
 /// the actual search + indexing behavior. Today: [org.jabref.logic.search.sqlbased.SqlSearchBackend]
 /// (Postgres metadata index + Lucene linked-file index) and
-/// [org.jabref.logic.search.inmemory.InMemorySearchBackend] (grammar walk
-/// against in-memory entries, no fulltext).
+/// [org.jabref.logic.search.inmemory.InMemoryLuceneSearchBackend] (grammar walk
+/// against in-memory entries plus a Lucene linked-file index).
 public interface SearchBackend {
 
     /// Run the query against this backend.

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackend.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackend.java
@@ -1,5 +1,6 @@
 package org.jabref.logic.search.inmemory;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import org.jabref.logic.FilePreferences;
@@ -34,12 +35,18 @@ public class InMemoryLuceneSearchBackend implements SearchBackend {
 
     @Override
     public SearchResults search(SearchQuery query) {
-        SearchResults searchResults = inMemorySearchBackend.search(query);
+        SearchResults searchResults = inMemorySearchBackend.search(createMetadataQuery(query));
         if (query.getSearchFlags().contains(SearchFlags.FULLTEXT)) {
             searchResults.mergeSearchResults(linkedFilesIndexManager.search(query));
         }
         query.setSearchResults(searchResults);
         return searchResults;
+    }
+
+    private static SearchQuery createMetadataQuery(SearchQuery query) {
+        EnumSet<SearchFlags> metadataFlags = EnumSet.copyOf(query.getSearchFlags());
+        metadataFlags.remove(SearchFlags.FULLTEXT);
+        return new SearchQuery(query.getSearchExpression(), metadataFlags);
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackend.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackend.java
@@ -4,8 +4,8 @@ import java.util.EnumSet;
 import java.util.List;
 
 import org.jabref.logic.FilePreferences;
-import org.jabref.logic.search.SearchBackend;
 import org.jabref.logic.search.LinkedFilesIndexManager;
+import org.jabref.logic.search.SearchBackend;
 import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackend.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackend.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.search.SearchBackend;
-import org.jabref.logic.search.sqlbased.LinkedFilesIndexManager;
+import org.jabref.logic.search.LinkedFilesIndexManager;
 import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackend.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackend.java
@@ -17,6 +17,7 @@ import org.jabref.model.search.query.SearchResults;
 import org.jspecify.annotations.NullMarked;
 
 /// A search backend that evaluates metadata in memory and searches linked files with Lucene.
+// [impl->req~jabgui.search.fulltext.lucene-without-postgres~1]
 @NullMarked
 public class InMemoryLuceneSearchBackend implements SearchBackend {
 

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackend.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackend.java
@@ -14,7 +14,10 @@ import org.jabref.model.search.SearchFlags;
 import org.jabref.model.search.query.SearchQuery;
 import org.jabref.model.search.query.SearchResults;
 
+import org.jspecify.annotations.NullMarked;
+
 /// A search backend that evaluates metadata in memory and searches linked files with Lucene.
+@NullMarked
 public class InMemoryLuceneSearchBackend implements SearchBackend {
 
     private final InMemorySearchBackend inMemorySearchBackend;

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackend.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackend.java
@@ -1,0 +1,70 @@
+package org.jabref.logic.search.inmemory;
+
+import java.util.List;
+
+import org.jabref.logic.FilePreferences;
+import org.jabref.logic.search.SearchBackend;
+import org.jabref.logic.search.sqlbased.LinkedFilesIndexManager;
+import org.jabref.logic.util.TaskExecutor;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryPreferences;
+import org.jabref.model.entry.event.FieldChangedEvent;
+import org.jabref.model.search.SearchFlags;
+import org.jabref.model.search.query.SearchQuery;
+import org.jabref.model.search.query.SearchResults;
+
+/// A search backend that evaluates metadata in memory and searches linked files with Lucene.
+public class InMemoryLuceneSearchBackend implements SearchBackend {
+
+    private final InMemorySearchBackend inMemorySearchBackend;
+    private final LinkedFilesIndexManager linkedFilesIndexManager;
+
+    public InMemoryLuceneSearchBackend(BibDatabaseContext databaseContext,
+                                       BibEntryPreferences bibEntryPreferences,
+                                       FilePreferences filePreferences,
+                                       TaskExecutor taskExecutor) {
+        inMemorySearchBackend = new InMemorySearchBackend(databaseContext, bibEntryPreferences);
+        linkedFilesIndexManager = new LinkedFilesIndexManager(databaseContext, taskExecutor, filePreferences);
+    }
+
+    @Override
+    public SearchResults search(SearchQuery query) {
+        SearchResults searchResults = inMemorySearchBackend.search(query);
+        if (query.getSearchFlags().contains(SearchFlags.FULLTEXT)) {
+            searchResults.mergeSearchResults(linkedFilesIndexManager.search(query));
+        }
+        query.setSearchResults(searchResults);
+        return searchResults;
+    }
+
+    @Override
+    public boolean isEntryMatched(BibEntry entry, SearchQuery query) {
+        return inMemorySearchBackend.isEntryMatched(entry, query);
+    }
+
+    @Override
+    public void addToIndex(List<BibEntry> entries) {
+        linkedFilesIndexManager.addToIndex(entries);
+    }
+
+    @Override
+    public void removeFromIndex(List<BibEntry> entries) {
+        linkedFilesIndexManager.removeFromIndex(entries);
+    }
+
+    @Override
+    public void updateEntry(FieldChangedEvent event) {
+        linkedFilesIndexManager.updateEntry(event);
+    }
+
+    @Override
+    public void rebuildFullTextIndex() {
+        linkedFilesIndexManager.rebuildIndex();
+    }
+
+    @Override
+    public void close() {
+        linkedFilesIndexManager.closeAndWait();
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/IndexManager.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/IndexManager.java
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 import org.jabref.logic.preferences.CliPreferences;
+import org.jabref.logic.search.LinkedFilesIndexManager;
 import org.jabref.logic.search.sqlbased.indexing.BibFieldsIndexer;
 import org.jabref.logic.search.sqlbased.retrieval.BibFieldsSearcher;
 import org.jabref.logic.util.BackgroundTask;

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/IndexManager.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/IndexManager.java
@@ -15,15 +15,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.value.ChangeListener;
-
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.search.sqlbased.indexing.BibFieldsIndexer;
-import org.jabref.logic.search.sqlbased.indexing.DefaultLinkedFilesIndexer;
-import org.jabref.logic.search.sqlbased.indexing.ReadOnlyLinkedFilesIndexer;
 import org.jabref.logic.search.sqlbased.retrieval.BibFieldsSearcher;
-import org.jabref.logic.search.sqlbased.retrieval.LinkedFilesSearcher;
 import org.jabref.logic.util.BackgroundTask;
 import org.jabref.logic.util.DelayTaskThrottler;
 import org.jabref.logic.util.Directories;
@@ -33,7 +27,6 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.event.FieldChangedEvent;
 import org.jabref.model.entry.field.Field;
-import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.search.SearchFlags;
 import org.jabref.model.search.event.IndexAddedOrUpdatedEvent;
 import org.jabref.model.search.event.IndexClosedEvent;
@@ -50,19 +43,12 @@ public class IndexManager {
 
     private final TaskExecutor taskExecutor;
     private final BibDatabaseContext databaseContext;
-    private final BooleanProperty shouldIndexLinkedFiles;
-    private final ChangeListener<Boolean> preferencesListener;
     private final BibFieldsIndexer bibFieldsIndexer;
-    private final LuceneIndexer linkedFilesIndexer;
     private final BibFieldsSearcher bibFieldsSearcher;
-    private final LinkedFilesSearcher linkedFilesSearcher;
+    private final LinkedFilesIndexManager linkedFilesIndexManager;
     private final DelayTaskThrottler indexUpdateThrottler;
     private final ConcurrentHashMap<String, PendingFieldUpdates> pendingFieldsByEntry = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, FileDelta> pendingFileValuesByEntry = new ConcurrentHashMap<>();
     private final AtomicBoolean closed = new AtomicBoolean(false);
-
-    private record FileDelta(String oldValue, String newValue) {
-    }
 
     private record PendingFieldUpdates(BibEntry entry, Set<Field> fields) {
     }
@@ -73,39 +59,12 @@ public class IndexManager {
                         PostgresServer postgresServer) {
         this.taskExecutor = executor;
         this.databaseContext = databaseContext;
-        this.shouldIndexLinkedFiles = preferences.getFilePreferences().fulltextIndexLinkedFilesProperty();
-        this.preferencesListener = (_, _, newValue) -> bindToPreferences(newValue);
-        this.shouldIndexLinkedFiles.addListener(preferencesListener);
 
         bibFieldsIndexer = new BibFieldsIndexer(preferences.getBibEntryPreferences(), databaseContext, postgresServer.getConnection());
-
-        LuceneIndexer indexer;
-        try {
-            indexer = new DefaultLinkedFilesIndexer(databaseContext, preferences.getFilePreferences());
-        } catch (IOException e) {
-            LOGGER.debug("Error initializing linked files index - using read only index");
-            indexer = new ReadOnlyLinkedFilesIndexer(databaseContext);
-        }
-        linkedFilesIndexer = indexer;
-
         this.bibFieldsSearcher = new BibFieldsSearcher(postgresServer.getConnection(), bibFieldsIndexer.getTable());
-        this.linkedFilesSearcher = new LinkedFilesSearcher(databaseContext, linkedFilesIndexer, preferences.getFilePreferences());
+        this.linkedFilesIndexManager = new LinkedFilesIndexManager(databaseContext, taskExecutor, preferences.getFilePreferences());
         this.indexUpdateThrottler = taskExecutor.createThrottler(700);
         updateOnStart();
-    }
-
-    private void bindToPreferences(boolean newValue) {
-        if (newValue) {
-            new BackgroundTask<>() {
-                @Override
-                public Void call() {
-                    linkedFilesIndexer.updateOnStart(this);
-                    return null;
-                }
-            }.executeWith(taskExecutor);
-        } else {
-            linkedFilesIndexer.removeAllFromIndex();
-        }
     }
 
     private void updateOnStart() {
@@ -118,16 +77,6 @@ public class IndexManager {
         }.willBeRecoveredAutomatically(true)
          .onFinished(() -> this.databaseContext.getDatabase().postEvent(new IndexStartedEvent()))
          .executeWith(taskExecutor);
-
-        if (shouldIndexLinkedFiles.get()) {
-            new BackgroundTask<>() {
-                @Override
-                public Void call() {
-                    linkedFilesIndexer.updateOnStart(this);
-                    return null;
-                }
-            }.executeWith(taskExecutor);
-        }
     }
 
     public void addToIndex(List<BibEntry> entries) {
@@ -139,16 +88,7 @@ public class IndexManager {
             }
         }.onFinished(() -> this.databaseContext.getDatabase().postEvent(new IndexAddedOrUpdatedEvent(entries)))
          .executeWith(taskExecutor);
-
-        if (shouldIndexLinkedFiles.get()) {
-            new BackgroundTask<>() {
-                @Override
-                public Void call() {
-                    linkedFilesIndexer.addToIndex(entries, this);
-                    return null;
-                }
-            }.executeWith(taskExecutor);
-        }
+        linkedFilesIndexManager.addToIndex(entries);
     }
 
     public void removeFromIndex(List<BibEntry> entries) {
@@ -160,16 +100,7 @@ public class IndexManager {
             }
         }.onFinished(() -> this.databaseContext.getDatabase().postEvent(new IndexRemovedEvent(entries)))
          .executeWith(taskExecutor);
-
-        if (shouldIndexLinkedFiles.get()) {
-            new BackgroundTask<>() {
-                @Override
-                public Void call() {
-                    linkedFilesIndexer.removeFromIndex(entries, this);
-                    return null;
-                }
-            }.executeWith(taskExecutor);
-        }
+        linkedFilesIndexManager.removeFromIndex(entries);
     }
 
     public void updateEntry(FieldChangedEvent event) {
@@ -195,22 +126,10 @@ public class IndexManager {
             return new PendingFieldUpdates(entry, pendingUpdates.fields());
         });
 
-        /// FILE field updates rely on oldValue/newValue diffing in linkedFilesIndexer
-        /// Intermediate events dropped by the throttler would corrupt the baseline,
-        /// so we preserve the first oldValue seen and always update to the latest newValue
-        if (field.equals(StandardField.FILE)) {
-            pendingFileValuesByEntry.compute(entryId, (_, existing) -> {
-                if (existing == null) {
-                    return new FileDelta(event.getOldValue(), event.getNewValue());
-                } else {
-                    return new FileDelta(existing.oldValue(), event.getNewValue());
-                }
-            });
-        }
+        linkedFilesIndexManager.updateEntry(event);
 
         if (closed.get()) {
             pendingFieldsByEntry.remove(entryId);
-            pendingFileValuesByEntry.remove(entryId);
             return;
         }
 
@@ -236,34 +155,13 @@ public class IndexManager {
                     }.onFinished(() -> this.databaseContext.getDatabase()
                                                            .postEvent(new IndexAddedOrUpdatedEvent(List.of(pendingEntry))))
                      .executeWith(taskExecutor);
-
-                    if (shouldIndexLinkedFiles.get() && fieldsSnapshot.contains(StandardField.FILE)) {
-                        FileDelta fileValues = pendingFileValuesByEntry.remove(pendingEntryId);
-                        if (fileValues != null) {
-                            new BackgroundTask<>() {
-                                @Override
-                                public Void call() {
-                                    linkedFilesIndexer.updateEntry(pendingEntry, fileValues.oldValue(), fileValues.newValue(), this);
-                                    return null;
-                                }
-                            }.executeWith(taskExecutor);
-                        }
-                    }
                 }
             });
         });
     }
 
     public void rebuildFullTextIndex() {
-        if (shouldIndexLinkedFiles.get()) {
-            new BackgroundTask<>() {
-                @Override
-                public Void call() {
-                    linkedFilesIndexer.rebuildIndex(this);
-                    return null;
-                }
-            }.executeWith(taskExecutor);
-        }
+        linkedFilesIndexManager.rebuildIndex();
     }
 
     public void close() {
@@ -272,8 +170,7 @@ public class IndexManager {
         }
         closeThrottler(false);
         bibFieldsIndexer.close();
-        shouldIndexLinkedFiles.removeListener(preferencesListener);
-        linkedFilesIndexer.close();
+        linkedFilesIndexManager.close();
         databaseContext.getDatabase().postEvent(new IndexClosedEvent());
     }
 
@@ -283,15 +180,13 @@ public class IndexManager {
         }
         closeThrottler(true);
         bibFieldsIndexer.closeAndWait();
-        shouldIndexLinkedFiles.removeListener(preferencesListener);
-        linkedFilesIndexer.closeAndWait();
+        linkedFilesIndexManager.closeAndWait();
         databaseContext.getDatabase().postEvent(new IndexClosedEvent());
     }
 
     private void closeThrottler(boolean waitForShutdown) {
         indexUpdateThrottler.cancel();
         pendingFieldsByEntry.clear();
-        pendingFileValuesByEntry.clear();
 
         if (waitForShutdown) {
             indexUpdateThrottler.shutdown();
@@ -311,7 +206,7 @@ public class IndexManager {
         tasks.add(() -> bibFieldsSearcher.search(query));
 
         if (query.getSearchFlags().contains(SearchFlags.FULLTEXT)) {
-            tasks.add(() -> linkedFilesSearcher.search(query));
+            tasks.add(() -> linkedFilesIndexManager.search(query));
         }
 
         List<Future<SearchResults>> futures = HeadlessExecutorService.INSTANCE.executeAll(tasks);

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/LinkedFilesIndexManager.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/LinkedFilesIndexManager.java
@@ -22,10 +22,12 @@ import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.search.query.SearchQuery;
 import org.jabref.model.search.query.SearchResults;
 
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /// Maintains the Lucene index for linked files independently of the metadata search backend.
+@NullMarked
 public class LinkedFilesIndexManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(LinkedFilesIndexManager.class);
 

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/LinkedFilesIndexManager.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/LinkedFilesIndexManager.java
@@ -1,0 +1,195 @@
+package org.jabref.logic.search.sqlbased;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.value.ChangeListener;
+
+import org.jabref.logic.FilePreferences;
+import org.jabref.logic.search.sqlbased.indexing.DefaultLinkedFilesIndexer;
+import org.jabref.logic.search.sqlbased.indexing.ReadOnlyLinkedFilesIndexer;
+import org.jabref.logic.search.sqlbased.retrieval.LinkedFilesSearcher;
+import org.jabref.logic.util.BackgroundTask;
+import org.jabref.logic.util.DelayTaskThrottler;
+import org.jabref.logic.util.TaskExecutor;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.event.FieldChangedEvent;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.search.query.SearchQuery;
+import org.jabref.model.search.query.SearchResults;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/// Maintains the Lucene index for linked files independently of the metadata search backend.
+public class LinkedFilesIndexManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LinkedFilesIndexManager.class);
+
+    private final TaskExecutor taskExecutor;
+    private final BooleanProperty shouldIndexLinkedFiles;
+    private final ChangeListener<Boolean> preferencesListener;
+    private final LuceneIndexer linkedFilesIndexer;
+    private final LinkedFilesSearcher linkedFilesSearcher;
+    private final DelayTaskThrottler indexUpdateThrottler;
+    private final ConcurrentHashMap<String, FileDelta> pendingFileValuesByEntry = new ConcurrentHashMap<>();
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private record FileDelta(String oldValue, String newValue) {
+    }
+
+    public LinkedFilesIndexManager(BibDatabaseContext databaseContext, TaskExecutor taskExecutor, FilePreferences filePreferences) {
+        this.taskExecutor = taskExecutor;
+        this.shouldIndexLinkedFiles = filePreferences.fulltextIndexLinkedFilesProperty();
+        this.preferencesListener = (_, _, newValue) -> bindToPreferences(newValue);
+        this.shouldIndexLinkedFiles.addListener(preferencesListener);
+
+        LuceneIndexer indexer;
+        try {
+            indexer = new DefaultLinkedFilesIndexer(databaseContext, filePreferences);
+        } catch (IOException e) {
+            LOGGER.debug("Error initializing linked files index - using read only index");
+            indexer = new ReadOnlyLinkedFilesIndexer(databaseContext);
+        }
+        linkedFilesIndexer = indexer;
+        linkedFilesSearcher = new LinkedFilesSearcher(databaseContext, linkedFilesIndexer, filePreferences);
+        indexUpdateThrottler = taskExecutor.createThrottler(700);
+        updateOnStart();
+    }
+
+    private void bindToPreferences(boolean newValue) {
+        if (newValue) {
+            new BackgroundTask<>() {
+                @Override
+                public Void call() {
+                    linkedFilesIndexer.updateOnStart(this);
+                    return null;
+                }
+            }.executeWith(taskExecutor);
+        } else {
+            linkedFilesIndexer.removeAllFromIndex();
+        }
+    }
+
+    private void updateOnStart() {
+        if (shouldIndexLinkedFiles.get()) {
+            new BackgroundTask<>() {
+                @Override
+                public Void call() {
+                    linkedFilesIndexer.updateOnStart(this);
+                    return null;
+                }
+            }.executeWith(taskExecutor);
+        }
+    }
+
+    public void addToIndex(List<BibEntry> entries) {
+        if (shouldIndexLinkedFiles.get()) {
+            new BackgroundTask<>() {
+                @Override
+                public Void call() {
+                    linkedFilesIndexer.addToIndex(entries, this);
+                    return null;
+                }
+            }.executeWith(taskExecutor);
+        }
+    }
+
+    public void removeFromIndex(List<BibEntry> entries) {
+        if (shouldIndexLinkedFiles.get()) {
+            new BackgroundTask<>() {
+                @Override
+                public Void call() {
+                    linkedFilesIndexer.removeFromIndex(entries, this);
+                    return null;
+                }
+            }.executeWith(taskExecutor);
+        }
+    }
+
+    public void updateEntry(FieldChangedEvent event) {
+        if (closed.get() || !shouldIndexLinkedFiles.get() || !event.getField().equals(StandardField.FILE)) {
+            return;
+        }
+
+        BibEntry entry = event.getBibEntry();
+        String entryId = entry.getId();
+        pendingFileValuesByEntry.compute(entryId, (_, existing) -> {
+            if (existing == null) {
+                return new FileDelta(event.getOldValue(), event.getNewValue());
+            }
+            return new FileDelta(existing.oldValue(), event.getNewValue());
+        });
+
+        indexUpdateThrottler.schedule(() -> {
+            if (closed.get()) {
+                return;
+            }
+
+            FileDelta fileValues = pendingFileValuesByEntry.remove(entryId);
+            if (fileValues != null) {
+                new BackgroundTask<>() {
+                    @Override
+                    public Void call() {
+                        linkedFilesIndexer.updateEntry(entry, fileValues.oldValue(), fileValues.newValue(), this);
+                        return null;
+                    }
+                }.executeWith(taskExecutor);
+            }
+        });
+    }
+
+    public void rebuildIndex() {
+        if (shouldIndexLinkedFiles.get()) {
+            new BackgroundTask<>() {
+                @Override
+                public Void call() {
+                    linkedFilesIndexer.rebuildIndex(this);
+                    return null;
+                }
+            }.executeWith(taskExecutor);
+        }
+    }
+
+    public SearchResults search(SearchQuery query) {
+        return linkedFilesSearcher.search(query);
+    }
+
+    public void close() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        closeThrottler(false);
+        shouldIndexLinkedFiles.removeListener(preferencesListener);
+        linkedFilesIndexer.close();
+    }
+
+    public void closeAndWait() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        closeThrottler(true);
+        shouldIndexLinkedFiles.removeListener(preferencesListener);
+        linkedFilesIndexer.closeAndWait();
+    }
+
+    private void closeThrottler(boolean waitForShutdown) {
+        indexUpdateThrottler.cancel();
+        pendingFileValuesByEntry.clear();
+
+        if (waitForShutdown) {
+            indexUpdateThrottler.shutdown();
+        } else {
+            new BackgroundTask<>() {
+                @Override
+                public Void call() {
+                    indexUpdateThrottler.shutdown();
+                    return null;
+                }
+            }.executeWith(taskExecutor);
+        }
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/LinkedFilesIndexManager.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/LinkedFilesIndexManager.java
@@ -2,6 +2,7 @@ package org.jabref.logic.search.sqlbased;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -120,10 +121,9 @@ public class LinkedFilesIndexManager {
         BibEntry entry = event.getBibEntry();
         String entryId = entry.getId();
         pendingFileValuesByEntry.compute(entryId, (_, existing) -> {
-            if (existing == null) {
-                return new FileDelta(event.getOldValue(), event.getNewValue());
-            }
-            return new FileDelta(existing.oldValue(), event.getNewValue());
+            return Optional.ofNullable(existing)
+                           .map(fileDelta -> new FileDelta(fileDelta.oldValue(), event.getNewValue()))
+                           .orElseGet(() -> new FileDelta(event.getOldValue(), event.getNewValue()));
         });
 
         indexUpdateThrottler.schedule(() -> {
@@ -131,8 +131,7 @@ public class LinkedFilesIndexManager {
                 return;
             }
 
-            FileDelta fileValues = pendingFileValuesByEntry.remove(entryId);
-            if (fileValues != null) {
+            Optional.ofNullable(pendingFileValuesByEntry.remove(entryId)).ifPresent(fileValues -> {
                 new BackgroundTask<>() {
                     @Override
                     public Void call() {
@@ -140,7 +139,7 @@ public class LinkedFilesIndexManager {
                         return null;
                     }
                 }.executeWith(taskExecutor);
-            }
+            });
         });
     }
 

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/indexing/ReadOnlyLinkedFilesIndexer.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/indexing/ReadOnlyLinkedFilesIndexer.java
@@ -3,8 +3,6 @@ package org.jabref.logic.search.sqlbased.indexing;
 import java.io.IOException;
 import java.util.Collection;
 
-import org.jspecify.annotations.Nullable;
-
 import org.jabref.logic.search.sqlbased.LuceneIndexer;
 import org.jabref.logic.util.BackgroundTask;
 import org.jabref.logic.util.HeadlessExecutorService;
@@ -19,8 +17,8 @@ import org.slf4j.LoggerFactory;
 
 public class ReadOnlyLinkedFilesIndexer implements LuceneIndexer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReadOnlyLinkedFilesIndexer.class);
-    private @Nullable Directory indexDirectory;
-    private @Nullable SearcherManager searcherManager;
+    private Directory indexDirectory;
+    private SearcherManager searcherManager;
 
     public ReadOnlyLinkedFilesIndexer(BibDatabaseContext databaseContext) {
         try {

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/indexing/ReadOnlyLinkedFilesIndexer.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/indexing/ReadOnlyLinkedFilesIndexer.java
@@ -3,6 +3,8 @@ package org.jabref.logic.search.sqlbased.indexing;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.jspecify.annotations.Nullable;
+
 import org.jabref.logic.search.sqlbased.LuceneIndexer;
 import org.jabref.logic.util.BackgroundTask;
 import org.jabref.logic.util.HeadlessExecutorService;
@@ -17,8 +19,8 @@ import org.slf4j.LoggerFactory;
 
 public class ReadOnlyLinkedFilesIndexer implements LuceneIndexer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReadOnlyLinkedFilesIndexer.class);
-    private Directory indexDirectory;
-    private SearcherManager searcherManager;
+    private @Nullable Directory indexDirectory;
+    private @Nullable SearcherManager searcherManager;
 
     public ReadOnlyLinkedFilesIndexer(BibDatabaseContext databaseContext) {
         try {
@@ -70,8 +72,12 @@ public class ReadOnlyLinkedFilesIndexer implements LuceneIndexer {
 
     private void closeIndex() {
         try {
-            searcherManager.close();
-            indexDirectory.close();
+            if (searcherManager != null) {
+                searcherManager.close();
+            }
+            if (indexDirectory != null) {
+                indexDirectory.close();
+            }
         } catch (IOException e) {
             LOGGER.error("Error closing index", e);
         }

--- a/jablib/src/main/java/org/jabref/logic/search/sqlbased/retrieval/LinkedFilesSearcher.java
+++ b/jablib/src/main/java/org/jabref/logic/search/sqlbased/retrieval/LinkedFilesSearcher.java
@@ -33,6 +33,7 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.highlight.Highlighter;
 import org.apache.lucene.search.highlight.QueryScorer;
 import org.apache.lucene.search.highlight.SimpleHTMLFormatter;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +42,7 @@ public final class LinkedFilesSearcher {
 
     private final FilePreferences filePreferences;
     private final BibDatabaseContext databaseContext;
-    private final SearcherManager searcherManager;
+    private final @Nullable SearcherManager searcherManager;
     private final MultiFieldQueryParser parser;
 
     public LinkedFilesSearcher(BibDatabaseContext databaseContext, LuceneIndexer linkedFilesIndexer, FilePreferences filePreferences) {
@@ -69,8 +70,15 @@ public final class LinkedFilesSearcher {
             return new SearchResults();
         }
 
+        Optional<SearcherManager> maybeSearcherManager = Optional.ofNullable(searcherManager);
+        if (maybeSearcherManager.isEmpty()) {
+            LOGGER.warn("Linked files search is unavailable because the searcher manager could not be initialized");
+            return new SearchResults();
+        }
+
         LOGGER.debug("Searching in linked files with query: {}", luceneQuery.get());
         try {
+            SearcherManager searcherManager = maybeSearcherManager.orElseThrow();
             IndexSearcher linkedFilesIndexSearcher = acquireIndexSearcher(searcherManager);
             SearchResults searchResults = search(linkedFilesIndexSearcher, luceneQuery.get());
             releaseIndexSearcher(searcherManager, linkedFilesIndexSearcher);

--- a/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackendTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackendTest.java
@@ -2,9 +2,10 @@ package org.jabref.logic.search.inmemory;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.EnumSet;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -45,9 +46,7 @@ class InMemoryLuceneSearchBackendTest {
 
     @AfterEach
     void tearDown() {
-        if (searchBackend != null) {
-            searchBackend.close();
-        }
+        Optional.ofNullable(searchBackend).ifPresent(InMemoryLuceneSearchBackend::close);
     }
 
     @Test
@@ -72,8 +71,10 @@ class InMemoryLuceneSearchBackendTest {
     }
 
     private BibDatabaseContext initializeDatabaseContext(String testFile) throws URISyntaxException, IOException {
-        Path bibFile = Path.of(Objects.requireNonNull(
-                InMemoryLuceneSearchBackendTest.class.getResource("/org/jabref/logic/search/" + testFile)).toURI());
+        URL bibResource = Optional.ofNullable(
+                InMemoryLuceneSearchBackendTest.class.getResource("/org/jabref/logic/search/" + testFile))
+                                  .orElseThrow();
+        Path bibFile = Path.of(bibResource.toURI());
         ParserResult result = new BibtexImporter(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS), new DummyFileUpdateMonitor()).importDatabase(bibFile);
         BibDatabaseContext databaseContext = spy(result.getDatabaseContext());
         when(databaseContext.getFulltextIndexPath()).thenReturn(indexDirectory);

--- a/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackendTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackendTest.java
@@ -1,0 +1,81 @@
+package org.jabref.logic.search.inmemory;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jabref.logic.FilePreferences;
+import org.jabref.logic.importer.ImportFormatPreferences;
+import org.jabref.logic.importer.ParserResult;
+import org.jabref.logic.importer.fileformat.BibtexImporter;
+import org.jabref.logic.util.CurrentThreadTaskExecutor;
+import org.jabref.logic.util.TaskExecutor;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntryPreferences;
+import org.jabref.model.search.SearchFlags;
+import org.jabref.model.search.query.SearchQuery;
+import org.jabref.model.util.DummyFileUpdateMonitor;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@NullMarked
+class InMemoryLuceneSearchBackendTest {
+
+    private static final TaskExecutor TASK_EXECUTOR = new CurrentThreadTaskExecutor();
+
+    @TempDir
+    private Path indexDirectory;
+
+    private @Nullable InMemoryLuceneSearchBackend searchBackend;
+
+    @AfterEach
+    void tearDown() {
+        if (searchBackend != null) {
+            searchBackend.close();
+        }
+    }
+
+    @Test
+    void searchesLinkedFileContentsWithoutPostgres() throws IOException, URISyntaxException {
+        BibDatabaseContext databaseContext = initializeDatabaseContext("test-library-with-attached-files.bib");
+        searchBackend = new InMemoryLuceneSearchBackend(
+                databaseContext,
+                BibEntryPreferences.getDefault(),
+                FilePreferences.getDefault(),
+                TASK_EXECUTOR);
+
+        SearchQuery searchQuery = new SearchQuery("comma", EnumSet.of(SearchFlags.FULLTEXT));
+
+        Set<String> matchedCitationKeys = searchBackend.search(searchQuery)
+                                                      .getMatchedEntries()
+                                                      .stream()
+                                                      .map(entryId -> databaseContext.getDatabase().getEntryById(entryId).orElseThrow())
+                                                      .map(entry -> entry.getCitationKey().orElseThrow())
+                                                      .collect(Collectors.toUnmodifiableSet());
+
+        assertEquals(Set.of("minimal-sentence-case", "minimal-all-upper-case", "minimal-mixed-case"), matchedCitationKeys);
+    }
+
+    private BibDatabaseContext initializeDatabaseContext(String testFile) throws URISyntaxException, IOException {
+        Path bibFile = Path.of(Objects.requireNonNull(
+                InMemoryLuceneSearchBackendTest.class.getResource("/org/jabref/logic/search/" + testFile)).toURI());
+        ParserResult result = new BibtexImporter(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS), new DummyFileUpdateMonitor()).importDatabase(bibFile);
+        BibDatabaseContext databaseContext = spy(result.getDatabaseContext());
+        when(databaseContext.getFulltextIndexPath()).thenReturn(indexDirectory);
+        return databaseContext;
+    }
+}

--- a/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackendTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackendTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @NullMarked
+// [utest->req~jabgui.search.fulltext.lucene-without-postgres~1]
 class InMemoryLuceneSearchBackendTest {
 
     private static final TaskExecutor TASK_EXECUTOR = new CurrentThreadTaskExecutor();

--- a/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackendTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/inmemory/InMemoryLuceneSearchBackendTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @NullMarked
-// [utest->req~jabgui.search.fulltext.lucene-without-postgres~1]
+        // [utest->req~jabgui.search.fulltext.lucene-without-postgres~1]
 class InMemoryLuceneSearchBackendTest {
 
     private static final TaskExecutor TASK_EXECUTOR = new CurrentThreadTaskExecutor();
@@ -61,18 +61,18 @@ class InMemoryLuceneSearchBackendTest {
         SearchQuery searchQuery = new SearchQuery("comma", EnumSet.of(SearchFlags.FULLTEXT));
 
         Set<String> matchedCitationKeys = searchBackend.search(searchQuery)
-                                                      .getMatchedEntries()
-                                                      .stream()
-                                                      .map(entryId -> databaseContext.getDatabase().getEntryById(entryId).orElseThrow())
-                                                      .map(entry -> entry.getCitationKey().orElseThrow())
-                                                      .collect(Collectors.toUnmodifiableSet());
+                                                       .getMatchedEntries()
+                                                       .stream()
+                                                       .map(entryId -> databaseContext.getDatabase().getEntryById(entryId).orElseThrow())
+                                                       .map(entry -> entry.getCitationKey().orElseThrow())
+                                                       .collect(Collectors.toUnmodifiableSet());
 
         assertEquals(Set.of("minimal-sentence-case", "minimal-all-upper-case", "minimal-mixed-case"), matchedCitationKeys);
     }
 
     private BibDatabaseContext initializeDatabaseContext(String testFile) throws URISyntaxException, IOException {
         URL bibResource = Optional.ofNullable(
-                InMemoryLuceneSearchBackendTest.class.getResource("/org/jabref/logic/search/" + testFile))
+                                          InMemoryLuceneSearchBackendTest.class.getResource("/org/jabref/logic/search/" + testFile))
                                   .orElseThrow();
         Path bibFile = Path.of(bibResource.toURI());
         ParserResult result = new BibtexImporter(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS), new DummyFileUpdateMonitor()).importDatabase(bibFile);


### PR DESCRIPTION
### Summary

This change keeps metadata searching in memory when experimental Postgres search is disabled, while continuing to index and search linked PDF contents with Lucene. It removes the previous coupling that made linked-file full-text search unavailable unless Postgres was enabled.

<img width="1110" height="841" alt="grafik" src="https://github.com/user-attachments/assets/c41277c9-325b-49a8-937a-6fa7d8071546" />


### Steps to test

1. Open a library containing a linked local PDF.
2. In Preferences, leave experimental Postgres search disabled and enable indexing linked files for full-text search.
3. Run a full-text query for text known to appear in the PDF.
4. Verify that the entry is returned and that the full-text result is available in the entry editor.

### Related issues and pull requests

Follow-up to https://github.com/JabRef/jabref/pull/15599
Follow-up to https://github.com/JabRef/jabref/pull/16084

### AI usage

Codex (model GPT-5) was used to assist with implementation and test creation. A human contributor must review, understand, and take responsibility for all changes before marking this PR ready for review.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [x] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [x] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [x] No `catch (Exception e)` — only specific exceptions are caught.
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [x] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [x] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [x] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [x] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [x] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.

## 2. Verification commands

Run in this order — cheapest first. Each must pass.

- [ ] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
- [ ] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [ ] `./gradlew modernizer`.
- [ ] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [ ] `./gradlew javadoc`.
- [ ] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.

## 3. Documentation

- [x] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Link the issue if one exists; link the PR only when no issue exists. Use `TODO` as the placeholder when neither is known yet — never a fake number.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [x] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [x] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [ ] PR created with `gh pr create --body-file <file>` (not `--body`).
- [ ] If `CHANGELOG.md` used a `TODO` placeholder (no issue confidently identified yet — an existing issue link always stays), it was replaced with the real PR-number link after PR creation, then committed and pushed. If an issue is identified or created later, the link is switched to the issue.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
