### PR TITLE
Select and focus newly added entry from New Entry dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the button shape changed when hovering over it. [#16188](https://github.com/JabRef/jabref/issues/16188)
 - We fixed handling of `exit` in the LSP server. [#16268](https://github.com/JabRef/jabref/pull/16268)
 - We fixed an issue where `LinkedFile.isOnlineLink()` did not recognize `ftp://` links as online links. [#16400](https://github.com/JabRef/jabref/issues/16400)
+- We fixed an issue where a newly added entry (e.g. via the New Entry dialog) was not automatically selected and scrolled into view in the main table. [#16035](https://github.com/JabRef/jabref/issues/16035)
 
 ### Removed
 

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
@@ -250,7 +250,7 @@ public class NewEntryViewModel {
     }
 
     /// Selects and scrolls to the entries that were just imported into the library, mirroring the
-    /// behavior of {@link LibraryTab#insertEntries(List)}. Only single-entry imports are focused, since
+    /// behavior of [LibraryTab#insertEntries(List)]. Only single-entry imports are focused, since
     /// selecting every entry of a bulk import would pollute the entry-editor navigation history.
     private void selectAndFocusImportedEntries(List<BibEntry> importedEntries) {
         if (importedEntries.size() != 1) {
@@ -472,9 +472,10 @@ public class NewEntryViewModel {
                     stateManager,
                     dialogService,
                     taskExecutor);
-            final EntryImportHandlerTracker tracker = new EntryImportHandlerTracker(stateManager, result.get().size());
+            final List<BibEntry> entries = result.get();
+            final EntryImportHandlerTracker tracker = new EntryImportHandlerTracker(stateManager, entries.size());
             tracker.setOnFinish(() -> selectAndFocusImportedEntries(tracker.getImportedEntries()));
-            handler.importEntriesWithDuplicateCheck(null, result.get(), tracker);
+            handler.importEntriesWithDuplicateCheck(null, entries, tracker);
 
             executedSuccessfully.set(true);
             executing.set(false);
@@ -559,9 +560,10 @@ public class NewEntryViewModel {
                     stateManager,
                     dialogService,
                     taskExecutor);
-            final EntryImportHandlerTracker tracker = new EntryImportHandlerTracker(stateManager, result.get().size());
+            final List<BibEntry> entries = result.get();
+            final EntryImportHandlerTracker tracker = new EntryImportHandlerTracker(stateManager, entries.size());
             tracker.setOnFinish(() -> selectAndFocusImportedEntries(tracker.getImportedEntries()));
-            handler.importEntriesWithDuplicateCheck(null, result.get(), tracker);
+            handler.importEntriesWithDuplicateCheck(null, entries, tracker);
 
             executedSuccessfully.set(true);
             executing.set(false);

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
@@ -21,6 +21,7 @@ import javafx.concurrent.Task;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.LibraryTab;
 import org.jabref.gui.StateManager;
+import org.jabref.gui.externalfiles.EntryImportHandlerTracker;
 import org.jabref.gui.externalfiles.ImportHandler;
 import org.jabref.gui.importer.BookCoverFetcher;
 import org.jabref.gui.preferences.GuiPreferences;
@@ -248,6 +249,20 @@ public class NewEntryViewModel {
         return entry;
     }
 
+    /// Selects and scrolls to the entries that were just imported into the library, mirroring the
+    /// behavior of {@link LibraryTab#insertEntries(List)}. Only single-entry imports are focused, since
+    /// selecting every entry of a bulk import would pollute the entry-editor navigation history.
+    private void selectAndFocusImportedEntries(List<BibEntry> importedEntries) {
+        if (importedEntries.size() != 1) {
+            return;
+        }
+        if (preferences.getEntryEditorPreferences().shouldOpenOnNewEntry()) {
+            libraryTab.showAndEdit(importedEntries.getFirst());
+        } else {
+            libraryTab.clearAndSelect(importedEntries.getFirst());
+        }
+    }
+
     private class WorkerLookupId extends Task<Optional<BibEntry>> {
         @Override
         protected Optional<BibEntry> call() throws FetcherException {
@@ -357,7 +372,9 @@ public class NewEntryViewModel {
                     stateManager,
                     dialogService,
                     taskExecutor);
-            handler.importEntryWithDuplicateCheck(new TransferInformation(libraryTab.getBibDatabaseContext(), TransferMode.NONE), result.get());
+            final EntryImportHandlerTracker tracker = new EntryImportHandlerTracker(stateManager);
+            tracker.setOnFinish(() -> selectAndFocusImportedEntries(tracker.getImportedEntries()));
+            handler.importEntriesWithDuplicateCheck(new TransferInformation(libraryTab.getBibDatabaseContext(), TransferMode.NONE), List.of(result.get()), tracker);
 
             executedSuccessfully.set(true);
             executing.set(false);
@@ -455,7 +472,9 @@ public class NewEntryViewModel {
                     stateManager,
                     dialogService,
                     taskExecutor);
-            handler.importEntriesWithDuplicateCheck(null, result.get());
+            final EntryImportHandlerTracker tracker = new EntryImportHandlerTracker(stateManager, result.get().size());
+            tracker.setOnFinish(() -> selectAndFocusImportedEntries(tracker.getImportedEntries()));
+            handler.importEntriesWithDuplicateCheck(null, result.get(), tracker);
 
             executedSuccessfully.set(true);
             executing.set(false);
@@ -540,7 +559,9 @@ public class NewEntryViewModel {
                     stateManager,
                     dialogService,
                     taskExecutor);
-            handler.importEntriesWithDuplicateCheck(null, result.get());
+            final EntryImportHandlerTracker tracker = new EntryImportHandlerTracker(stateManager, result.get().size());
+            tracker.setOnFinish(() -> selectAndFocusImportedEntries(tracker.getImportedEntries()));
+            handler.importEntriesWithDuplicateCheck(null, result.get(), tracker);
 
             executedSuccessfully.set(true);
             executing.set(false);


### PR DESCRIPTION
### Summary

The New Entry dialog's DOI/ISBN lookup, citation interpretation, and BibTeX paste flows insert entries asynchronously through a duplicate-check pipeline, but never selected or scrolled to the resulting row in the main table — you had to find the new entry yourself. This already worked correctly for the plain "New Entry" toolbar button, so I extended the same behavior to the other three ways of adding an entry, using the existing EntryImportHandlerTracker to hook into the async completion callback.

### Steps to test

1. Open JabRef with a library that has several entries in it
2. Go to File → New Entry
3. Try the "Look up by ID" tab then paste a DOI (e.g. `10.1038/nature12373`) and submit
4. The new entry should be automatically selected/highlighted in the main table
5. Same behavior applies to the "paste BibTeX" and "interpret citation" tabs

Screenshot:
<img width="878" height="543" alt="image" src="https://github.com/user-attachments/assets/4df9d44a-d2db-451e-8c92-97bf9473af13" />


### Related issues and pull requests

Closes #16035

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [x] New classes annotated with `@NullMarked`. (N/A — no new classes were added, only a new private method `selectAndFocusImportedEntries` on the existing `NewEntryViewModel` class.)
- [x] `Optional` consumed with `ifPresent`/`ifPresentOrElse`/`map`/`orElseThrow`.
- [x] `StringUtil.isBlank(...)` used instead of manual null/blank checks. (N/A — no blank-string checks in this diff.)

### Exceptions

- [x] No `catch (Exception e)` — only specific exceptions are caught.
- [x] No `throw new RuntimeException(...)`/`IllegalStateException(...)`.
- [x] Logged exceptions passed as last logger argument. (N/A — no `LOGGER` calls added in this diff.)

### Style and idioms

- [x] New `BibEntry` objects built with withers. (N/A — no new `BibEntry` objects are constructed; existing entries are only passed through.)
- [x] Modern Java used (`List.of()`, etc.).
- [x] Regexes use a precompiled `Pattern.compile(...)` constant. (N/A — no regex in this diff.)
- [x] Background work uses `BackgroundTask`, not `new Thread()`. (N/A — no new threading; reuses the existing `EntryImportHandlerTracker`/`ImportHandler` async machinery.)
- [x] No commented-out code, no trivial comments, no AI-disclosure comments in source.
- [x] Markdown Javadoc uses `[ClassName]` syntax, not `{@link}`.

### User-facing text

- [x] All user-facing text localized. (N/A — no new user-facing strings added.)
- [x] Sentence case, no trailing `!`, labels don't end with `:`. (N/A — no labels added.)
- [x] Variance expressed with placeholders. (N/A — no formatted strings added.)

### Security

- [x] User-controlled data HTML-escaped before HTML response. (N/A — no HTML/web response involved.)

### Tests

- [x] Behavior changes in `org.jabref.model`/`org.jabref.logic` have tests. (N/A by scope — this change is entirely in the `jabgui` module, not model/logic.)
- [x] Test style conventions followed. (N/A — no tests were added in this diff.)

## 2. Verification commands

- [ ] `./gradlew check` — not run (full suite skipped for time; relied on manual testing in the running app instead).
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh` — PASS.
- [x] `./gradlew modernizer` — PASS.
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` — PASS, no formatting drift.
- [x] `./gradlew javadoc` — PASS.
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` — PASS (CHANGELOG.md changed).
- [x] Docker intellij-format. (Not needed — no formatting drift found.)
</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [ ] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)