### PR TITLE
Reintroduce custom entry editor tabs with two-column preferences UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We extended the per-fetcher timeout for fulltext PDF lookups from 10 to 120 seconds so fetchers that bounce through an institutional sign-in or a slow publisher CDN have a chance to complete. [#15877](https://github.com/JabRef/jabref/pull/15877)
 - When an imported entry has an empty citation key, it is generated. [#15624](https://github.com/JabRef/jabref/pull/15624)
 - We made the `Move file to directory` operation for Linked Files show every configured JabRef directory as possible options. [#12287](https://github.com/JabRef/jabref/issues/12287)
-- We reworked the entry editor tab preferences into a single "Editor tabs" list where you can show, hide, add, and remove both built-in and custom tabs. [#15998](https://github.com/JabRef/jabref/pull/15998)
+- We reworked the entry editor tab preferences into a two-column "Tabs"/"Fields" editor supporting reordering, custom tabs, and regular expressions as field names. [#15998](https://github.com/JabRef/jabref/pull/15998) [#16594](https://github.com/JabRef/jabref/issues/16594)
 - We extended library pseudonymization to also pseudonymize group names, not just the entries. [#14117](https://github.com/JabRef/jabref/issues/14117)
 - We introduced a leightweight search engine without fulltext search in linked files as default variant. [#15599](https://github.com/JabRef/jabref/pull/15599)
 - We moved arXiv handling out of the DOI cleanup into the dedicated "arXiv DOI" cleanup. [#16033](https://github.com/JabRef/jabref/pull/16033)
@@ -153,7 +153,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - We removed the redundant "Look up BibTeX entries in all open libraries" setting from the LibreOffice panel, which is now the toggle of "Look up BibTeX entries in the currently selected library only". [#16484](https://github.com/JabRef/jabref/pull/16484)
 - We removed the entry editor tabs "Required fields", "Optional fields", "Optional fields 2", "Deprecated fields", "Other fields", and "Comments"; their content is part of the new "Main" tab. [#12711](https://github.com/JabRef/jabref/issues/12711)
-- We removed the ability to define custom entry editor tabs (including the default "General" and "Abstract" tabs); the entry editor tab preferences now only toggle the visibility of the built-in tabs. [#12711](https://github.com/JabRef/jabref/issues/12711)
+- We removed the default custom entry editor tabs "General" and "Abstract"; their content is part of the new "Main" tab. User-defined custom tabs are kept. [#12711](https://github.com/JabRef/jabref/issues/12711)
 - The citation key integrity check now includes the generated citation key in its warning message. [#15776](https://github.com/JabRef/jabref/pull/15776)
 - We removed the [CiteSeerX](https://en.wikipedia.org/wiki/CiteSeerX) fetcher, because the service is defunct and its links now redirect to the Wayback Machine. [#16299](https://github.com/JabRef/jabref/issues/16299)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We extended the per-fetcher timeout for fulltext PDF lookups from 10 to 120 seconds so fetchers that bounce through an institutional sign-in or a slow publisher CDN have a chance to complete. [#15877](https://github.com/JabRef/jabref/pull/15877)
 - When an imported entry has an empty citation key, it is generated. [#15624](https://github.com/JabRef/jabref/pull/15624)
 - We made the `Move file to directory` operation for Linked Files show every configured JabRef directory as possible options. [#12287](https://github.com/JabRef/jabref/issues/12287)
-- We reworked the entry editor tab preferences into a two-column "Tabs"/"Fields" editor supporting reordering, custom tabs, and regular expressions as field names. [#15998](https://github.com/JabRef/jabref/pull/15998) [#16594](https://github.com/JabRef/jabref/issues/16594)
+- We reworked the entry editor tab preferences into a two-column "Tabs"/"Fields" editor supporting reordering, custom tabs, and regular expressions as field names. [#15998](https://github.com/JabRef/jabref/pull/15998). [#16594](https://github.com/JabRef/jabref/issues/16594)
 - We extended library pseudonymization to also pseudonymize group names, not just the entries. [#14117](https://github.com/JabRef/jabref/issues/14117)
 - We introduced a leightweight search engine without fulltext search in linked files as default variant. [#15599](https://github.com/JabRef/jabref/pull/15599)
 - We moved arXiv handling out of the DOI cleanup into the dedicated "arXiv DOI" cleanup. [#16033](https://github.com/JabRef/jabref/pull/16033)

--- a/docs/requirements/entry-editor.md
+++ b/docs/requirements/entry-editor.md
@@ -75,6 +75,13 @@ A field's row shows a small gray "remove field" icon button pinned to its top-ri
 
 Needs: impl
 
+## Custom tabs show a user-defined list of field patterns
+`req~entry-editor.custom-tabs~1`
+
+Users can define custom entry editor tabs in the preferences ("Entry editor" → "Editor tabs"): a "Tabs" column lists all tabs (built-in tabs with a visibility checkbox, custom tabs with a delete action) and supports adding custom tabs and reordering all tabs via drag and drop; a "Fields" column edits the selected custom tab's ordered field list, also reorderable via drag and drop. A field entry is either a plain field name (always shown on the tab, even while unset) or a regular expression (e.g. `comment-.*`), which shows every set field of the entry whose name matches. A field listed on more than one tab is marked with a warning sign. Custom tabs configured in JabRef versions before the "Main" tab rework are picked up again without migration.
+
+Needs: impl
+
 ## Special fields are edited with the same icon controls as the main table
 `req~entry-editor.special-field-editors~1`
 

--- a/jabgui/src/main/java/org/jabref/gui/DragAndDropDataFormats.java
+++ b/jabgui/src/main/java/org/jabref/gui/DragAndDropDataFormats.java
@@ -14,5 +14,6 @@ public class DragAndDropDataFormats {
     public static final DataFormat LINKED_FILE = new DataFormat("dnd/org.jabref.model.entry.LinkedFile");
     public static final DataFormat ENTRIES = new DataFormat("dnd/org.jabref.model.entry.BibEntries");
     public static final DataFormat PREVIEWLAYOUTS = new DataFormat("dnd/org.jabref.logic.citationstyle.PreviewLayouts");
+    public static final DataFormat ENTRY_EDITOR_TAB = new DataFormat("dnd/org.jabref.gui.preferences.entryeditor.EditorTabViewModel");
     @SuppressWarnings("unchecked") public static final Class<List<PreviewLayout>> PREVIEWLAYOUT_LIST_CLASS = (Class<List<PreviewLayout>>) (Class<?>) List.class;
 }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -212,6 +212,15 @@ public class AllFieldsTab extends FieldsEditorTab {
         super.bindToEntry(entry);
     }
 
+    @Override
+    protected void dispose() {
+        // The entry's event bus holds listeners strongly; without unregistering, a discarded tab
+        // instance would be retained (and keep reacting) for as long as the entry lives.
+        subscribedEntry.ifPresent(entry -> entry.unregisterListener(this));
+        subscribedEntry = Optional.empty();
+        super.dispose();
+    }
+
     /// Refreshes the list when a field is set or unset from outside this tab
     /// (Source tab, fetchers, undo, …). Rebuilds only when the set of shown fields
     /// actually changes, so typing inside a visible editor never rebuilds or steals focus.

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditorTabFactory.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditorTabFactory.java
@@ -109,6 +109,18 @@ public class EntryEditorTabFactory {
                                                   : entryEditorPreferences.tabVisibleProperty(type));
                 yield tab;
             }
+            // Custom tabs have no preference-driven visibility gate: they exist exactly while configured,
+            // and hide themselves via content-driven visibility when their patterns resolve to no fields.
+            case EntryEditorTabModel.CustomizedFieldsTab customTab ->
+                    new UserDefinedFieldsTab(
+                            customTab,
+                            undoManager,
+                            undoAction,
+                            redoAction,
+                            preferences,
+                            journalAbbreviationRepository,
+                            stateManager,
+                            previewPanel);
         };
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditorTabModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditorTabModel.java
@@ -1,16 +1,25 @@
 package org.jabref.gui.entryeditor;
 
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.SequencedSet;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.FieldFactory;
 
 /// Model of the tabs that appear in the entry editor.
 ///
-/// Since the single scroll-list "Main" tab (issue #12711) replaced the classic category
-/// tabs and the user-customizable field-set tabs, every tab is a fixed [BuiltInTab]
-/// identified by a [BuiltIn] constant; users only toggle visibility.
+/// [BuiltInTab] — a fixed tab (the single scroll-list "Main" tab of issue #12711 and the
+/// feature tabs) identified by a [BuiltIn] constant; users only toggle visibility and order.
+/// [CustomizedFieldsTab] — a user-defined tab backed by a named, ordered list of field patterns.
 public sealed interface EntryEditorTabModel
-        permits EntryEditorTabModel.BuiltInTab {
+        permits EntryEditorTabModel.BuiltInTab, EntryEditorTabModel.CustomizedFieldsTab {
 
     boolean isVisible();
 
@@ -84,6 +93,58 @@ public sealed interface EntryEditorTabModel
         @Override
         public EntryEditorTabModel withVisible(boolean visible) {
             return new BuiltInTab(type, visible);
+        }
+    }
+
+    /// A user-defined tab showing an explicit, ordered list of field patterns. Always shown while its
+    /// pattern list resolves to at least one field; toggled only by being added to or removed from the
+    /// tab list, so it carries no visibility flag (unlike [BuiltInTab]).
+    ///
+    /// A pattern is either a plain field name (always shown, even while unset on the entry) or a
+    /// regular expression (contains regex metacharacters), which captures every *set* field of the
+    /// entry whose name matches it — e.g. `comment-.*` for all user-specific comment fields.
+    record CustomizedFieldsTab(String name, List<String> fieldPatterns)
+            implements EntryEditorTabModel {
+
+        /// A pattern without any regex metacharacter is a plain field name.
+        private static final Pattern PLAIN_FIELD_NAME = Pattern.compile("[^\\\\^$.|?*+()\\[\\]{}]+");
+
+        public CustomizedFieldsTab {
+            fieldPatterns = List.copyOf(fieldPatterns);
+        }
+
+        @Override
+        public boolean isVisible() {
+            return true;
+        }
+
+        @Override
+        public EntryEditorTabModel withVisible(boolean visible) {
+            return this;
+        }
+
+        /// Resolves [#fieldPatterns] against the given entry, keeping the configured pattern order;
+        /// the fields captured by one regex pattern are sorted by name. Invalid regexes resolve to nothing.
+        // [impl->req~entry-editor.custom-tabs~1]
+        public SequencedSet<Field> resolveFields(BibEntry entry) {
+            SequencedSet<Field> result = new LinkedHashSet<>();
+            for (String pattern : fieldPatterns) {
+                if (PLAIN_FIELD_NAME.matcher(pattern).matches()) {
+                    result.add(FieldFactory.parseField(entry.getType(), pattern));
+                    continue;
+                }
+                try {
+                    Pattern compiled = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
+                    entry.getFields().stream()
+                         .filter(field -> compiled.matcher(field.getName()).matches())
+                         .sorted(Comparator.comparing(Field::getName))
+                         .forEach(result::add);
+                } catch (PatternSyntaxException _) {
+                    // Invalid regex: resolves to no fields; the preferences UI accepts any string, so
+                    // a broken pattern must not break rendering the tab.
+                }
+            }
+            return result;
         }
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/UserDefinedFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/UserDefinedFieldsTab.java
@@ -1,0 +1,103 @@
+package org.jabref.gui.entryeditor;
+
+import java.util.Optional;
+import java.util.SequencedSet;
+
+import javax.swing.undo.UndoManager;
+
+import javafx.application.Platform;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+
+import org.jabref.gui.StateManager;
+import org.jabref.gui.icon.IconTheme;
+import org.jabref.gui.preferences.GuiPreferences;
+import org.jabref.gui.preview.PreviewPanel;
+import org.jabref.gui.undo.RedoAction;
+import org.jabref.gui.undo.UndoAction;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.event.FieldChangedEvent;
+import org.jabref.model.entry.field.Field;
+
+import com.google.common.eventbus.Subscribe;
+import com.tobiasdiez.easybind.EasyBind;
+import org.jspecify.annotations.NullMarked;
+
+/// A user-defined tab showing the fields resolved from a [EntryEditorTabModel.CustomizedFieldsTab]
+/// (configured in the entry editor preferences).
+@NullMarked
+public class UserDefinedFieldsTab extends FieldsEditorTab {
+
+    private final EntryEditorTabModel.CustomizedFieldsTab model;
+
+    /// Replaces the base class's content-driven visibility: a regex pattern's matches change when fields
+    /// are set or cleared on the *same* entry (e.g. from the Main or Source tab), which the base class's
+    /// entry-switch-only evaluation would miss.
+    private final BooleanProperty hasResolvedFields = new SimpleBooleanProperty();
+
+    /// The entry whose event bus this tab is subscribed to, for live refresh of regex-captured fields.
+    private Optional<BibEntry> subscribedEntry = Optional.empty();
+
+    public UserDefinedFieldsTab(EntryEditorTabModel.CustomizedFieldsTab model,
+                                UndoManager undoManager,
+                                UndoAction undoAction,
+                                RedoAction redoAction,
+                                GuiPreferences preferences,
+                                JournalAbbreviationRepository journalAbbreviationRepository,
+                                StateManager stateManager,
+                                PreviewPanel previewPanel) {
+        super(
+                false,
+                undoManager,
+                undoAction,
+                redoAction,
+                preferences,
+                journalAbbreviationRepository,
+                stateManager,
+                previewPanel);
+
+        this.model = model;
+
+        setContentDrivenVisibility(hasResolvedFields);
+        EasyBind.subscribe(currentEntryProperty(), entry ->
+                hasResolvedFields.set((entry != null) && !model.resolveFields(entry).isEmpty()));
+
+        setText(model.name());
+        setGraphic(IconTheme.JabRefIcons.OPTIONAL.getGraphicNode());
+    }
+
+    @Override
+    protected SequencedSet<Field> determineFieldsToShow(BibEntry entry) {
+        return model.resolveFields(entry);
+    }
+
+    @Override
+    protected void bindToEntry(BibEntry entry) {
+        if (subscribedEntry.filter(current -> current == entry).isEmpty()) {
+            subscribedEntry.ifPresent(previous -> previous.unregisterListener(this));
+            entry.registerListener(this);
+            subscribedEntry = Optional.of(entry);
+        }
+        super.bindToEntry(entry);
+    }
+
+    /// Refreshes the tab when a field is set or cleared from outside (Main tab, Source tab, fetchers,
+    /// undo, …), since that can change which fields a regex pattern captures. Rebuilds only when the
+    /// resolved field set actually changes, so typing inside this tab's editors never steals focus.
+    @Subscribe
+    public void listen(FieldChangedEvent event) {
+        Platform.runLater(() -> {
+            BibEntry entry = event.getBibEntry();
+            if (getCurrentEntry() != entry) {
+                return;
+            }
+            SequencedSet<Field> target = determineFieldsToShow(entry);
+            hasResolvedFields.set(!target.isEmpty());
+            if ((gridPane != null) && !target.equals(editors.keySet())) {
+                setupPanel(stateManager.getActiveDatabase().orElse(new BibDatabaseContext()), entry, false);
+            }
+        });
+    }
+}

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/UserDefinedFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/UserDefinedFieldsTab.java
@@ -2,6 +2,7 @@ package org.jabref.gui.entryeditor;
 
 import java.util.Optional;
 import java.util.SequencedSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.undo.UndoManager;
 
@@ -39,6 +40,10 @@ public class UserDefinedFieldsTab extends FieldsEditorTab {
 
     /// The entry whose event bus this tab is subscribed to, for live refresh of regex-captured fields.
     private Optional<BibEntry> subscribedEntry = Optional.empty();
+
+    /// Set while a refresh is queued on the FX thread (events may arrive from background threads,
+    /// e.g. fetchers), so bursts of field changes coalesce into one refresh instead of one each.
+    private final AtomicBoolean refreshQueued = new AtomicBoolean();
 
     public UserDefinedFieldsTab(EntryEditorTabModel.CustomizedFieldsTab model,
                                 UndoManager undoManager,
@@ -93,13 +98,21 @@ public class UserDefinedFieldsTab extends FieldsEditorTab {
     }
 
     /// Refreshes the tab when a field is set or cleared from outside (Main tab, Source tab, fetchers,
-    /// undo, …), since that can change which fields a regex pattern captures. Rebuilds only when the
-    /// resolved field set actually changes, so typing inside this tab's editors never steals focus.
+    /// undo, …), since that can change which fields a regex pattern captures. Event bursts coalesce
+    /// into a single deferred refresh, and the refresh reads the entry's state at callback time (the
+    /// event's payload is deliberately ignored), so a queued callback can never apply stale state.
+    /// Rebuilds only when the resolved field set actually changes, so typing inside this tab's
+    /// editors never steals focus.
     @Subscribe
     public void listen(FieldChangedEvent event) {
+        if (refreshQueued.getAndSet(true)) {
+            return;
+        }
         Platform.runLater(() -> {
-            BibEntry entry = event.getBibEntry();
-            if (getCurrentEntry() != entry) {
+            // Cleared before refreshing: an event arriving while we refresh must queue a new callback.
+            refreshQueued.set(false);
+            BibEntry entry = getCurrentEntry();
+            if (entry == null) {
                 return;
             }
             SequencedSet<Field> target = determineFieldsToShow(entry);

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/UserDefinedFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/UserDefinedFieldsTab.java
@@ -83,6 +83,15 @@ public class UserDefinedFieldsTab extends FieldsEditorTab {
         super.bindToEntry(entry);
     }
 
+    @Override
+    protected void dispose() {
+        // The entry's event bus holds listeners strongly; without unregistering, a discarded tab
+        // instance would be retained (and keep reacting) for as long as the entry lives.
+        subscribedEntry.ifPresent(entry -> entry.unregisterListener(this));
+        subscribedEntry = Optional.empty();
+        super.dispose();
+    }
+
     /// Refreshes the tab when a field is set or cleared from outside (Main tab, Source tab, fetchers,
     /// undo, …), since that can change which fields a regex pattern captures. Rebuilds only when the
     /// resolved field set actually changes, so typing inside this tab's editors never steals focus.

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -100,6 +100,11 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     public static final String BINDINGS = "bindings";
     // endregion
 
+    // All custom entry editor tabs in one JSON object, `{"tab name": ["field pattern", ...], ...}`, in
+    // display order. Public because needed for pref migration (the numbered-series format of versions up
+    // to v6.0-alpha.6 is converted to this key).
+    public static final String ENTRY_EDITOR_CUSTOM_TABS = "entryEditorCustomTabs";
+
     // region column names
     // public because of migration
     // Variable names have changed to ensure backward compatibility with pre 5.0 releases of JabRef
@@ -243,12 +248,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     // backing store and only serves as the tabModels binding's reporting key in getPreferences()/getDefaults()
     // (see bindMap/PUSH_APPLICATIONS_PATHS_KEY for the same pattern).
     private static final String ENTRY_EDITOR_TABS = "entryEditorTabs";
-    // All custom tabs in one JSON object, `{"tab name": ["field pattern", ...], ...}`, in display order.
-    private static final String ENTRY_EDITOR_CUSTOM_TABS = "entryEditorCustomTabs";
-    // Storage format of versions before the "Main" tab rework (#12711): tab names and field lists in two
-    // parallel numbered series. Read only as a migration fallback and purged on the next store.
-    private static final String OLD_CUSTOM_TAB_NAME = "customTabName_";
-    private static final String OLD_CUSTOM_TAB_FIELDS = "customTabFields_";
     private static final String ENTRY_EDITOR_TAB_ORDER = "entryEditorTabOrder";
     private static final String AUTO_OPEN_FORM = "autoOpenForm";
     private static final String SHOW_ALL_FIELDS_TAB = "showAllFieldsTab";
@@ -452,13 +451,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         ));
 
         String storedCustomTabs = get(ENTRY_EDITOR_CUSTOM_TABS, "");
-        if (StringUtil.isBlank(storedCustomTabs)) {
-            // Migration: custom tabs stored by versions before the "Main" tab rework (#12711).
-            List<String> oldTabNames = getSeries(OLD_CUSTOM_TAB_NAME);
-            for (int i = 0; i < oldTabNames.size(); i++) {
-                tabModels.add(new EntryEditorTabModel.CustomizedFieldsTab(oldTabNames.get(i), getStringList(OLD_CUSTOM_TAB_FIELDS + i)));
-            }
-        } else {
+        if (StringUtil.isNotBlank(storedCustomTabs)) {
             try {
                 OBJECT_MAPPER.readValue(storedCustomTabs, CUSTOM_TABS_TYPE).forEach((name, fieldPatterns) ->
                         tabModels.add(new EntryEditorTabModel.CustomizedFieldsTab(name, fieldPatterns)));
@@ -530,9 +523,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         SequencedMap<String, List<String>> customTabsByName = new LinkedHashMap<>();
         customTabs.forEach(tab -> customTabsByName.put(tab.name(), tab.fieldPatterns()));
         put(ENTRY_EDITOR_CUSTOM_TABS, OBJECT_MAPPER.writeValueAsString(customTabsByName));
-        // The migrated-from format must not resurrect after the user changes or deletes tabs.
-        purgeSeries(OLD_CUSTOM_TAB_NAME, 0);
-        purgeSeries(OLD_CUSTOM_TAB_FIELDS, 0);
 
         putStringList(ENTRY_EDITOR_TAB_ORDER, configs.stream()
                                                      .filter(config -> !config.isPreview())

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -100,11 +100,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     public static final String BINDINGS = "bindings";
     // endregion
 
-    // All custom entry editor tabs in one JSON object, `{"tab name": ["field pattern", ...], ...}`, in
-    // display order. Public because needed for pref migration (the numbered-series format of versions up
-    // to v6.0-alpha.6 is converted to this key).
-    public static final String ENTRY_EDITOR_CUSTOM_TABS = "entryEditorCustomTabs";
-
     // region column names
     // public because of migration
     // Variable names have changed to ensure backward compatibility with pre 5.0 releases of JabRef
@@ -248,6 +243,10 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     // backing store and only serves as the tabModels binding's reporting key in getPreferences()/getDefaults()
     // (see bindMap/PUSH_APPLICATIONS_PATHS_KEY for the same pattern).
     private static final String ENTRY_EDITOR_TABS = "entryEditorTabs";
+    // All custom tabs in one JSON object, `{"tab name": ["field pattern", ...], ...}`, in display order.
+    // The numbered-series format of versions up to v6.0-alpha.6 is converted to this key by
+    // org.jabref.migrations.PreferencesMigrations#upgradeEntryEditorCustomTabs (key name duplicated there).
+    private static final String ENTRY_EDITOR_CUSTOM_TABS = "entryEditorCustomTabs";
     private static final String ENTRY_EDITOR_TAB_ORDER = "entryEditorTabOrder";
     private static final String AUTO_OPEN_FORM = "autoOpenForm";
     private static final String SHOW_ALL_FIELDS_TAB = "showAllFieldsTab";

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -294,8 +294,8 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     private MathSciNetPreferences mathSciNetPreferences;
 
     /// @deprecated Never ever add a call to this method. There should be only one caller.
-     /// All other usages should get the preferences passed (or injected).
-     /// The JabRef team leaves the `@deprecated` annotation to have IntelliJ listing this method with a strike-through.
+    /// All other usages should get the preferences passed (or injected).
+    /// The JabRef team leaves the `@deprecated` annotation to have IntelliJ listing this method with a strike-through.
     @Deprecated
     public static JabRefGuiPreferences getInstance() {
         if (JabRefGuiPreferences.singleton == null) {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.preferences;
 
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -9,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.SequencedMap;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -69,6 +71,7 @@ import org.jabref.model.metadata.SaveOrder;
 import org.jabref.model.metadata.SelfContainedSaveOrder;
 
 import com.airhacks.afterburner.injection.Injector;
+import com.google.common.annotations.VisibleForTesting;
 import com.tobiasdiez.easybind.EasyBind;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -440,34 +443,39 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             tabModels.add(new EntryEditorTabModel.CustomizedFieldsTab(customTabNames.get(i), getStringList(CUSTOM_TAB_FIELDS + i)));
         }
 
-        return applyStoredTabOrder(tabModels);
+        return applyStoredTabOrder(tabModels, getStringList(ENTRY_EDITOR_TAB_ORDER));
     }
 
-    /// Reorders `tabModels` to match [#ENTRY_EDITOR_TAB_ORDER]. The Preview tab stays first; tabs unknown
-    /// to the stored order (e.g. built-ins introduced after the order was written) keep their default
-    /// relative position at the end.
-    private List<EntryEditorTabModel> applyStoredTabOrder(List<EntryEditorTabModel> tabModels) {
-        List<String> storedOrder = getStringList(ENTRY_EDITOR_TAB_ORDER);
+    /// Reorders `tabModels` to match `storedOrder` (see [#ENTRY_EDITOR_TAB_ORDER]). The Preview tab stays
+    /// first; tabs unknown to the stored order (e.g. built-ins introduced after the order was written) keep
+    /// their default relative position at the end. Tabs sharing an ID (duplicate custom-tab names in
+    /// persisted data — the preferences UI prevents them, but older versions and hand-edited stores may
+    /// not) are kept, consumed one per matching stored-order entry.
+    @VisibleForTesting
+    static List<EntryEditorTabModel> applyStoredTabOrder(List<EntryEditorTabModel> tabModels, List<String> storedOrder) {
         if (storedOrder.isEmpty()) {
             return tabModels;
         }
 
-        Map<String, EntryEditorTabModel> remaining = new LinkedHashMap<>();
+        SequencedMap<String, ArrayDeque<EntryEditorTabModel>> remaining = new LinkedHashMap<>();
         List<EntryEditorTabModel> ordered = new ArrayList<>();
         for (EntryEditorTabModel model : tabModels) {
             if (model.isPreview()) {
                 ordered.add(model);
             } else {
-                remaining.put(tabOrderId(model), model);
+                remaining.computeIfAbsent(tabOrderId(model), _ -> new ArrayDeque<>()).add(model);
             }
         }
         for (String id : storedOrder) {
-            EntryEditorTabModel model = remaining.remove(id);
-            if (model != null) {
-                ordered.add(model);
+            ArrayDeque<EntryEditorTabModel> models = remaining.get(id);
+            if (models != null) {
+                ordered.add(models.removeFirst());
+                if (models.isEmpty()) {
+                    remaining.remove(id);
+                }
             }
         }
-        ordered.addAll(remaining.values());
+        remaining.values().forEach(ordered::addAll);
         return ordered;
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -62,6 +62,7 @@ import org.jabref.logic.preferences.JabRefCliPreferences;
 import org.jabref.logic.preview.CitationStylePreviewLayout;
 import org.jabref.logic.preview.PreviewLayout;
 import org.jabref.logic.preview.TextBasedPreviewLayout;
+import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.types.EntryType;
@@ -75,6 +76,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.tobiasdiez.easybind.EasyBind;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPreferences {
 
@@ -110,6 +114,13 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     // endregion
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JabRefGuiPreferences.class);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    /// JSON shape of [#ENTRY_EDITOR_CUSTOM_TABS]; Jackson reads JSON objects into insertion-ordered maps,
+    /// so the tabs' display order survives the round-trip.
+    private static final TypeReference<LinkedHashMap<String, List<String>>> CUSTOM_TABS_TYPE = new TypeReference<>() {
+    };
 
     // region WorkspacePreferences
     private static final String OVERRIDE_DEFAULT_FONT_SIZE = "overrideDefaultFontSize";
@@ -232,10 +243,12 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     // backing store and only serves as the tabModels binding's reporting key in getPreferences()/getDefaults()
     // (see bindMap/PUSH_APPLICATIONS_PATHS_KEY for the same pattern).
     private static final String ENTRY_EDITOR_TABS = "entryEditorTabs";
-    // Deliberately the same keys as before the "Main" tab rework (#12711), so custom tabs configured
-    // in older versions are picked up again without migration code.
-    private static final String CUSTOM_TAB_NAME = "customTabName_";
-    private static final String CUSTOM_TAB_FIELDS = "customTabFields_";
+    // All custom tabs in one JSON object, `{"tab name": ["field pattern", ...], ...}`, in display order.
+    private static final String ENTRY_EDITOR_CUSTOM_TABS = "entryEditorCustomTabs";
+    // Storage format of versions before the "Main" tab rework (#12711): tab names and field lists in two
+    // parallel numbered series. Read only as a migration fallback and purged on the next store.
+    private static final String OLD_CUSTOM_TAB_NAME = "customTabName_";
+    private static final String OLD_CUSTOM_TAB_FIELDS = "customTabFields_";
     private static final String ENTRY_EDITOR_TAB_ORDER = "entryEditorTabOrder";
     private static final String AUTO_OPEN_FORM = "autoOpenForm";
     private static final String SHOW_ALL_FIELDS_TAB = "showAllFieldsTab";
@@ -438,9 +451,20 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                         getBoolean(SHOW_FULLTEXT_SEARCH_TAB, defaults.isTabVisible(EntryEditorTabModel.BuiltIn.FULLTEXT_SEARCH_RESULTS)))
         ));
 
-        List<String> customTabNames = getSeries(CUSTOM_TAB_NAME);
-        for (int i = 0; i < customTabNames.size(); i++) {
-            tabModels.add(new EntryEditorTabModel.CustomizedFieldsTab(customTabNames.get(i), getStringList(CUSTOM_TAB_FIELDS + i)));
+        String storedCustomTabs = get(ENTRY_EDITOR_CUSTOM_TABS, "");
+        if (StringUtil.isBlank(storedCustomTabs)) {
+            // Migration: custom tabs stored by versions before the "Main" tab rework (#12711).
+            List<String> oldTabNames = getSeries(OLD_CUSTOM_TAB_NAME);
+            for (int i = 0; i < oldTabNames.size(); i++) {
+                tabModels.add(new EntryEditorTabModel.CustomizedFieldsTab(oldTabNames.get(i), getStringList(OLD_CUSTOM_TAB_FIELDS + i)));
+            }
+        } else {
+            try {
+                OBJECT_MAPPER.readValue(storedCustomTabs, CUSTOM_TABS_TYPE).forEach((name, fieldPatterns) ->
+                        tabModels.add(new EntryEditorTabModel.CustomizedFieldsTab(name, fieldPatterns)));
+            } catch (JacksonException e) {
+                LOGGER.warn("Could not read the custom entry editor tabs, dropping them", e);
+            }
         }
 
         return applyStoredTabOrder(tabModels, getStringList(ENTRY_EDITOR_TAB_ORDER));
@@ -501,12 +525,14 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                                                                           .filter(EntryEditorTabModel.CustomizedFieldsTab.class::isInstance)
                                                                           .map(EntryEditorTabModel.CustomizedFieldsTab.class::cast)
                                                                           .toList();
-        for (int i = 0; i < customTabs.size(); i++) {
-            put(CUSTOM_TAB_NAME + i, customTabs.get(i).name());
-            putStringList(CUSTOM_TAB_FIELDS + i, customTabs.get(i).fieldPatterns());
-        }
-        purgeSeries(CUSTOM_TAB_NAME, customTabs.size());
-        purgeSeries(CUSTOM_TAB_FIELDS, customTabs.size());
+        // Keyed by name, so a duplicate tab name cannot exist in the stored format (the preferences UI
+        // prevents creating duplicates; legacy duplicates merge here, last one wins).
+        SequencedMap<String, List<String>> customTabsByName = new LinkedHashMap<>();
+        customTabs.forEach(tab -> customTabsByName.put(tab.name(), tab.fieldPatterns()));
+        put(ENTRY_EDITOR_CUSTOM_TABS, OBJECT_MAPPER.writeValueAsString(customTabsByName));
+        // The migrated-from format must not resurrect after the user changes or deletes tabs.
+        purgeSeries(OLD_CUSTOM_TAB_NAME, 0);
+        purgeSeries(OLD_CUSTOM_TAB_FIELDS, 0);
 
         putStringList(ENTRY_EDITOR_TAB_ORDER, configs.stream()
                                                      .filter(config -> !config.isPreview())

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -228,6 +229,11 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     // backing store and only serves as the tabModels binding's reporting key in getPreferences()/getDefaults()
     // (see bindMap/PUSH_APPLICATIONS_PATHS_KEY for the same pattern).
     private static final String ENTRY_EDITOR_TABS = "entryEditorTabs";
+    // Deliberately the same keys as before the "Main" tab rework (#12711), so custom tabs configured
+    // in older versions are picked up again without migration code.
+    private static final String CUSTOM_TAB_NAME = "customTabName_";
+    private static final String CUSTOM_TAB_FIELDS = "customTabFields_";
+    private static final String ENTRY_EDITOR_TAB_ORDER = "entryEditorTabOrder";
     private static final String AUTO_OPEN_FORM = "autoOpenForm";
     private static final String SHOW_ALL_FIELDS_TAB = "showAllFieldsTab";
     private static final String SHOW_RECOMMENDATIONS = "showRecommendations";
@@ -285,8 +291,8 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     private MathSciNetPreferences mathSciNetPreferences;
 
     /// @deprecated Never ever add a call to this method. There should be only one caller.
-    /// All other usages should get the preferences passed (or injected).
-    /// The JabRef team leaves the `@deprecated` annotation to have IntelliJ listing this method with a strike-through.
+     /// All other usages should get the preferences passed (or injected).
+     /// The JabRef team leaves the `@deprecated` annotation to have IntelliJ listing this method with a strike-through.
     @Deprecated
     public static JabRefGuiPreferences getInstance() {
         if (JabRefGuiPreferences.singleton == null) {
@@ -397,8 +403,9 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         return entryEditorPreferences;
     }
 
-    /// The single source of truth for the entry editor's tab list: the user-configured field-set tabs,
-    /// followed by every static (built-in) tab's visibility flag, in [EntryEditorTabModel.BuiltIn] order.
+    /// The single source of truth for the entry editor's tab list: every built-in tab's visibility flag
+    /// plus the user-defined custom tabs, ordered by [#ENTRY_EDITOR_TAB_ORDER] (falling back to
+    /// [EntryEditorTabModel.BuiltIn] order followed by the custom tabs).
     private List<EntryEditorTabModel> getEntryEditorTabs(EntryEditorPreferences defaults) {
         List<EntryEditorTabModel> tabModels = new ArrayList<>();
 
@@ -428,10 +435,76 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                         getBoolean(SHOW_FULLTEXT_SEARCH_TAB, defaults.isTabVisible(EntryEditorTabModel.BuiltIn.FULLTEXT_SEARCH_RESULTS)))
         ));
 
-        return tabModels;
+        List<String> customTabNames = getSeries(CUSTOM_TAB_NAME);
+        for (int i = 0; i < customTabNames.size(); i++) {
+            tabModels.add(new EntryEditorTabModel.CustomizedFieldsTab(customTabNames.get(i), getStringList(CUSTOM_TAB_FIELDS + i)));
+        }
+
+        return applyStoredTabOrder(tabModels);
+    }
+
+    /// Reorders `tabModels` to match [#ENTRY_EDITOR_TAB_ORDER]. The Preview tab stays first; tabs unknown
+    /// to the stored order (e.g. built-ins introduced after the order was written) keep their default
+    /// relative position at the end.
+    private List<EntryEditorTabModel> applyStoredTabOrder(List<EntryEditorTabModel> tabModels) {
+        List<String> storedOrder = getStringList(ENTRY_EDITOR_TAB_ORDER);
+        if (storedOrder.isEmpty()) {
+            return tabModels;
+        }
+
+        Map<String, EntryEditorTabModel> remaining = new LinkedHashMap<>();
+        List<EntryEditorTabModel> ordered = new ArrayList<>();
+        for (EntryEditorTabModel model : tabModels) {
+            if (model.isPreview()) {
+                ordered.add(model);
+            } else {
+                remaining.put(tabOrderId(model), model);
+            }
+        }
+        for (String id : storedOrder) {
+            EntryEditorTabModel model = remaining.remove(id);
+            if (model != null) {
+                ordered.add(model);
+            }
+        }
+        ordered.addAll(remaining.values());
+        return ordered;
+    }
+
+    /// Stable identifier of a tab in [#ENTRY_EDITOR_TAB_ORDER]. Custom tabs are prefixed so a custom tab
+    /// named like a [EntryEditorTabModel.BuiltIn] constant cannot collide with it.
+    private static String tabOrderId(EntryEditorTabModel model) {
+        return switch (model) {
+            case EntryEditorTabModel.BuiltInTab(
+                    EntryEditorTabModel.BuiltIn type,
+                    boolean _
+            ) ->
+                    type.name();
+            case EntryEditorTabModel.CustomizedFieldsTab(
+                    String name,
+                    List<String> _
+            ) ->
+                    "custom:" + name;
+        };
     }
 
     private void storeTabConfigs(List<EntryEditorTabModel> configs) {
+        List<EntryEditorTabModel.CustomizedFieldsTab> customTabs = configs.stream()
+                                                                          .filter(EntryEditorTabModel.CustomizedFieldsTab.class::isInstance)
+                                                                          .map(EntryEditorTabModel.CustomizedFieldsTab.class::cast)
+                                                                          .toList();
+        for (int i = 0; i < customTabs.size(); i++) {
+            put(CUSTOM_TAB_NAME + i, customTabs.get(i).name());
+            putStringList(CUSTOM_TAB_FIELDS + i, customTabs.get(i).fieldPatterns());
+        }
+        purgeSeries(CUSTOM_TAB_NAME, customTabs.size());
+        purgeSeries(CUSTOM_TAB_FIELDS, customTabs.size());
+
+        putStringList(ENTRY_EDITOR_TAB_ORDER, configs.stream()
+                                                     .filter(config -> !config.isPreview())
+                                                     .map(JabRefGuiPreferences::tabOrderId)
+                                                     .toList());
+
         for (EntryEditorTabModel config : configs) {
             if (config instanceof EntryEditorTabModel.BuiltInTab(
                     EntryEditorTabModel.BuiltIn type,

--- a/jabgui/src/main/java/org/jabref/gui/preferences/entryeditor/EditorTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/entryeditor/EditorTabViewModel.java
@@ -1,0 +1,79 @@
+package org.jabref.gui.preferences.entryeditor;
+
+import java.util.List;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import org.jabref.gui.entryeditor.EntryEditorTabModel;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/// Mutable working copy of one entry editor tab ([EntryEditorTabModel]) while it is edited in the
+/// preferences dialog; converted back via [#toModel()] on store.
+@NullMarked
+public class EditorTabViewModel {
+
+    /// `null` for custom tabs.
+    private final EntryEditorTabModel.@Nullable BuiltIn builtIn;
+    private final String customName;
+    private final BooleanProperty visible = new SimpleBooleanProperty(true);
+    private final ObservableList<String> fieldPatterns = FXCollections.observableArrayList();
+
+    private EditorTabViewModel(EntryEditorTabModel.@Nullable BuiltIn builtIn, String customName) {
+        this.builtIn = builtIn;
+        this.customName = customName;
+    }
+
+    public static EditorTabViewModel fromModel(EntryEditorTabModel model) {
+        return switch (model) {
+            case EntryEditorTabModel.BuiltInTab(
+                    EntryEditorTabModel.BuiltIn type,
+                    boolean visible
+            ) -> {
+                EditorTabViewModel tab = new EditorTabViewModel(type, "");
+                tab.visible.set(visible);
+                yield tab;
+            }
+            case EntryEditorTabModel.CustomizedFieldsTab(
+                    String name,
+                    List<String> fieldPatterns
+            ) -> {
+                EditorTabViewModel tab = new EditorTabViewModel(null, name);
+                tab.fieldPatterns.setAll(fieldPatterns);
+                yield tab;
+            }
+        };
+    }
+
+    public static EditorTabViewModel newCustomTab(String name) {
+        return new EditorTabViewModel(null, name);
+    }
+
+    public EntryEditorTabModel toModel() {
+        if (builtIn != null) {
+            return new EntryEditorTabModel.BuiltInTab(builtIn, visible.get());
+        }
+        return new EntryEditorTabModel.CustomizedFieldsTab(customName, List.copyOf(fieldPatterns));
+    }
+
+    public boolean isCustom() {
+        return builtIn == null;
+    }
+
+    public String getDisplayName() {
+        return builtIn != null ? builtIn.displayName() : customName;
+    }
+
+    public BooleanProperty visibleProperty() {
+        return visible;
+    }
+
+    /// The tab's ordered field patterns; only ever non-empty for custom tabs.
+    public ObservableList<String> getFieldPatterns() {
+        return fieldPatterns;
+    }
+}

--- a/jabgui/src/main/java/org/jabref/gui/preferences/entryeditor/EntryEditorTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/entryeditor/EntryEditorTab.java
@@ -1,24 +1,59 @@
 package org.jabref.gui.preferences.entryeditor;
 
+import javafx.beans.InvalidationListener;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.collections.FXCollections;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
-import javafx.scene.control.ListCell;
-import javafx.scene.control.ListView;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
+import javafx.scene.input.ClipboardContent;
+import javafx.scene.input.DataFormat;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.input.TransferMode;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
-import org.jabref.gui.entryeditor.EntryEditorTabModel;
+import org.jabref.gui.DragAndDropDataFormats;
+import org.jabref.gui.StateManager;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.preferences.AbstractPreferenceTabView;
+import org.jabref.gui.util.ControlHelper;
+import org.jabref.gui.util.CustomLocalDragboard;
+import org.jabref.gui.util.ValueTableCellFactory;
+import org.jabref.gui.util.ViewModelTableRowFactory;
 import org.jabref.logic.importer.fetcher.citation.CitationCountFetcherType;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.FieldFactory;
+
+import com.airhacks.afterburner.injection.Injector;
+import com.tobiasdiez.easybind.EasyBind;
+import org.controlsfx.control.textfield.TextFields;
+
+import static org.jabref.gui.preferences.forms.FormMetrics.GAP;
 
 public class EntryEditorTab extends AbstractPreferenceTabView<EntryEditorTabViewModel> {
+
+    private final TableView<EditorTabViewModel> tabsTable = new TableView<>();
+    private final TableView<String> fieldsTable = new TableView<>();
+    private final TextField addTabName = new TextField();
+    private final TextField addFieldName = new TextField();
+    private final Label fieldsPlaceholder = new Label();
+
+    private final CustomLocalDragboard localDragboard;
 
     public EntryEditorTab() {
         this.viewModel = new EntryEditorTabViewModel(
@@ -27,6 +62,7 @@ public class EntryEditorTab extends AbstractPreferenceTabView<EntryEditorTabView
                 preferences.getMrDlibPreferences(),
                 preferences.getAbbreviationPreferences(),
                 taskExecutor);
+        this.localDragboard = Injector.instantiateModelOrService(StateManager.class).getLocalDragboard();
         buildView();
     }
 
@@ -57,62 +93,289 @@ public class EntryEditorTab extends AbstractPreferenceTabView<EntryEditorTabView
                 .build());
     }
 
+    // [impl->req~entry-editor.custom-tabs~1]
     private Node buildTabConfigRegion() {
-        ListView<EntryEditorTabModel> tabConfigsList = new ListView<>();
-        VBox.setVgrow(tabConfigsList, Priority.ALWAYS);
-        tabConfigsList.setItems(viewModel.getTabModels());
-        tabConfigsList.setCellFactory(_ -> new TabConfigCell());
+        HBox columns = new HBox(GAP, buildTabsColumn(), buildFieldsColumn());
+        VBox.setVgrow(columns, Priority.ALWAYS);
+        return columns;
+    }
+
+    // region Tabs column
+
+    private Node buildTabsColumn() {
+        setupTabsTable();
+
+        addTabName.setPromptText(Localization.lang("Tab name..."));
+        addTabName.setOnAction(_ -> addTab());
+
+        Button addTabButton = new Button();
+        addTabButton.setPrefSize(20.0, 20.0);
+        addTabButton.getStyleClass().addAll("icon-button", "narrow");
+        addTabButton.setGraphic(IconTheme.JabRefIcons.ADD_NOBOX.getGraphicNode());
+        addTabButton.setTooltip(new Tooltip(Localization.lang("Add new tab")));
+        addTabButton.setOnAction(_ -> addTab());
+        addTabButton.disableProperty().bind(addTabName.textProperty().isEmpty());
+
+        VBox column = new VBox(GAP, tabsTable, new HBox(GAP, addTabName, addTabButton));
+        column.setPrefWidth(280.0);
+        return column;
+    }
+
+    private void setupTabsTable() {
+        tabsTable.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tabsTable.setPrefHeight(300.0);
+        VBox.setVgrow(tabsTable, Priority.ALWAYS);
+
+        TableColumn<EditorTabViewModel, EditorTabViewModel> visibleColumn = new TableColumn<>();
+        visibleColumn.setMinWidth(40.0);
+        visibleColumn.setMaxWidth(40.0);
+        visibleColumn.setResizable(false);
+        visibleColumn.setSortable(false);
+        visibleColumn.setReorderable(false);
+        visibleColumn.setCellValueFactory(cellData -> new ReadOnlyObjectWrapper<>(cellData.getValue()));
+        // Only built-in tabs have a visibility flag; custom tabs are shown while they exist and are
+        // removed via the delete action instead.
+        visibleColumn.setCellFactory(_ -> new TableCell<>() {
+            private final CheckBox checkBox = new CheckBox();
+            private BooleanProperty boundVisible;
+
+            @Override
+            protected void updateItem(EditorTabViewModel tab, boolean empty) {
+                super.updateItem(tab, empty);
+                if (boundVisible != null) {
+                    checkBox.selectedProperty().unbindBidirectional(boundVisible);
+                    boundVisible = null;
+                }
+                if (empty || (tab == null) || tab.isCustom()) {
+                    setGraphic(null);
+                    return;
+                }
+                boundVisible = tab.visibleProperty();
+                checkBox.selectedProperty().bindBidirectional(boundVisible);
+                setGraphic(checkBox);
+            }
+        });
+
+        TableColumn<EditorTabViewModel, String> nameColumn = new TableColumn<>(Localization.lang("Tabs"));
+        nameColumn.setSortable(false);
+        nameColumn.setReorderable(false);
+        nameColumn.setCellValueFactory(cellData -> new ReadOnlyStringWrapper(cellData.getValue().getDisplayName()));
+
+        TableColumn<EditorTabViewModel, EditorTabViewModel> actionsColumn = new TableColumn<>();
+        actionsColumn.setMinWidth(40.0);
+        actionsColumn.setMaxWidth(40.0);
+        actionsColumn.setResizable(false);
+        actionsColumn.setSortable(false);
+        actionsColumn.setReorderable(false);
+        actionsColumn.setCellValueFactory(cellData -> new ReadOnlyObjectWrapper<>(cellData.getValue()));
+        new ValueTableCellFactory<EditorTabViewModel, EditorTabViewModel>()
+                .withGraphic(tab -> tab.isCustom() ? IconTheme.JabRefIcons.DELETE_ENTRY.getGraphicNode() : null)
+                .withTooltip(tab -> tab.isCustom() ? Localization.lang("Remove tab %0", tab.getDisplayName()) : null)
+                .withOnMouseClickedEvent(tab -> _ -> {
+                    viewModel.removeTab(tab);
+                    fieldsTable.refresh();
+                })
+                .install(actionsColumn);
+
+        tabsTable.getColumns().add(visibleColumn);
+        tabsTable.getColumns().add(nameColumn);
+        tabsTable.getColumns().add(actionsColumn);
+        tabsTable.setItems(viewModel.getTabs());
+
+        new ViewModelTableRowFactory<EditorTabViewModel>()
+                .setOnDragDetected((row, tab, event) -> handleOnDragDetected(tabsTable, DragAndDropDataFormats.ENTRY_EDITOR_TAB, EditorTabViewModel.class, tab, event))
+                .setOnDragDropped((row, tab, event) -> handleOnDragDropped(tabsTable, EditorTabViewModel.class, row, event))
+                .setOnDragOver((row, tab, event) -> handleOnDragOver(DragAndDropDataFormats.ENTRY_EDITOR_TAB, row, event))
+                .setOnDragExited((row, tab, event) -> ControlHelper.removeDroppingPseudoClasses(row))
+                .install(tabsTable);
+
+        EasyBind.subscribe(tabsTable.getSelectionModel().selectedItemProperty(), this::onSelectedTabChanged);
+        // The tab list is filled after construction (setValues), so select the first row once it arrives.
+        viewModel.getTabs().addListener((InvalidationListener) _ -> {
+            if (tabsTable.getSelectionModel().isEmpty() && !tabsTable.getItems().isEmpty()) {
+                tabsTable.getSelectionModel().selectFirst();
+            }
+        });
+    }
+
+    private void onSelectedTabChanged(EditorTabViewModel tab) {
+        if ((tab != null) && tab.isCustom()) {
+            fieldsTable.setItems(tab.getFieldPatterns());
+            fieldsPlaceholder.setText(Localization.lang("This tab has no fields yet."));
+        } else {
+            fieldsTable.setItems(FXCollections.emptyObservableList());
+            fieldsPlaceholder.setText(tab == null
+                                      ? Localization.lang("Select a tab to configure its fields.")
+                                      : Localization.lang("The content of built-in tabs is fixed."));
+        }
+        addFieldName.clear();
+    }
+
+    private void addTab() {
+        viewModel.addCustomTab(addTabName.getText()).ifPresent(tab -> {
+            addTabName.clear();
+            tabsTable.getSelectionModel().select(tab);
+            tabsTable.scrollTo(tab);
+        });
+    }
+
+    // endregion
+
+    // region Fields column
+
+    private Node buildFieldsColumn() {
+        setupFieldsTable();
+
+        addFieldName.setPrefWidth(200.0);
+        addFieldName.setPromptText(Localization.lang("Field name"));
+        addFieldName.setOnAction(_ -> addField());
+        TextFields.bindAutoCompletion(
+                addFieldName,
+                FieldFactory.getAllFieldsWithOutInternal().stream()
+                            .map(Field::getName)
+                            .sorted()
+                            .toList());
+
+        Button addFieldButton = new Button(Localization.lang("Add"));
+        addFieldButton.setOnAction(_ -> addField());
+
+        addFieldName.disableProperty().bind(EasyBind.map(tabsTable.getSelectionModel().selectedItemProperty(),
+                tab -> (tab == null) || !tab.isCustom()));
+        addFieldButton.disableProperty().bind(addFieldName.disabledProperty().or(addFieldName.textProperty().isEmpty()));
+
+        Label regexInfo = new Label(Localization.lang("A field name can also be a regular expression, e.g. \"comment-.*\"."));
+        regexInfo.getStyleClass().add("italic");
+
+        Button resetButton = new Button(Localization.lang("Reset to default tabs"));
+        resetButton.setGraphic(IconTheme.JabRefIcons.REFRESH.getGraphicNode());
+        resetButton.setOnAction(_ -> resetTabs());
 
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
-        Button resetTabsButton = new Button();
-        resetTabsButton.setGraphic(IconTheme.JabRefIcons.REFRESH.getGraphicNode());
-        resetTabsButton.getStyleClass().add("icon-button");
-        resetTabsButton.setTooltip(new Tooltip(Localization.lang("Reset to default tabs")));
-        resetTabsButton.setOnAction(_ -> viewModel.resetToDefaults());
-        HBox buttonRow = new HBox(5.0, spacer, resetTabsButton);
+        HBox bottomRow = new HBox(GAP, addFieldName, addFieldButton, spacer, resetButton);
 
-        VBox region = new VBox(5.0, tabConfigsList, buttonRow);
-        VBox.setVgrow(region, Priority.ALWAYS);
-        return region;
+        VBox column = new VBox(GAP, fieldsTable, bottomRow, regexInfo);
+        HBox.setHgrow(column, Priority.ALWAYS);
+        return column;
     }
 
-    // region Cell
+    private void setupFieldsTable() {
+        fieldsTable.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        fieldsTable.setPrefHeight(300.0);
+        fieldsTable.setPlaceholder(fieldsPlaceholder);
+        VBox.setVgrow(fieldsTable, Priority.ALWAYS);
 
-    /// A tab with its visibility checkbox.
-    private class TabConfigCell extends ListCell<EntryEditorTabModel> {
+        TableColumn<String, String> patternColumn = new TableColumn<>(Localization.lang("Fields"));
+        patternColumn.setSortable(false);
+        patternColumn.setReorderable(false);
+        patternColumn.setCellValueFactory(cellData -> new ReadOnlyStringWrapper(cellData.getValue()));
 
-        private final CheckBox checkBox = new CheckBox();
-        private final Label nameLabel = new Label();
-        private final HBox container = new HBox(checkBox, nameLabel);
+        TableColumn<String, String> warningColumn = new TableColumn<>();
+        warningColumn.setMinWidth(40.0);
+        warningColumn.setMaxWidth(40.0);
+        warningColumn.setResizable(false);
+        warningColumn.setSortable(false);
+        warningColumn.setReorderable(false);
+        warningColumn.setCellValueFactory(cellData -> new ReadOnlyStringWrapper(cellData.getValue()));
+        new ValueTableCellFactory<String, String>()
+                .withGraphic(pattern -> viewModel.isFieldPatternDuplicated(pattern)
+                                        ? IconTheme.JabRefIcons.WARNING.getGraphicNode()
+                                        : null)
+                .withTooltip(pattern -> viewModel.isFieldPatternDuplicated(pattern)
+                                        ? Localization.lang("The field is contained in multiple tabs.")
+                                        : null)
+                .install(warningColumn);
 
-        private boolean updatingCell = false;
+        TableColumn<String, String> actionsColumn = new TableColumn<>();
+        actionsColumn.setMinWidth(40.0);
+        actionsColumn.setMaxWidth(40.0);
+        actionsColumn.setResizable(false);
+        actionsColumn.setSortable(false);
+        actionsColumn.setReorderable(false);
+        actionsColumn.setCellValueFactory(cellData -> new ReadOnlyStringWrapper(cellData.getValue()));
+        new ValueTableCellFactory<String, String>()
+                .withGraphic(_ -> IconTheme.JabRefIcons.DELETE_ENTRY.getGraphicNode())
+                .withTooltip(pattern -> Localization.lang("Remove field %0 from currently selected tab", pattern))
+                .withOnMouseClickedEvent(pattern -> _ -> {
+                    EditorTabViewModel tab = tabsTable.getSelectionModel().getSelectedItem();
+                    if (tab != null) {
+                        viewModel.removeFieldPattern(tab, pattern);
+                        fieldsTable.refresh();
+                    }
+                })
+                .install(actionsColumn);
 
-        TabConfigCell() {
-            container.getStyleClass().add("entry-editor-tab-cell");
-            checkBox.selectedProperty().addListener((_, _, selected) -> {
-                if (updatingCell) {
-                    return;
-                }
-                viewModel.toggleTabVisibility(getItem());
-            });
+        fieldsTable.getColumns().add(patternColumn);
+        fieldsTable.getColumns().add(warningColumn);
+        fieldsTable.getColumns().add(actionsColumn);
+
+        new ViewModelTableRowFactory<String>()
+                .setOnDragDetected((row, pattern, event) -> handleOnDragDetected(fieldsTable, DragAndDropDataFormats.FIELD, String.class, pattern, event))
+                .setOnDragDropped((row, pattern, event) -> handleOnDragDropped(fieldsTable, String.class, row, event))
+                .setOnDragOver((row, pattern, event) -> handleOnDragOver(DragAndDropDataFormats.FIELD, row, event))
+                .setOnDragExited((row, pattern, event) -> ControlHelper.removeDroppingPseudoClasses(row))
+                .install(fieldsTable);
+    }
+
+    private void addField() {
+        EditorTabViewModel tab = tabsTable.getSelectionModel().getSelectedItem();
+        if ((tab == null) || !tab.isCustom()) {
+            return;
         }
-
-        @Override
-        protected void updateItem(EntryEditorTabModel config, boolean empty) {
-            super.updateItem(config, empty);
-            if (empty || (config == null)) {
-                setGraphic(null);
-                return;
-            }
-            updatingCell = true;
-            if (config instanceof EntryEditorTabModel.BuiltInTab builtIn) {
-                checkBox.setSelected(builtIn.visible());
-                nameLabel.setText(builtIn.type().displayName());
-            }
-            updatingCell = false;
-            setGraphic(container);
+        if (viewModel.addFieldPattern(tab, addFieldName.getText())) {
+            addFieldName.clear();
+            // Recompute the warning cells: the new pattern may now be duplicated across tabs.
+            fieldsTable.refresh();
         }
+    }
+
+    private void resetTabs() {
+        boolean reset = dialogService.showConfirmationDialogAndWait(
+                Localization.lang("Reset to default tabs"),
+                Localization.lang("This will restore the default tabs and remove all custom tabs."),
+                Localization.lang("Reset to default tabs"));
+        if (reset) {
+            viewModel.resetToDefaults();
+            tabsTable.getSelectionModel().selectFirst();
+        }
+    }
+
+    // endregion
+
+    // region Drag & drop row reordering
+
+    private <T> void handleOnDragDetected(TableView<T> table, DataFormat format, Class<T> type, T item, MouseEvent event) {
+        ClipboardContent content = new ClipboardContent();
+        Dragboard dragboard = table.startDragAndDrop(TransferMode.MOVE);
+        content.put(format, "");
+        localDragboard.putValue(type, item);
+        dragboard.setContent(content);
+        event.consume();
+    }
+
+    private <T> void handleOnDragOver(DataFormat format, TableRow<T> row, DragEvent event) {
+        if (event.getDragboard().hasContent(format)) {
+            event.acceptTransferModes(TransferMode.MOVE);
+            ControlHelper.setDroppingPseudoClasses(row, event);
+        }
+    }
+
+    private <T> void handleOnDragDropped(TableView<T> table, Class<T> type, TableRow<T> row, DragEvent event) {
+        if (localDragboard.hasType(type)) {
+            T item = localDragboard.getValue(type);
+            table.getItems().remove(item);
+
+            if (row.isEmpty()) {
+                table.getItems().add(item);
+            } else {
+                // decide based on drop position whether to add the element before or after
+                int offset = event.getY() > (row.getHeight() / 2) ? 1 : 0;
+                table.getItems().add(row.getIndex() + offset, item);
+            }
+            table.getSelectionModel().select(item);
+        }
+        event.setDropCompleted(true);
+        event.consume();
     }
 
     // endregion

--- a/jabgui/src/main/java/org/jabref/gui/preferences/entryeditor/EntryEditorTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/entryeditor/EntryEditorTabViewModel.java
@@ -1,6 +1,9 @@
 package org.jabref.gui.preferences.entryeditor;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ListProperty;
@@ -25,6 +28,7 @@ import org.jabref.logic.util.BackgroundTask;
 import org.jabref.logic.util.Directories;
 import org.jabref.logic.util.TaskExecutor;
 import org.jabref.logic.util.URLUtil;
+import org.jabref.logic.util.strings.StringUtil;
 
 import com.tobiasdiez.easybind.EasyBind;
 import org.slf4j.Logger;
@@ -47,8 +51,8 @@ public class EntryEditorTabViewModel implements PreferenceTabViewModel {
             new SimpleListProperty<>(FXCollections.observableArrayList(CitationCountFetcherType.values()));
 
     /// Working copy of tab configurations — not the live preferences list.
-    /// Written to preferences only in [#storeSettings()].
-    private final ObservableList<EntryEditorTabModel> tabModels = FXCollections.observableArrayList();
+    /// Written to preferences only in [#storeSettings()]. Excludes the Preview tab (see [#setValues()]).
+    private final ObservableList<EditorTabViewModel> tabs = FXCollections.observableArrayList();
 
     private final DialogService dialogService;
     private final EntryEditorPreferences entryEditorPreferences;
@@ -75,9 +79,10 @@ public class EntryEditorTabViewModel implements PreferenceTabViewModel {
     public void setValues() {
         // The Preview tab is configured via the "show preview as a separate tab" preference, not here,
         // so it is omitted from the configurable tab list (its model visibility bit is unused).
-        tabModels.setAll(entryEditorPreferences.getTabModels().stream()
-                                               .filter(model -> !model.isPreview())
-                                               .toList());
+        tabs.setAll(entryEditorPreferences.getTabModels().stream()
+                                          .filter(model -> !model.isPreview())
+                                          .map(EditorTabViewModel::fromModel)
+                                          .toList());
 
         openOnNewEntryProperty.setValue(entryEditorPreferences.shouldOpenOnNewEntry());
         defaultSourceProperty.setValue(entryEditorPreferences.showSourceTabByDefault());
@@ -91,21 +96,66 @@ public class EntryEditorTabViewModel implements PreferenceTabViewModel {
         mscKeywordDescriptionsInitialized = true;
     }
 
+    /// Restores the default tab set: every built-in tab visible in default order, no custom tabs.
     public void resetToDefaults() {
-        for (int i = 0; i < tabModels.size(); i++) {
-            if (tabModels.get(i) instanceof EntryEditorTabModel.BuiltInTab builtIn && !builtIn.isVisible()) {
-                tabModels.set(i, builtIn.withVisible(true));
-            }
+        tabs.setAll(EntryEditorPreferences.getDefault().getTabModels().stream()
+                                          .filter(model -> !model.isPreview())
+                                          .map(EditorTabViewModel::fromModel)
+                                          .toList());
+    }
+
+    /// Adds a custom tab with the given name, or returns the existing tab when one with that name
+    /// (custom or built-in, compared case-insensitively) is already present. Empty for a blank name.
+    public Optional<EditorTabViewModel> addCustomTab(String name) {
+        if (StringUtil.isBlank(name)) {
+            return Optional.empty();
+        }
+        String trimmed = name.trim();
+        Optional<EditorTabViewModel> existing = tabs.stream()
+                                                    .filter(tab -> tab.getDisplayName().equalsIgnoreCase(trimmed))
+                                                    .findFirst();
+        if (existing.isPresent()) {
+            return existing;
+        }
+        EditorTabViewModel tab = EditorTabViewModel.newCustomTab(trimmed);
+        tabs.add(tab);
+        return Optional.of(tab);
+    }
+
+    public void removeTab(EditorTabViewModel tab) {
+        if (tab.isCustom()) {
+            tabs.remove(tab);
         }
     }
 
-    /// Toggles the visibility of a tab. Called by the cell's checkbox.
-    public void toggleTabVisibility(EntryEditorTabModel config) {
-        int index = tabModels.indexOf(config);
-        if (index < 0) {
-            return;
+    /// Adds a field pattern to the given custom tab; `false` if the pattern is blank or already on that tab.
+    public boolean addFieldPattern(EditorTabViewModel tab, String pattern) {
+        if (StringUtil.isBlank(pattern)) {
+            return false;
         }
-        tabModels.set(index, config.withVisible(!config.isVisible()));
+        String trimmed = pattern.trim();
+        if (containsIgnoreCase(tab.getFieldPatterns(), trimmed)) {
+            return false;
+        }
+        tab.getFieldPatterns().add(trimmed);
+        return true;
+    }
+
+    public void removeFieldPattern(EditorTabViewModel tab, String pattern) {
+        tab.getFieldPatterns().remove(pattern);
+    }
+
+    /// `true` if the pattern occurs on more than one tab (duplicates within one tab are prevented on add) —
+    /// the fields table shows a warning sign on such rows. Literal comparison only; overlap between a regex
+    /// pattern and the field names it captures is not detected.
+    public boolean isFieldPatternDuplicated(String pattern) {
+        return tabs.stream()
+                   .filter(tab -> containsIgnoreCase(tab.getFieldPatterns(), pattern))
+                   .count() > 1;
+    }
+
+    private static boolean containsIgnoreCase(List<String> patterns, String pattern) {
+        return patterns.stream().anyMatch(existing -> existing.equalsIgnoreCase(pattern));
     }
 
     @Override
@@ -122,21 +172,20 @@ public class EntryEditorTabViewModel implements PreferenceTabViewModel {
         entryEditorPreferences.setCitationCountFetcherType(citationCountFetcherTypeProperty.getValue());
         abbreviationPreferences.setShouldEnableMscKeywordDescriptions(enableMscKeywordDescriptionsProperty.getValue());
 
-        // Write tab visibility from the working copy
-        for (EntryEditorTabModel tabModel : tabModels) {
-            if (tabModel instanceof EntryEditorTabModel.BuiltInTab(
-                    EntryEditorTabModel.BuiltIn key,
-                    boolean _
-            )) {
-                entryEditorPreferences.setTabVisible(key, tabModel.isVisible());
-            }
-        }
+        // Replace the tab list wholesale from the working copy: the Preview tab (filtered out in
+        // setValues()) stays in front, everything else takes the working copy's order and content.
+        List<EntryEditorTabModel> newModels = new ArrayList<>();
+        entryEditorPreferences.getTabModels().stream()
+                              .filter(EntryEditorTabModel::isPreview)
+                              .forEach(newModels::add);
+        tabs.stream().map(EditorTabViewModel::toModel).forEach(newModels::add);
+        entryEditorPreferences.getTabModels().setAll(newModels);
     }
 
     // region Properties
 
-    public ObservableList<EntryEditorTabModel> getTabModels() {
-        return tabModels;
+    public ObservableList<EditorTabViewModel> getTabs() {
+        return tabs;
     }
 
     public BooleanProperty openOnNewEntryProperty() {

--- a/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -2,8 +2,10 @@ package org.jabref.migrations;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.SequencedMap;
 import java.util.function.UnaryOperator;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
@@ -31,6 +33,7 @@ import org.jabref.model.entry.types.EntryTypeFactory;
 import com.github.javakeyring.Keyring;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
 
 public class PreferencesMigrations {
 
@@ -65,6 +68,33 @@ public class PreferencesMigrations {
         upgradeResolveBibTeXStringsFields(preferences);
         upgradeTheme(preferences);
         migrateFileAnnotationsTabVisibility(preferences);
+        upgradeEntryEditorCustomTabs(preferences);
+    }
+
+    /// Up to and including v6.0-alpha.6, custom entry editor tabs were stored in two parallel numbered
+    /// series (`customTabName_0`/`customTabFields_0`, ...). Since [#16598](https://github.com/JabRef/jabref/pull/16598)
+    /// they are stored as one JSON object (`{"tab name": ["field pattern",...], ...}`, see
+    /// [JabRefGuiPreferences#ENTRY_EDITOR_CUSTOM_TABS]). The old keys are kept in case an old version of
+    /// JabRef is used with these preferences; they are only read when the new key does not exist yet.
+    static void upgradeEntryEditorCustomTabs(JabRefGuiPreferences prefs) {
+        final String V6_0_ALPHA_CUSTOM_TAB_NAME = "customTabName_";
+        final String V6_0_ALPHA_CUSTOM_TAB_FIELDS = "customTabFields_";
+
+        if (prefs.get(JabRefGuiPreferences.ENTRY_EDITOR_CUSTOM_TABS, null) != null) {
+            return;
+        }
+
+        SequencedMap<String, List<String>> customTabs = new LinkedHashMap<>();
+        String tabName;
+        for (int i = 0; (tabName = prefs.get(V6_0_ALPHA_CUSTOM_TAB_NAME + i, null)) != null; i++) {
+            customTabs.put(tabName, prefs.getStringList(V6_0_ALPHA_CUSTOM_TAB_FIELDS + i));
+        }
+        if (customTabs.isEmpty()) {
+            return;
+        }
+
+        LOGGER.info("Migrating {} custom entry editor tab(s) to the JSON preference format.", customTabs.size());
+        prefs.put(JabRefGuiPreferences.ENTRY_EDITOR_CUSTOM_TABS, new ObjectMapper().writeValueAsString(customTabs));
     }
 
     /// The legacy key `smartFileAnnotations` toggled a "smart visibility" mode. Mode was adapted for all tabs in

--- a/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -73,14 +73,15 @@ public class PreferencesMigrations {
 
     /// Up to and including v6.0-alpha.6, custom entry editor tabs were stored in two parallel numbered
     /// series (`customTabName_0`/`customTabFields_0`, ...). Since [#16598](https://github.com/JabRef/jabref/pull/16598)
-    /// they are stored as one JSON object (`{"tab name": ["field pattern",...], ...}`, see
-    /// [JabRefGuiPreferences#ENTRY_EDITOR_CUSTOM_TABS]). The old keys are kept in case an old version of
-    /// JabRef is used with these preferences; they are only read when the new key does not exist yet.
+    /// they are stored as one JSON object, `{"tab name": ["field pattern", ...], ...}`. The old keys are
+    /// kept in case an old version of JabRef is used with these preferences; they are only read when the
+    /// new key does not exist yet.
     static void upgradeEntryEditorCustomTabs(JabRefGuiPreferences prefs) {
         final String V6_0_ALPHA_CUSTOM_TAB_NAME = "customTabName_";
         final String V6_0_ALPHA_CUSTOM_TAB_FIELDS = "customTabFields_";
+        final String V6_0_ENTRY_EDITOR_CUSTOM_TABS = "entryEditorCustomTabs";
 
-        if (prefs.get(JabRefGuiPreferences.ENTRY_EDITOR_CUSTOM_TABS, null) != null) {
+        if (prefs.get(V6_0_ENTRY_EDITOR_CUSTOM_TABS, null) != null) {
             return;
         }
 
@@ -94,7 +95,7 @@ public class PreferencesMigrations {
         }
 
         LOGGER.info("Migrating {} custom entry editor tab(s) to the JSON preference format.", customTabs.size());
-        prefs.put(JabRefGuiPreferences.ENTRY_EDITOR_CUSTOM_TABS, new ObjectMapper().writeValueAsString(customTabs));
+        prefs.put(V6_0_ENTRY_EDITOR_CUSTOM_TABS, new ObjectMapper().writeValueAsString(customTabs));
     }
 
     /// The legacy key `smartFileAnnotations` toggled a "smart visibility" mode. Mode was adapted for all tabs in

--- a/jabgui/src/test/java/org/jabref/gui/entryeditor/EntryEditorTabModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/entryeditor/EntryEditorTabModelTest.java
@@ -1,0 +1,56 @@
+package org.jabref.gui.entryeditor;
+
+import java.util.List;
+
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.field.UnknownField;
+import org.jabref.model.entry.field.UserSpecificCommentField;
+import org.jabref.model.entry.types.StandardEntryType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EntryEditorTabModelTest {
+
+    private final BibEntry entry = new BibEntry(StandardEntryType.Article)
+            .withField(StandardField.AUTHOR, "Author")
+            .withField(StandardField.COMMENT, "general comment")
+            .withField(new UserSpecificCommentField("alice"), "alice's comment")
+            .withField(new UserSpecificCommentField("bob"), "bob's comment");
+
+    private static List<Field> resolve(BibEntry entry, String... patterns) {
+        return List.copyOf(new EntryEditorTabModel.CustomizedFieldsTab("Test", List.of(patterns)).resolveFields(entry));
+    }
+
+    @Test
+    void plainFieldNamesAreAlwaysShownEvenWhenUnset() {
+        assertEquals(List.of(StandardField.AUTHOR, StandardField.URL), resolve(entry, "author", "url"));
+    }
+
+    @Test
+    void unknownPlainFieldNameResolvesToUnknownField() {
+        assertEquals(List.of(new UnknownField("myfield")), resolve(entry, "myfield"));
+    }
+
+    @Test
+    void regexPatternCapturesMatchingSetFields() {
+        assertEquals(
+                List.of(new UserSpecificCommentField("alice"), new UserSpecificCommentField("bob")),
+                resolve(entry, "comment-.*"));
+    }
+
+    @Test
+    void patternOrderIsKept() {
+        assertEquals(
+                List.of(StandardField.AUTHOR, new UserSpecificCommentField("alice"), new UserSpecificCommentField("bob"), StandardField.COMMENT),
+                resolve(entry, "author", "comment-.*", "comment"));
+    }
+
+    @Test
+    void invalidRegexResolvesToNothing() {
+        assertEquals(List.of(StandardField.AUTHOR), resolve(entry, "author", "comment-["));
+    }
+}

--- a/jabgui/src/test/java/org/jabref/gui/preferences/JabRefGuiPreferencesTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/preferences/JabRefGuiPreferencesTest.java
@@ -1,0 +1,50 @@
+package org.jabref.gui.preferences;
+
+import java.util.List;
+
+import org.jabref.gui.entryeditor.EntryEditorTabModel;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JabRefGuiPreferencesTest {
+
+    private static final EntryEditorTabModel PREVIEW =
+            new EntryEditorTabModel.BuiltInTab(EntryEditorTabModel.BuiltIn.PREVIEW, true);
+    private static final EntryEditorTabModel MAIN =
+            new EntryEditorTabModel.BuiltInTab(EntryEditorTabModel.BuiltIn.ALL_FIELDS, true);
+    private static final EntryEditorTabModel SOURCE =
+            new EntryEditorTabModel.BuiltInTab(EntryEditorTabModel.BuiltIn.SOURCE, true);
+
+    @Test
+    void storedTabOrderIsApplied() {
+        List<EntryEditorTabModel> ordered = JabRefGuiPreferences.applyStoredTabOrder(
+                List.of(PREVIEW, MAIN, SOURCE),
+                List.of("SOURCE", "ALL_FIELDS"));
+
+        assertEquals(List.of(PREVIEW, SOURCE, MAIN), ordered);
+    }
+
+    @Test
+    void tabsUnknownToStoredOrderAreAppendedInDefaultOrder() {
+        List<EntryEditorTabModel> ordered = JabRefGuiPreferences.applyStoredTabOrder(
+                List.of(PREVIEW, MAIN, SOURCE),
+                List.of("SOURCE"));
+
+        assertEquals(List.of(PREVIEW, SOURCE, MAIN), ordered);
+    }
+
+    @Test
+    void duplicateCustomTabNamesAreAllKept() {
+        EntryEditorTabModel first = new EntryEditorTabModel.CustomizedFieldsTab("General", List.of("keywords"));
+        EntryEditorTabModel second = new EntryEditorTabModel.CustomizedFieldsTab("General", List.of("doi"));
+
+        List<EntryEditorTabModel> ordered = JabRefGuiPreferences.applyStoredTabOrder(
+                List.of(PREVIEW, MAIN, first, second),
+                List.of("custom:General", "ALL_FIELDS"));
+
+        // The stored-order entry consumes the first duplicate; the second survives at the end.
+        assertEquals(List.of(PREVIEW, first, MAIN, second), ordered);
+    }
+}

--- a/jabgui/src/test/java/org/jabref/gui/preferences/entryeditor/EntryEditorTabViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/preferences/entryeditor/EntryEditorTabViewModelTest.java
@@ -1,7 +1,10 @@
 package org.jabref.gui.preferences.entryeditor;
 
+import java.util.List;
+
 import org.jabref.gui.DialogService;
 import org.jabref.gui.entryeditor.EntryEditorPreferences;
+import org.jabref.gui.entryeditor.EntryEditorTabModel;
 import org.jabref.logic.importer.fetcher.MrDlibPreferences;
 import org.jabref.logic.journals.AbbreviationPreferences;
 import org.jabref.logic.l10n.Localization;
@@ -10,7 +13,9 @@ import org.jabref.logic.util.TaskExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -21,18 +26,83 @@ import static org.mockito.Mockito.when;
 class EntryEditorTabViewModelTest {
 
     private DialogService dialogService;
+    private EntryEditorPreferences entryEditorPreferences;
     private EntryEditorTabViewModel viewModel;
 
     @BeforeEach
     void setUp() {
         dialogService = mock(DialogService.class);
+        entryEditorPreferences = EntryEditorPreferences.getDefault();
 
         viewModel = new EntryEditorTabViewModel(
                 dialogService,
-                EntryEditorPreferences.getDefault(),
+                entryEditorPreferences,
                 MrDlibPreferences.getDefault(),
                 AbbreviationPreferences.getDefault(),
                 mock(TaskExecutor.class));
+    }
+
+    @Test
+    void customTabRoundTripsThroughStoreSettings() {
+        viewModel.setValues();
+
+        EditorTabViewModel tab = viewModel.addCustomTab("General").orElseThrow();
+        assertTrue(viewModel.addFieldPattern(tab, "keywords"));
+        assertTrue(viewModel.addFieldPattern(tab, "comment-.*"));
+        // duplicates within the same tab are rejected
+        assertFalse(viewModel.addFieldPattern(tab, "Keywords"));
+
+        viewModel.storeSettings();
+
+        assertEquals(
+                new EntryEditorTabModel.CustomizedFieldsTab("General", List.of("keywords", "comment-.*")),
+                entryEditorPreferences.getTabModels().getLast());
+        // Preview stays in front even though the working copy excludes it
+        assertTrue(entryEditorPreferences.getTabModels().getFirst().isPreview());
+    }
+
+    @Test
+    void addCustomTabWithExistingNameReturnsExistingTab() {
+        viewModel.setValues();
+        EditorTabViewModel tab = viewModel.addCustomTab("General").orElseThrow();
+        int tabCount = viewModel.getTabs().size();
+
+        assertEquals(tab, viewModel.addCustomTab("general").orElseThrow());
+        assertEquals(tabCount, viewModel.getTabs().size());
+    }
+
+    @Test
+    void fieldPatternOnMultipleTabsIsFlaggedAsDuplicate() {
+        viewModel.setValues();
+        EditorTabViewModel first = viewModel.addCustomTab("First").orElseThrow();
+        EditorTabViewModel second = viewModel.addCustomTab("Second").orElseThrow();
+        viewModel.addFieldPattern(first, "keywords");
+        viewModel.addFieldPattern(first, "doi");
+        viewModel.addFieldPattern(second, "keywords");
+
+        assertTrue(viewModel.isFieldPatternDuplicated("keywords"));
+        assertFalse(viewModel.isFieldPatternDuplicated("doi"));
+    }
+
+    @Test
+    void tabOrderIsStored() {
+        viewModel.setValues();
+        EditorTabViewModel first = viewModel.getTabs().removeFirst();
+        viewModel.getTabs().add(first);
+
+        viewModel.storeSettings();
+
+        assertEquals(first.toModel(), entryEditorPreferences.getTabModels().getLast());
+    }
+
+    @Test
+    void resetToDefaultsRemovesCustomTabs() {
+        viewModel.setValues();
+        viewModel.addCustomTab("General");
+
+        viewModel.resetToDefaults();
+
+        assertTrue(viewModel.getTabs().stream().noneMatch(EditorTabViewModel::isCustom));
     }
 
     @Test

--- a/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
+++ b/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
@@ -303,4 +303,28 @@ class GuiPreferencesMigrationsTest {
 
         verify(workspacePreferences).setTheme(Theme.light());
     }
+
+    @Test
+    void upgradeEntryEditorCustomTabsConvertsSeriesToJson() {
+        when(preferences.get(eq(JabRefGuiPreferences.ENTRY_EDITOR_CUSTOM_TABS), any())).thenReturn(null);
+        when(preferences.get(eq("customTabName_0"), any())).thenReturn("General");
+        when(preferences.getStringList("customTabFields_0")).thenReturn(List.of("keywords", "doi"));
+        when(preferences.get(eq("customTabName_1"), any())).thenReturn("Abstract");
+        when(preferences.getStringList("customTabFields_1")).thenReturn(List.of("abstract"));
+        when(preferences.get(eq("customTabName_2"), any())).thenReturn(null);
+
+        PreferencesMigrations.upgradeEntryEditorCustomTabs(preferences);
+
+        verify(preferences).put(JabRefGuiPreferences.ENTRY_EDITOR_CUSTOM_TABS,
+                "{\"General\":[\"keywords\",\"doi\"],\"Abstract\":[\"abstract\"]}");
+    }
+
+    @Test
+    void upgradeEntryEditorCustomTabsKeepsExistingJson() {
+        when(preferences.get(eq(JabRefGuiPreferences.ENTRY_EDITOR_CUSTOM_TABS), any())).thenReturn("{\"General\":[\"keywords\"]}");
+
+        PreferencesMigrations.upgradeEntryEditorCustomTabs(preferences);
+
+        verify(preferences, never()).put(eq(JabRefGuiPreferences.ENTRY_EDITOR_CUSTOM_TABS), anyString());
+    }
 }

--- a/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
+++ b/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
@@ -306,7 +306,7 @@ class GuiPreferencesMigrationsTest {
 
     @Test
     void upgradeEntryEditorCustomTabsConvertsSeriesToJson() {
-        when(preferences.get(eq(JabRefGuiPreferences.ENTRY_EDITOR_CUSTOM_TABS), any())).thenReturn(null);
+        when(preferences.get(eq("entryEditorCustomTabs"), any())).thenReturn(null);
         when(preferences.get(eq("customTabName_0"), any())).thenReturn("General");
         when(preferences.getStringList("customTabFields_0")).thenReturn(List.of("keywords", "doi"));
         when(preferences.get(eq("customTabName_1"), any())).thenReturn("Abstract");
@@ -315,16 +315,16 @@ class GuiPreferencesMigrationsTest {
 
         PreferencesMigrations.upgradeEntryEditorCustomTabs(preferences);
 
-        verify(preferences).put(JabRefGuiPreferences.ENTRY_EDITOR_CUSTOM_TABS,
+        verify(preferences).put("entryEditorCustomTabs",
                 "{\"General\":[\"keywords\",\"doi\"],\"Abstract\":[\"abstract\"]}");
     }
 
     @Test
     void upgradeEntryEditorCustomTabsKeepsExistingJson() {
-        when(preferences.get(eq(JabRefGuiPreferences.ENTRY_EDITOR_CUSTOM_TABS), any())).thenReturn("{\"General\":[\"keywords\"]}");
+        when(preferences.get(eq("entryEditorCustomTabs"), any())).thenReturn("{\"General\":[\"keywords\"]}");
 
         PreferencesMigrations.upgradeEntryEditorCustomTabs(preferences);
 
-        verify(preferences, never()).put(eq(JabRefGuiPreferences.ENTRY_EDITOR_CUSTOM_TABS), anyString());
+        verify(preferences, never()).put(eq("entryEditorCustomTabs"), anyString());
     }
 }

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -2206,6 +2206,18 @@ There\ already\ exists\ an\ external\ file\ type\ with\ the\ same\ name=There al
 # EntryEditor tabs
 Editor\ tabs=Editor tabs
 Reset\ to\ default\ tabs=Reset to default tabs
+Tabs=Tabs
+Fields=Fields
+Tab\ name...=Tab name...
+Add\ new\ tab=Add new tab
+Remove\ tab\ %0=Remove tab %0
+Select\ a\ tab\ to\ configure\ its\ fields.=Select a tab to configure its fields.
+The\ content\ of\ built-in\ tabs\ is\ fixed.=The content of built-in tabs is fixed.
+This\ tab\ has\ no\ fields\ yet.=This tab has no fields yet.
+The\ field\ is\ contained\ in\ multiple\ tabs.=The field is contained in multiple tabs.
+Remove\ field\ %0\ from\ currently\ selected\ tab=Remove field %0 from currently selected tab
+A\ field\ name\ can\ also\ be\ a\ regular\ expression,\ e.g.\ "comment-.*".=A field name can also be a regular expression, e.g. "comment-.*".
+This\ will\ restore\ the\ default\ tabs\ and\ remove\ all\ custom\ tabs.=This will restore the default tabs and remove all custom tabs.
 Fulltext\ search\ results=Fulltext search results
 
 See\ full\ report=See full report


### PR DESCRIPTION
### Summary

🤖 The entry editor rework (#16166) dropped support for user-defined ("custom") entry editor tabs, which broke existing user configurations (#16594). This PR brings custom tabs back and reworks the "Editor tabs" preferences into a two-column editor modeled on the "Custom entry types" page: a **Tabs** column (visibility checkboxes for built-in tabs, add/remove for custom tabs, drag-and-drop reordering for all tabs) and a **Fields** column editing the selected custom tab's ordered field list, where a field name may also be a regular expression (e.g. `comment-.*`) and a field contained in multiple tabs is flagged with a warning sign. Custom tabs are stored as a JSON map (`{"tab name": ["field pattern", ...], ...}`) under a single preference key (serialized with Jackson, which jabgui already uses); the pre-rework keys are read as a migration fallback and purged on the next store, so tabs configured in older versions (e.g. v6.0-alpha.6) are picked up again automatically.

`jabref-contrib-policy:4.2:reviewed​:ok`

**Analogies:** Like honey, this PR preserves what users already gathered — custom tab configurations from older versions flow back in unspoiled. Like chocolate, it is composed of familiar ingredients (the proven "Custom entry types" two-column design) recombined into something immediately recognizable and easy to consume. And like the moon, the custom tabs disappeared for a phase but were never truly gone — this PR completes the cycle and brings them back into full view, with regex support as the new bright side.

### Steps to test

1. Open **File → Preferences → Entry editor** and scroll to the **Editor tabs** section.
2. In the **Tabs** column, type a name (e.g. `General`) into "Tab name..." and press <kbd>Enter</kbd> — the custom tab appears and is selected.
3. In the **Fields** column, add fields (e.g. `keywords`, `doi`, `comment-.*`) via the "Field name" box (autocompletion offers known field names).
4. Drag rows in either column to reorder tabs and fields.
5. Add the same field to a second custom tab — a warning sign appears next to it in the Fields column.
6. Save, open an entry: the custom tabs appear in the entry editor in the configured order, showing the configured fields. Setting a field matching a regex pattern (e.g. `comment-test` in the Main or source tab) makes it appear on the custom tab immediately.
7. Restart JabRef: the custom tabs are still there. Users upgrading from v6.0-alpha.6 or earlier get their previously configured custom tabs back automatically.

Preferences UI:

![Editor tabs preferences](https://raw.githubusercontent.com/JabRef/jabref-koppor/assets-entry-editor-custom-tabs/editor-tabs-preferences.png)

Custom "General" tab in the entry editor with a `comment-test` field captured by the `comment-.*` pattern:

![General tab with regex-captured field](https://raw.githubusercontent.com/JabRef/jabref-koppor/assets-entry-editor-custom-tabs/general-tab-regex.png)

Library with a single test entry:

![Single entry 16594](https://raw.githubusercontent.com/JabRef/jabref-koppor/assets-entry-editor-custom-tabs/single-entry-16594.png)

### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/16594

User documentation PR: https://github.com/JabRef/user-documentation/pull/659

### AI usage

Claude Code (model claude-fable-5), AIL4 — the implementation was AI-generated under human direction; the change was manually tested in a running JabRef.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead. (Remaining `(tab == null)` checks are JavaFX selection-model states in the view, matching surrounding code; `(model != null)` guards a possibly-absent drag payload.)
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [x] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [x] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [x] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [x] No `catch (Exception e)` — only `PatternSyntaxException` is caught (invalid user regex resolves to no fields).
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)`.
- [/] Logged exceptions are passed as the last logger argument — no logging added.

### Style and idioms

- [x] New `BibEntry` objects built with withers (`withField`, not `setField`) — in tests.
- [x] Modern Java used: `List.of()` / `List.copyOf()`, `SequencedSet`, records, pattern-matching switch.
- [x] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)` (the user-supplied patterns are compiled per resolution, which is inherent to the feature).
- [/] Background work uses `BackgroundTask` — no background work added.
- [x] No commented-out code, no trivial comments, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags.

### User-facing text

- [x] All user-facing text localized (`Localization.lang`).
- [x] Sentence case; no trailing `!`; labels do not end with `:`.
- [x] Variance expressed with placeholders (`"Remove tab %0"`), not string concatenation.

### Security

- [/] No `text/html` responses touched.

### Tests

- [x] Behavior changes covered: `EntryEditorTabModelTest` (pattern resolution: literals, regex, order, invalid regex) and extended `EntryEditorTabViewModelTest` (add/remove custom tabs, duplicate detection, order round-trip, reset).
- [x] Tests assert object contents with plain JUnit asserts, no `@DisplayName`, no caught exceptions, no manual temp directories.

## 2. Verification commands

- [x] `xvfb-run -a ./gradlew :jablib:test --tests "*LocalizationConsistency*"` passed (jablib change is localization keys only; GUI tests for the touched classes pass via `:jabgui:test`).
- [x] `./gradlew :jabgui:checkstyleMain :jabgui:checkstyleTest` passed.
- [x] `./gradlew :jabgui:modernizer` passed.
- [x] `./gradlew --no-configuration-cache :rewriteRun` applied, no remaining diff.
- [x] Touched Java files reformatted with IntelliJ IDEA using `.idea/codeStyles/Project.xml` (`idea format`).
- [/] `npx markdownlint-cli2` — only `CHANGELOG.md`/`docs/requirements` list entries changed, following existing formatting.
- [/] Docker IntelliJ format — not needed, `idea format` was run directly.

## 3. Documentation

- [x] `CHANGELOG.md`: updated the existing "Changed" entry for the tab preferences rework and softened the "Removed" entry (the removal itself was unreleased); linked #16594.
- [x] Issue linked: https://github.com/JabRef/jabref/issues/16594 (confident match — this PR restores the removed capability).
- [x] Requirement added: `req~entry-editor.custom-tabs~1` in `docs/requirements/entry-editor.md`, with `[impl->...]` tags in code.
- [/] Developer documentation under `docs/` — no architecture change beyond the requirement entry.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file`.
- [/] CHANGELOG uses the issue link, no `TODO` placeholder.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
