### PR TITLE
Keep external change detection active while saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed missed external-change detection while JabRef saves a library, so concurrent changes can be reviewed for resolution. [TODO](https://github.com/JabRef/jabref/pull/TODO)
+- We fixed missed external-change detection while JabRef saves a library, so concurrent changes can be reviewed for resolution. [#16613](https://github.com/JabRef/jabref/pull/16613)
 - We fixed an issue where full-text search in linked files was not working when the experimental Postgres search backend is disabled. [#16591](https://github.com/JabRef/jabref/pull/16591)
 - We fixed unreadable notification text and icons when using the dark theme. [#16475](https://github.com/JabRef/jabref/issues/16475)
 - We fixed an issue where removing filtered entries from a group could cause JabRef to throw an exception. [#16541](https://github.com/JabRef/jabref/issues/16541)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed missed external-change detection while JabRef saves a library, so concurrent changes can be reviewed for resolution. [TODO](https://github.com/JabRef/jabref/pull/TODO)
 - We fixed an issue where full-text search in linked files was not working when the experimental Postgres search backend is disabled. [#16591](https://github.com/JabRef/jabref/pull/16591)
 - We fixed unreadable notification text and icons when using the dark theme. [#16475](https://github.com/JabRef/jabref/issues/16475)
 - We fixed an issue where removing filtered entries from a group could cause JabRef to throw an exception. [#16541](https://github.com/JabRef/jabref/issues/16541)

--- a/docs/requirements/ux.md
+++ b/docs/requirements/ux.md
@@ -96,4 +96,11 @@ When a user creates a new explicit group, JabRef should allow reusing the curren
 
 Needs: impl
 
+### Saving keeps external change detection active
+`req~ux.external-library-changes.after-save~1`
+
+When JabRef saves a library, it must keep observing filesystem changes, defer change detection until the save has finished, and then inspect the resulting file for external changes that require conflict resolution.
+
+Needs: impl
+
 <!-- markdownlint-disable-file MD022 -->

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -817,12 +817,12 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
                 stateManager));
     }
 
-    public void suspendChangeMonitor() {
-        changeMonitor.ifPresent(DatabaseChangeMonitor::unregister);
+    public void suspendChangeDetection() {
+        changeMonitor.ifPresent(DatabaseChangeMonitor::suspendChangeDetection);
     }
 
-    public void resumeChangeMonitor() {
-        bibDatabaseContext.getDatabasePath().ifPresent(_ -> resetChangeMonitor());
+    public void resumeChangeDetection() {
+        changeMonitor.ifPresent(DatabaseChangeMonitor::resumeChangeDetection);
     }
 
     public void insertEntry(final BibEntry bibEntry) {

--- a/jabgui/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
@@ -39,6 +39,7 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
     private final StateManager stateManager;
     private final Optional<Path> monitoredPath;
     private LibraryTab saveState;
+    private boolean changeDetectionSuspended;
 
     public DatabaseChangeMonitor(BibDatabaseContext database,
                                  FileUpdateMonitor fileMonitor,
@@ -118,17 +119,38 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
     @Override
     public void fileUpdated() {
         synchronized (database) {
-            // File on disk has changed, thus look for notable changes and notify listeners in case there are such changes
-            ChangeScanner scanner = new ChangeScanner(database, dialogService, preferences, stateManager);
-            BackgroundTask.wrap(scanner::scanForChanges)
-                          .onSuccess(changes -> {
-                              if (!changes.isEmpty()) {
-                                  listeners.forEach(listener -> listener.databaseChanged(changes));
-                              }
-                          })
-                          .onFailure(e -> LOGGER.error("Error while watching for changes", e))
-                          .executeWith(taskExecutor);
+            if (!changeDetectionSuspended) {
+                scanForChanges();
+            }
         }
+    }
+
+    public void suspendChangeDetection() {
+        synchronized (database) {
+            changeDetectionSuspended = true;
+        }
+    }
+
+    public void resumeChangeDetection() {
+        synchronized (database) {
+            changeDetectionSuspended = false;
+            scanForChanges();
+        }
+    }
+
+    // [impl->req~ux.external-library-changes.after-save~1]
+    private void scanForChanges() {
+        // File watchers can report JabRef's own write or an external change while saving. Scanning once after the
+        // save finishes avoids reacting to an incomplete file and still detects an external write that occurred then.
+        ChangeScanner scanner = new ChangeScanner(database, dialogService, preferences, stateManager);
+        BackgroundTask.wrap(scanner::scanForChanges)
+                      .onSuccess(changes -> {
+                          if (!changes.isEmpty()) {
+                              listeners.forEach(listener -> listener.databaseChanged(changes));
+                          }
+                      })
+                      .onFailure(e -> LOGGER.error("Error while watching for changes", e))
+                      .executeWith(taskExecutor);
     }
 
     public void addListener(DatabaseChangeListener listener) {

--- a/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -222,7 +222,7 @@ public class SaveDatabaseAction {
             libraryTab.setSaving(true);
         }
 
-        libraryTab.suspendChangeMonitor();
+        libraryTab.suspendChangeDetection();
 
         try {
             Charset encoding = libraryTab.getBibDatabaseContext()
@@ -246,7 +246,7 @@ public class SaveDatabaseAction {
             dialogService.showErrorDialogAndWait(Localization.lang("Save library"), Localization.lang("Could not save file."), ex);
             return false;
         } finally {
-            libraryTab.resumeChangeMonitor();
+            libraryTab.resumeChangeDetection();
             // release panel from save status
             libraryTab.setSaving(false);
         }

--- a/jabgui/src/test/java/org/jabref/gui/collab/DatabaseChangeMonitorTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/collab/DatabaseChangeMonitorTest.java
@@ -17,9 +17,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class DatabaseChangeMonitorTest {
@@ -49,5 +52,82 @@ class DatabaseChangeMonitorTest {
         monitor.unregister();
 
         verify(fileUpdateMonitor).removeListener(eq(originalPath), eq(listenerCaptor.getValue()));
+    }
+
+    @Test
+    void suspendChangeDetectionKeepsWatchingAndRescansOnResume(@TempDir Path tempDir) throws Exception {
+        Path monitoredPath = tempDir.resolve("library.bib");
+        BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
+        when(databaseContext.getDatabasePath()).thenReturn(Optional.of(monitoredPath));
+
+        FileUpdateMonitor fileUpdateMonitor = mock(FileUpdateMonitor.class);
+        TaskExecutor taskExecutor = mock(TaskExecutor.class);
+        DatabaseChangeMonitor monitor = new DatabaseChangeMonitor(
+                databaseContext,
+                fileUpdateMonitor,
+                taskExecutor,
+                mock(DialogService.class),
+                mock(GuiPreferences.class),
+                mock(UndoManager.class),
+                mock(StateManager.class));
+
+        monitor.suspendChangeDetection();
+        monitor.fileUpdated();
+
+        verify(fileUpdateMonitor).addListenerForFile(eq(monitoredPath), eq(monitor));
+        verify(fileUpdateMonitor, never()).removeListener(eq(monitoredPath), eq(monitor));
+        verifyNoInteractions(taskExecutor);
+
+        monitor.resumeChangeDetection();
+
+        verify(taskExecutor).execute(any());
+    }
+
+    @Test
+    void fileUpdateSchedulesScanWhenChangeDetectionIsActive(@TempDir Path tempDir) throws Exception {
+        Path monitoredPath = tempDir.resolve("library.bib");
+        BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
+        when(databaseContext.getDatabasePath()).thenReturn(Optional.of(monitoredPath));
+
+        TaskExecutor taskExecutor = mock(TaskExecutor.class);
+        DatabaseChangeMonitor monitor = new DatabaseChangeMonitor(
+                databaseContext,
+                mock(FileUpdateMonitor.class),
+                taskExecutor,
+                mock(DialogService.class),
+                mock(GuiPreferences.class),
+                mock(UndoManager.class),
+                mock(StateManager.class));
+
+        monitor.fileUpdated();
+
+        verify(taskExecutor).execute(any());
+    }
+
+    @Test
+    void multipleFileUpdatesDuringSuspensionScheduleOneScanOnResume(@TempDir Path tempDir) throws Exception {
+        Path monitoredPath = tempDir.resolve("library.bib");
+        BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
+        when(databaseContext.getDatabasePath()).thenReturn(Optional.of(monitoredPath));
+
+        TaskExecutor taskExecutor = mock(TaskExecutor.class);
+        DatabaseChangeMonitor monitor = new DatabaseChangeMonitor(
+                databaseContext,
+                mock(FileUpdateMonitor.class),
+                taskExecutor,
+                mock(DialogService.class),
+                mock(GuiPreferences.class),
+                mock(UndoManager.class),
+                mock(StateManager.class));
+
+        monitor.suspendChangeDetection();
+        monitor.fileUpdated();
+        monitor.fileUpdated();
+
+        verifyNoInteractions(taskExecutor);
+
+        monitor.resumeChangeDetection();
+
+        verify(taskExecutor).execute(any());
     }
 }

--- a/jabgui/src/test/java/org/jabref/gui/exporter/SaveDatabaseActionTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/exporter/SaveDatabaseActionTest.java
@@ -166,17 +166,17 @@ class SaveDatabaseActionTest {
     }
 
     @Test
-    void saveSuspendsAndResumesChangeMonitorAroundSuccessfulSave() throws Exception {
+    void saveSuspendsAndResumesChangeDetectionAroundSuccessfulSave() throws Exception {
         BibDatabase database = new BibDatabase(List.of(new BibEntry().withField(StandardField.AUTHOR, "first")));
         saveDatabaseAction = createSaveDatabaseActionForBibDatabase(database);
         when(libraryTab.isSaving()).thenReturn(false);
 
         saveDatabaseAction.save();
 
-        verify(libraryTab).suspendChangeMonitor();
-        verify(libraryTab).resumeChangeMonitor();
+        verify(libraryTab).suspendChangeDetection();
+        verify(libraryTab).resumeChangeDetection();
         var inOrder = inOrder(libraryTab);
-        inOrder.verify(libraryTab).suspendChangeMonitor();
-        inOrder.verify(libraryTab).resumeChangeMonitor();
+        inOrder.verify(libraryTab).suspendChangeDetection();
+        inOrder.verify(libraryTab).resumeChangeDetection();
     }
 }


### PR DESCRIPTION
### Summary

JabRef now keeps its external-change watcher registered while a library is saved. Filesystem events received during the save are deferred, then the saved library is scanned once afterwards so persistent external changes can still be offered for conflict resolution.

### Analogies

The monitor is like honey: it stays connected rather than being removed while the jar is opened. It waits like chocolate cooling before judging the final shape of a save. Once the save finishes, it checks the resulting file like the moon reflecting what is actually on disk.

This draft requires contributor review before adding the policy compliance tag required for a ready-for-review pull request.

### Steps to test

1. Open the same library in two JabRef instances.
2. Save the library in the first instance and verify that the second instance offers the external-changes notification and resolver.
3. While a save is in progress, modify the library from another process. After the save completes, verify that JabRef scans the resulting file and offers persistent external changes for review.

### Related issues and pull requests

No confident matching issue identified.

### AI usage

Codex (GPT-5) assisted with implementation and tests from the contributor-requested design. AIL4: AI produced the implementation from a human-provided basic idea. The contributor must review, understand, and take full ownership before marking this PR ready for review.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

# Code checklist

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [x] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [x] No `catch (Exception e)` — only specific exceptions are caught.
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [x] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [/] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [x] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [x] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.

## 2. Verification commands

- [ ] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
- [ ] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [ ] `./gradlew modernizer`.
- [ ] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [ ] `./gradlew javadoc`.
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.

## 3. Documentation

- [x] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Link the issue if one exists; link the PR only when no issue exists. Use `TODO` as the placeholder when neither is known yet — never a fake number.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [x] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [x] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [x] If `CHANGELOG.md` used a `TODO` placeholder (no issue confidently identified yet — an existing issue link always stays), it was replaced with the real PR-number link after PR creation, then committed and pushed. If an issue is identified or created later, the link is switched to the issue.

</details>

### Checklist

- [ ] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
