### PR TITLE
Fix macOS Option-key conflict for identifier search shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
+- We changed the shortcut for "Search document identifier online" from <kbd>Alt + F</kbd> to <kbd>Ctrl + Alt + F</kbd> (<kbd>Cmd + Option + F</kbd> on macOS) so it no longer inserts special characters such as `ƒ` on macOS. [#16528](https://github.com/JabRef/jabref/issues/16528)
+- We changed the shortcut for "Focus group list" from <kbd>Alt + S</kbd> to <kbd>Ctrl + Alt + G</kbd> (<kbd>Cmd + Option + G</kbd> on macOS) for the same reason. [#16528](https://github.com/JabRef/jabref/issues/16528)
 - The LibreOffice integration's bibliography generation for CSL styles is now more performant for a large number of entries. [#16555](https://github.com/JabRef/jabref/pull/16555)
 - We now identify Crossref requests with a configured email address, allowing them to use Crossref's polite pool. [#16535](https://github.com/JabRef/jabref/pull/16535)
 - We improved user experience by making the welcome tab visible when no libraries are open. [#16451](https://github.com/JabRef/jabref/issues/16451)

--- a/jabgui/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
+++ b/jabgui/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
@@ -64,7 +64,7 @@ public enum KeyBinding {
     FILE_LIST_EDITOR_MOVE_ENTRY_UP("File list editor, move entry up", Localization.lang("File list editor, move entry up"), "shortcut+UP", KeyBindingCategory.VIEW),
     FIND_UNLINKED_FILES("Search for unlinked local files", Localization.lang("Search for unlinked local files"), "shift+F7", KeyBindingCategory.QUALITY),
     FOCUS_ENTRY_TABLE("Focus entry table", Localization.lang("Focus entry table"), "alt+1", KeyBindingCategory.VIEW),
-    FOCUS_GROUP_LIST("Focus group list", Localization.lang("Focus group list"), "alt+s", KeyBindingCategory.VIEW),
+    FOCUS_GROUP_LIST("Focus group list", Localization.lang("Focus group list"), "shortcut+alt+G", KeyBindingCategory.VIEW),
     HELP("Help", Localization.lang("Help"), "F1", KeyBindingCategory.FILE),
     IMPORT_INTO_CURRENT_LIBRARY("Import into current library...", Localization.lang("Import into current library..."), "shortcut+I", KeyBindingCategory.FILE),
     IMPORT_INTO_NEW_LIBRARY("Import into new library...", Localization.lang("Import into new library..."), "shortcut+alt+I", KeyBindingCategory.FILE),
@@ -128,7 +128,7 @@ public enum KeyBinding {
     SKIMMED("Set read status to skimmed", Localization.lang("Set read status to skimmed"), "", KeyBindingCategory.EDIT),
     GROUP_RENAME("Rename group", Localization.lang("Rename group"), "F2", KeyBindingCategory.EDIT),
     MERGE_WITH_FETCHED_ENTRY("Get bibliographic data from %0, \"DOI/ISBN/...\"", Localization.lang("Get bibliographic data from %0", "DOI/ISBN/..."), "F5", KeyBindingCategory.EDIT),
-    LOOKUP_DOC_IDENTIFIER("Search document identifier online", Localization.lang("Search document identifier online"), "alt+F", KeyBindingCategory.EDIT),
+    LOOKUP_DOC_IDENTIFIER("Search document identifier online", Localization.lang("Search document identifier online"), "shortcut+alt+F", KeyBindingCategory.EDIT),
     RENAME_FILE_TO_NAME("Rename file(s) to configured filename format pattern", Localization.lang("Rename file(s) to configured filename format pattern"), "shortcut+P", KeyBindingCategory.EDIT);
 
     private final String constant;

--- a/jabgui/src/test/java/org/jabref/gui/keyboard/KeyBindingRepositoryTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/keyboard/KeyBindingRepositoryTest.java
@@ -3,6 +3,7 @@ package org.jabref.gui.keyboard;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -33,5 +34,15 @@ class KeyBindingRepositoryTest {
 
         assertEquals(keyBindingRepository.get(bindNames.getFirst()), bindings.getFirst());
         assertEquals(keyBindingRepository.get(bindNames.get(1)), bindings.get(1));
+    }
+
+    @Test
+    void lookupDocIdentifierDefaultAvoidsBareAltF() {
+        assertEquals("shortcut+alt+F", KeyBinding.LOOKUP_DOC_IDENTIFIER.getDefaultKeyBinding());
+    }
+
+    @Test
+    void focusGroupListDefaultAvoidsBareAltS() {
+        assertEquals("shortcut+alt+G", KeyBinding.FOCUS_GROUP_LIST.getDefaultKeyBinding());
     }
 }


### PR DESCRIPTION
### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

### Summary

On macOS, `Alt` is the Option key and Option+letter inserts special characters. The default shortcut for "Search document identifier online" was `Alt + F`, which also inserts `ƒ` into the focused text field. "Focus group list" had the same problem with `Alt + S` (`ß`).

The defaults now use the OS-independent `shortcut` modifier (`Ctrl` on Windows, `Cmd` on macOS):

- Search document identifier online: `Ctrl + Alt + F` / `Cmd + Option + F`
- Focus group list: `Ctrl + Alt + G` / `Cmd + Option + G`

`shortcut+alt+S` is already used by Save all, so the group-list shortcut uses `G` for groups.

Existing custom keybindings in preferences are unchanged; reset keybindings to pick up the new defaults.

### Steps to test

1. Reset keybindings to defaults (Preferences > Key bindings).
2. Open an entry, put the cursor in a text field, and press `Cmd + Option + F` (macOS) or `Ctrl + Alt + F` (Windows/Linux). The identifier lookup should run and no `ƒ` should be inserted.
3. Press `Cmd + Option + G` / `Ctrl + Alt + G`. Focus should move to the group list.
4. Confirm `Cmd + F` / `Ctrl + F` still opens search.

### Related issues and pull requests

Closes #16528

### AI usage

None.
