### PR TITLE
Fix 16553 multi merge dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where empty values in the merge entries dialog could not be selected to clear the merged entry field. [#15014](https://github.com/JabRef/jabref/issues/15014)
 - We fixed an issue where `Update with bibliographic information via entry data` did not apply the confirmed merge result back to the selected entry. [#15265](https://github.com/JabRef/jabref/issues/15265)
 - We fixed an issue where `Update with bibliographic information via entry data` could fail with an exception while the merge dialog was open. [#16583](https://github.com/JabRef/jabref/pull/16583)
+- We fixed unreadable text colors and a missing window title in the multi-way merge dialog. [#16553](https://github.com/JabRef/jabref/issues/16553)
 - We fixed an issue where switching the citation provider in the "Citations" tab froze the user interface while the results were matched against the library. [#16270](https://github.com/JabRef/jabref/issues/16270)
 - We fixed an issue where reference mark expands onto the text when cursor is at the end of the mark. [#16515](https://github.com/JabRef/jabref/issues/16515)
 - We fixed an issue where the exception message would show in the notification. [#14886](https://github.com/JabRef/jabref/issues/14886)

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/UpdateWithBibliographicInformationByWebFetchers.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/UpdateWithBibliographicInformationByWebFetchers.java
@@ -46,6 +46,7 @@ public class UpdateWithBibliographicInformationByWebFetchers extends SimpleComma
         BibEntry originalEntry = stateManager.getSelectedEntries().getFirst();
 
         MultiMergeEntriesView mergedEntriesView = new MultiMergeEntriesView(guiPreferences, taskExecutor);
+        mergedEntriesView.setTitle(Localization.lang("Merge entry with information"));
         mergedEntriesView.addSource(Localization.lang("Original entry"), originalEntry);
 
         Set<EntryBasedFetcher> webFetchers = WebFetchers.getEntryBasedFetchers(

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/multiwaymerge/DiffHighlightingEllipsingTextFlow.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/multiwaymerge/DiffHighlightingEllipsingTextFlow.java
@@ -118,6 +118,7 @@ public class DiffHighlightingEllipsingTextFlow extends TextFlow {
             Text shortenedChild = new Text(ellipseString(lastChildAsShown.getText()));
             shortenedChild.getStyleClass().addAll(lastChildAsShown.getStyleClass());
             super.getChildren().add(shortenedChild);
+            shortenedChild.applyCss();
             super.autosize();
         }
         return true;

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -1573,6 +1573,10 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-fill: -jr-light-orange;
 }
 
+#multiMergeEntries .text-unchanged {
+    -fx-fill: -jr-text-foreground;
+}
+
 #multiMergeEntries .text-added {
     -fx-fill: -jr-green;
 }


### PR DESCRIPTION
### Summary

This fixes unreadable text in the multi-way merge dialog by making unchanged diff text use a theme-aware foreground color. It also ensures shortened ellipsis text gets CSS applied correctly in dark mode, and adds a title to the entry data merge dialog.

### Steps to test

1. Open JabRef in light theme.
2. Open the example library.
3. Select an entry such as `Garcia_2018`.
4. Use `Lookup -> Update with bibliographic information via entry data`.
5. Verify that the multi-way merge dialog shows readable text in the original/source columns.
6. Switch to dark theme and repeat the same flow.
7. Verify that shortened fields such as title and author remain readable when ellipsized.
8. Verify that the dialog has a proper window title.
After change, light mode goes well:
<img width="797" height="517" alt="light mode " src="https://github.com/user-attachments/assets/501d3ce4-2d48-4be5-9741-22ff087fc9ed" />
Dark mode has some issues at first,
<img width="1588" height="1050" alt="darkmode1" src="https://github.com/user-attachments/assets/5163d789-82f0-4dd3-92a3-05c341aa231b" />
It got some black fields in dark mode. The black text happened because ellipsized diff text was recreated as a new JavaFX Text node. The new node copied the style class, but its CSS had not been applied yet, so it kept JavaFX’s default black fill in dark mode.
I fixed it by applying CSS to the shortened text node after adding it back to the TextFlow. I also set unchanged diff text in the multi-way merge dialog to use the theme-aware foreground color, so it stays readable in both light and dark themes.
Final appearance after change: 
<img width="788" height="522" alt="darkmode2" src="https://github.com/user-attachments/assets/b34b94c2-0887-4653-93a0-369f00855abc" />

### Related issues and pull requests

Closes #16553

### AI usage

I used Codex / ChatGPT (model GPT-5) to help analyze the JavaFX styling issue and review the affected code paths. I reviewed and understood the changes and take full ownership of the submitted code. 

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
