### PR TITLE
Detect concurrent modification of the library file when saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where two JabRef instances saving the same library file could silently overwrite each other's changes. The instance finishing last now aborts its save and offers the usual review flow for the external changes instead. [#16631](https://github.com/JabRef/jabref/pull/16646)
+- We fixed an issue where two JabRef instances saving the same library file could silently overwrite each other's changes. The instance finishing last now aborts its save and offers the usual review flow for the external changes instead. [#16646](https://github.com/JabRef/jabref/pull/16646)
 - We fixed saving libraries with long file names, hard links, or file systems that do not support atomic moves. [#7718](https://github.com/JabRef/jabref/issues/7718)
 - We fixed an issue where full-text search in linked files was not working when the experimental Postgres search backend is disabled. [#16591](https://github.com/JabRef/jabref/pull/16591)
 - We fixed unreadable notification text and icons when using the dark theme. [#16475](https://github.com/JabRef/jabref/issues/16475)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where two JabRef instances saving the same library file could silently overwrite each other's changes. The instance finishing last now aborts its save with a "file was modified by another program" error instead. [#16631](https://github.com/JabRef/jabref/pull/16631)
 - We fixed saving libraries with long file names, hard links, or file systems that do not support atomic moves. [#7718](https://github.com/JabRef/jabref/issues/7718)
 - We fixed an issue where full-text search in linked files was not working when the experimental Postgres search backend is disabled. [#16591](https://github.com/JabRef/jabref/pull/16591)
 - We fixed unreadable notification text and icons when using the dark theme. [#16475](https://github.com/JabRef/jabref/issues/16475)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ### Fixed
 
 - We fixed an issue where two JabRef instances saving the same library file could silently overwrite each other's changes. The instance finishing last now aborts its save and offers the usual review flow for the external changes instead. [#16646](https://github.com/JabRef/jabref/pull/16646)
+- We fixed missed external-change detection while JabRef saves a library, so concurrent changes can be reviewed for resolution. [#16646](https://github.com/JabRef/jabref/pull/16646)
 - We fixed saving libraries with long file names, hard links, or file systems that do not support atomic moves. [#7718](https://github.com/JabRef/jabref/issues/7718)
 - We fixed an issue where full-text search in linked files was not working when the experimental Postgres search backend is disabled. [#16591](https://github.com/JabRef/jabref/pull/16591)
 - We fixed unreadable notification text and icons when using the dark theme. [#16475](https://github.com/JabRef/jabref/issues/16475)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where two JabRef instances saving the same library file could silently overwrite each other's changes. The instance finishing last now aborts its save with a "file was modified by another program" error instead. [#16631](https://github.com/JabRef/jabref/pull/16631)
+- We fixed an issue where two JabRef instances saving the same library file could silently overwrite each other's changes. The instance finishing last now aborts its save and offers the usual review flow for the external changes instead. [#16631](https://github.com/JabRef/jabref/pull/16631)
 - We fixed saving libraries with long file names, hard links, or file systems that do not support atomic moves. [#7718](https://github.com/JabRef/jabref/issues/7718)
 - We fixed an issue where full-text search in linked files was not working when the experimental Postgres search backend is disabled. [#16591](https://github.com/JabRef/jabref/pull/16591)
 - We fixed unreadable notification text and icons when using the dark theme. [#16475](https://github.com/JabRef/jabref/issues/16475)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where two JabRef instances saving the same library file could silently overwrite each other's changes. The instance finishing last now aborts its save and offers the usual review flow for the external changes instead. [#16631](https://github.com/JabRef/jabref/pull/16631)
+- We fixed an issue where two JabRef instances saving the same library file could silently overwrite each other's changes. The instance finishing last now aborts its save and offers the usual review flow for the external changes instead. [#16631](https://github.com/JabRef/jabref/pull/16646)
 - We fixed saving libraries with long file names, hard links, or file systems that do not support atomic moves. [#7718](https://github.com/JabRef/jabref/issues/7718)
 - We fixed an issue where full-text search in linked files was not working when the experimental Postgres search backend is disabled. [#16591](https://github.com/JabRef/jabref/pull/16591)
 - We fixed unreadable notification text and icons when using the dark theme. [#16475](https://github.com/JabRef/jabref/issues/16475)

--- a/docs/requirements/save.md
+++ b/docs/requirements/save.md
@@ -1,0 +1,15 @@
+---
+parent: Requirements
+---
+# Saving a Library
+
+## Concurrent modification of the library file is detected on save
+`req~logic.exporter.concurrent-save-detection~1`
+
+Two processes (e.g., two JabRef instances on different machines using a network share) may write the same library file at overlapping times.
+When the target file is modified by another process between the start of a save and its commit, the save must be aborted with an error instead of silently overwriting the other process's changes.
+The detection is best-effort: it is based on the file's size and modification time, so it is subject to the file system's timestamp resolution.
+
+Needs: impl, utest
+
+<!-- markdownlint-disable-file MD022 -->

--- a/docs/requirements/ux.md
+++ b/docs/requirements/ux.md
@@ -96,4 +96,12 @@ When a user creates a new explicit group, JabRef should allow reusing the curren
 
 Needs: impl
 
+### Saving keeps external change detection active
+`req~ux.external-library-changes.after-save~1`
+
+When JabRef saves a library, it must keep observing filesystem changes, defer change detection until the save has finished, and then inspect the resulting file for external changes that require conflict resolution.
+Since inspecting a library file means parsing it completely, the inspection is skipped when the file's size and modification time show that it has not changed since the last state known to match the in-memory library.
+
+Needs: impl
+
 <!-- markdownlint-disable-file MD022 -->

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -818,18 +818,13 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
     }
 
     public void suspendChangeMonitor() {
-        changeMonitor.ifPresent(DatabaseChangeMonitor::unregister);
+        changeMonitor.ifPresent(DatabaseChangeMonitor::suspendChangeDetection);
     }
 
+    /// Resuming also scans for external changes that arrived while the monitor was suspended, e.g. a concurrent write
+    /// that aborted the suspended save — the standard external-changes review flow is offered for them.
     public void resumeChangeMonitor() {
-        bibDatabaseContext.getDatabasePath().ifPresent(_ -> resetChangeMonitor());
-    }
-
-    /// Scans the file on disk for changes compared to the in-memory library and shows the standard external-changes
-    /// notification (with the review flow) if there are any. Needed after a save was aborted because of a concurrent
-    /// write: the change monitor is suspended while saving, so it never sees that write itself.
-    public void scanForExternalChanges() {
-        changeMonitor.ifPresent(DatabaseChangeMonitor::fileUpdated);
+        changeMonitor.ifPresent(DatabaseChangeMonitor::resumeChangeDetection);
     }
 
     public void insertEntry(final BibEntry bibEntry) {
@@ -1029,6 +1024,8 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
     public void resetChangedProperties() {
         this.nonUndoableChangeProperty.setValue(false);
         this.changedProperty.setValue(false);
+        // Both call sites mean "in-memory library now matches the disk", so file events for this state need no scan
+        changeMonitor.ifPresent(DatabaseChangeMonitor::markConsistentWithDisk);
     }
 
     public void back() {

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -74,6 +74,7 @@ import org.jabref.logic.util.BackgroundTask;
 import org.jabref.logic.util.CoarseChangeFilter;
 import org.jabref.logic.util.OptionalObjectProperty;
 import org.jabref.logic.util.TaskExecutor;
+import org.jabref.logic.util.io.FileSnapshot;
 import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.FieldChange;
 import org.jabref.model.TransferInformation;
@@ -102,6 +103,7 @@ import com.google.common.eventbus.Subscribe;
 import com.tobiasdiez.easybind.EasyBind;
 import com.tobiasdiez.easybind.Subscription;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1022,10 +1024,17 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
     }
 
     public void resetChangedProperties() {
+        resetChangedProperties(null);
+    }
+
+    /// All call sites mean "in-memory library now matches the disk", so file events for that state need no scan.
+    ///
+    /// @param diskState the on-disk state the library matches, as reported by the writer that committed it; `null` to
+    ///                  determine it from the file (e.g. after merging all external changes)
+    public void resetChangedProperties(@Nullable FileSnapshot diskState) {
         this.nonUndoableChangeProperty.setValue(false);
         this.changedProperty.setValue(false);
-        // Both call sites mean "in-memory library now matches the disk", so file events for this state need no scan
-        changeMonitor.ifPresent(DatabaseChangeMonitor::markConsistentWithDisk);
+        changeMonitor.ifPresent(monitor -> monitor.markConsistentWithDisk(diskState));
     }
 
     public void back() {

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -1030,7 +1030,7 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
     /// All call sites mean "in-memory library now matches the disk", so file events for that state need no scan.
     ///
     /// @param diskState the on-disk state the library matches, as reported by the writer that committed it; `null` to
-    ///                  determine it from the file (e.g. after merging all external changes)
+    ///                                   determine it from the file (e.g. after merging all external changes)
     public void resetChangedProperties(@Nullable FileSnapshot diskState) {
         this.nonUndoableChangeProperty.setValue(false);
         this.changedProperty.setValue(false);

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -825,6 +825,13 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
         bibDatabaseContext.getDatabasePath().ifPresent(_ -> resetChangeMonitor());
     }
 
+    /// Scans the file on disk for changes compared to the in-memory library and shows the standard external-changes
+    /// notification (with the review flow) if there are any. Needed after a save was aborted because of a concurrent
+    /// write: the change monitor is suspended while saving, so it never sees that write itself.
+    public void scanForExternalChanges() {
+        changeMonitor.ifPresent(DatabaseChangeMonitor::fileUpdated);
+    }
+
     public void insertEntry(final BibEntry bibEntry) {
         insertEntries(List.of(bibEntry));
     }

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -1029,8 +1029,7 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
 
     /// All call sites mean "in-memory library now matches the disk", so file events for that state need no scan.
     ///
-    /// @param diskState the on-disk state the library matches, as reported by the writer that committed it; `null` to
-    ///                                   determine it from the file (e.g. after merging all external changes)
+    /// @param diskState the on-disk state the library matches, as reported by the writer that committed it; `null` to determine it from the file (e.g. after merging all external changes)
     public void resetChangedProperties(@Nullable FileSnapshot diskState) {
         this.nonUndoableChangeProperty.setValue(false);
         this.changedProperty.setValue(false);

--- a/jabgui/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
@@ -155,10 +155,10 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
     /// not trigger a scan.
     ///
     /// @param diskState the matching on-disk state, ideally as reported by the writer that committed it (captured
-    ///                  right after the commit, this leaves no window in which a concurrent write could be mistaken
-    ///                  for the consistent state); `null` to read the current state from the file instead, which is
-    ///                  subject to such a window — its worst case is a delayed notification, never a lost update,
-    ///                  since lost-update protection lives in [org.jabref.logic.exporter.AtomicFileOutputStream]
+    ///                                   right after the commit, this leaves no window in which a concurrent write could be mistaken
+    ///                                   for the consistent state); `null` to read the current state from the file instead, which is
+    ///                                   subject to such a window — its worst case is a delayed notification, never a lost update,
+    ///                                   since lost-update protection lives in [org.jabref.logic.exporter.AtomicFileOutputStream]
     public void markConsistentWithDisk(@Nullable FileSnapshot diskState) {
         synchronized (database) {
             if (diskState != null) {

--- a/jabgui/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
@@ -1,10 +1,7 @@
 package org.jabref.gui.collab;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -20,6 +17,7 @@ import org.jabref.gui.undo.NamedCompoundEdit;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.BackgroundTask;
 import org.jabref.logic.util.TaskExecutor;
+import org.jabref.logic.util.io.FileSnapshot;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.util.FileUpdateListener;
 import org.jabref.model.util.FileUpdateMonitor;
@@ -45,23 +43,10 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
     private LibraryTab saveState;
     private boolean changeDetectionSuspended;
 
-    /// Size and modification time of the monitored file as of the last scan or the last point where the in-memory
-    /// library was known to match the disk (library load, successful save, all external changes merged). Guarded by
+    /// State of the monitored file as of the last scan or the last point where the in-memory library was known to
+    /// match the disk (library load, successful save, all external changes merged). Guarded by
     /// `synchronized (database)`; `null` when unknown, in which case the next event triggers a full scan.
-    @Nullable private FileState knownDiskState;
-
-    private record FileState(long size, FileTime lastModified) {
-        @Nullable
-        static FileState read(Path file) {
-            try {
-                BasicFileAttributes attributes = Files.readAttributes(file, BasicFileAttributes.class);
-                return new FileState(attributes.size(), attributes.lastModifiedTime());
-            } catch (IOException exception) {
-                LOGGER.debug("Could not read attributes of {}", file, exception);
-                return null;
-            }
-        }
-    }
+    @Nullable private FileSnapshot knownDiskState;
 
     public DatabaseChangeMonitor(BibDatabaseContext database,
                                  FileUpdateMonitor fileMonitor,
@@ -82,7 +67,7 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
         this.listeners = new ArrayList<>();
 
         monitoredPath.ifPresent(path -> {
-            knownDiskState = FileState.read(path);
+            knownDiskState = FileSnapshot.read(path);
             try {
                 fileMonitor.addListenerForFile(path, this);
             } catch (IOException e) {
@@ -165,21 +150,29 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
         }
     }
 
-    /// Records the current file state as consistent with the in-memory library. To be called whenever the two are
-    /// known to match (successful save, all external changes merged), so that watcher events reflecting that very
-    /// state do not trigger a scan. A concurrent write between the point of consistency and this call is recorded as
-    /// consistent and its notification missed — a tiny race accepted here, since lost-update protection lives in
-    /// [org.jabref.logic.exporter.AtomicFileOutputStream] and not in this notification path.
-    public void markConsistentWithDisk() {
+    /// Records the given file state as consistent with the in-memory library. To be called whenever the two are known
+    /// to match (successful save, all external changes merged), so that watcher events reflecting that very state do
+    /// not trigger a scan.
+    ///
+    /// @param diskState the matching on-disk state, ideally as reported by the writer that committed it (captured
+    ///                  right after the commit, this leaves no window in which a concurrent write could be mistaken
+    ///                  for the consistent state); `null` to read the current state from the file instead, which is
+    ///                  subject to such a window — its worst case is a delayed notification, never a lost update,
+    ///                  since lost-update protection lives in [org.jabref.logic.exporter.AtomicFileOutputStream]
+    public void markConsistentWithDisk(@Nullable FileSnapshot diskState) {
         synchronized (database) {
-            monitoredPath.ifPresent(path -> knownDiskState = FileState.read(path));
+            if (diskState != null) {
+                knownDiskState = diskState;
+            } else {
+                monitoredPath.ifPresent(path -> knownDiskState = FileSnapshot.read(path));
+            }
         }
     }
 
     /// A full scan parses the whole library file, so it is skipped when size and modification time show that the file
     /// has not actually changed since the last known-consistent state — e.g. for events caused by JabRef's own save.
     private void scanIfFileChanged() {
-        FileState currentState = monitoredPath.map(FileState::read).orElse(null);
+        FileSnapshot currentState = monitoredPath.map(FileSnapshot::read).orElse(null);
         if (currentState != null && currentState.equals(knownDiskState)) {
             return;
         }

--- a/jabgui/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
@@ -1,7 +1,10 @@
 package org.jabref.gui.collab;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +25,7 @@ import org.jabref.model.util.FileUpdateListener;
 import org.jabref.model.util.FileUpdateMonitor;
 
 import com.dlsc.gemsfx.infocenter.NotificationAction;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +43,25 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
     private final StateManager stateManager;
     private final Optional<Path> monitoredPath;
     private LibraryTab saveState;
+    private boolean changeDetectionSuspended;
+
+    /// Size and modification time of the monitored file as of the last scan or the last point where the in-memory
+    /// library was known to match the disk (library load, successful save, all external changes merged). Guarded by
+    /// `synchronized (database)`; `null` when unknown, in which case the next event triggers a full scan.
+    @Nullable private FileState knownDiskState;
+
+    private record FileState(long size, FileTime lastModified) {
+        @Nullable
+        static FileState read(Path file) {
+            try {
+                BasicFileAttributes attributes = Files.readAttributes(file, BasicFileAttributes.class);
+                return new FileState(attributes.size(), attributes.lastModifiedTime());
+            } catch (IOException exception) {
+                LOGGER.debug("Could not read attributes of {}", file, exception);
+                return null;
+            }
+        }
+    }
 
     public DatabaseChangeMonitor(BibDatabaseContext database,
                                  FileUpdateMonitor fileMonitor,
@@ -59,6 +82,7 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
         this.listeners = new ArrayList<>();
 
         monitoredPath.ifPresent(path -> {
+            knownDiskState = FileState.read(path);
             try {
                 fileMonitor.addListenerForFile(path, this);
             } catch (IOException e) {
@@ -118,17 +142,63 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
     @Override
     public void fileUpdated() {
         synchronized (database) {
-            // File on disk has changed, thus look for notable changes and notify listeners in case there are such changes
-            ChangeScanner scanner = new ChangeScanner(database, dialogService, preferences, stateManager);
-            BackgroundTask.wrap(scanner::scanForChanges)
-                          .onSuccess(changes -> {
-                              if (!changes.isEmpty()) {
-                                  listeners.forEach(listener -> listener.databaseChanged(changes));
-                              }
-                          })
-                          .onFailure(e -> LOGGER.error("Error while watching for changes", e))
-                          .executeWith(taskExecutor);
+            if (changeDetectionSuspended) {
+                return;
+            }
+            scanIfFileChanged();
         }
+    }
+
+    /// Defers handling of file events while keeping the watcher registered, so that events arriving during JabRef's
+    /// own save are neither acted upon (the file may be half-written) nor lost.
+    public void suspendChangeDetection() {
+        synchronized (database) {
+            changeDetectionSuspended = true;
+        }
+    }
+
+    // [impl->req~ux.external-library-changes.after-save~1]
+    public void resumeChangeDetection() {
+        synchronized (database) {
+            changeDetectionSuspended = false;
+            scanIfFileChanged();
+        }
+    }
+
+    /// Records the current file state as consistent with the in-memory library. To be called whenever the two are
+    /// known to match (successful save, all external changes merged), so that watcher events reflecting that very
+    /// state do not trigger a scan. A concurrent write between the point of consistency and this call is recorded as
+    /// consistent and its notification missed — a tiny race accepted here, since lost-update protection lives in
+    /// [org.jabref.logic.exporter.AtomicFileOutputStream] and not in this notification path.
+    public void markConsistentWithDisk() {
+        synchronized (database) {
+            monitoredPath.ifPresent(path -> knownDiskState = FileState.read(path));
+        }
+    }
+
+    /// A full scan parses the whole library file, so it is skipped when size and modification time show that the file
+    /// has not actually changed since the last known-consistent state — e.g. for events caused by JabRef's own save.
+    private void scanIfFileChanged() {
+        FileState currentState = monitoredPath.map(FileState::read).orElse(null);
+        if (currentState != null && currentState.equals(knownDiskState)) {
+            return;
+        }
+        knownDiskState = currentState;
+        scanForChanges();
+    }
+
+    /// Looks for notable changes of the file on disk compared to the in-memory library and notifies listeners in case
+    /// there are such changes.
+    private void scanForChanges() {
+        ChangeScanner scanner = new ChangeScanner(database, dialogService, preferences, stateManager);
+        BackgroundTask.wrap(scanner::scanForChanges)
+                      .onSuccess(changes -> {
+                          if (!changes.isEmpty()) {
+                              listeners.forEach(listener -> listener.databaseChanged(changes));
+                          }
+                      })
+                      .onFailure(e -> LOGGER.error("Error while watching for changes", e))
+                      .executeWith(taskExecutor);
     }
 
     public void addListener(DatabaseChangeListener listener) {

--- a/jabgui/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
@@ -154,11 +154,7 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
     /// to match (successful save, all external changes merged), so that watcher events reflecting that very state do
     /// not trigger a scan.
     ///
-    /// @param diskState the matching on-disk state, ideally as reported by the writer that committed it (captured
-    ///                                   right after the commit, this leaves no window in which a concurrent write could be mistaken
-    ///                                   for the consistent state); `null` to read the current state from the file instead, which is
-    ///                                   subject to such a window — its worst case is a delayed notification, never a lost update,
-    ///                                   since lost-update protection lives in [org.jabref.logic.exporter.AtomicFileOutputStream]
+    /// @param diskState the matching on-disk state, ideally as reported by the writer that committed it (captured right after the commit, this leaves no window in which a concurrent write could be mistaken for the consistent state); `null` to read the current state from the file instead, which is subject to such a window — its worst case is a delayed notification, never a lost update, since lost-update protection lives in [org.jabref.logic.exporter.AtomicFileOutputStream]
     public void markConsistentWithDisk(@Nullable FileSnapshot diskState) {
         synchronized (database) {
             if (diskState != null) {

--- a/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -257,14 +257,8 @@ public class SaveDatabaseAction {
             // release panel from save status
             libraryTab.setSaving(false);
             if (fileChangedDuringSave) {
+                // resumeChangeMonitor() above already scans for the concurrent write and offers the review flow
                 dialogService.notify(Localization.lang("Library was not saved: the file was modified by another program."));
-                if (libraryTab.getBibDatabaseContext().getDatabasePath().filter(targetPath::equals).isPresent()) {
-                    // The change monitor was suspended during the save and thus never saw the concurrent write;
-                    // trigger the scan manually so the user gets the standard external-changes review flow. Only for
-                    // plain saves: during "Save as", the context (and thus the monitor) still points to the old path,
-                    // so a scan would not compare against the file that conflicted.
-                    libraryTab.scanForExternalChanges();
-                }
             }
         }
     }

--- a/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -6,6 +6,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -45,6 +47,7 @@ import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.metadata.SaveOrder;
 import org.jabref.model.metadata.SelfContainedSaveOrder;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -299,13 +302,29 @@ public class SaveDatabaseAction {
             // Deliberately outside the try-with-resources: the retry must run after the writer above committed its
             // content, otherwise the writer's close() would overwrite the re-encoded file with the problematic one
             if (!encodingProblems.isEmpty()) {
-                saveWithDifferentEncoding(file, selectedOnly, encoding, encodingProblems, saveType, saveOrder);
+                saveWithDifferentEncoding(file, selectedOnly, encoding, encodingProblems, saveType, saveOrder, FileState.read(file));
             }
             return true;
         }
     }
 
-    private void saveWithDifferentEncoding(Path file, boolean selectedOnly, Charset encoding, Set<Character> encodingProblems, BibDatabaseWriter.SaveType saveType, SelfContainedSaveOrder saveOrder) throws SaveException {
+    /// Size and modification time of the library file as committed by the save above, used to detect a concurrent
+    /// save while the encoding dialogs of [#saveWithDifferentEncoding] are open. `null` when the attributes cannot be
+    /// read, which disables the detection.
+    private record FileState(long size, FileTime lastModified) {
+        @Nullable
+        static FileState read(Path file) {
+            try {
+                BasicFileAttributes attributes = Files.readAttributes(file, BasicFileAttributes.class);
+                return new FileState(attributes.size(), attributes.lastModifiedTime());
+            } catch (IOException exception) {
+                LOGGER.debug("Could not read attributes of {}", file, exception);
+                return null;
+            }
+        }
+    }
+
+    private void saveWithDifferentEncoding(Path file, boolean selectedOnly, Charset encoding, Set<Character> encodingProblems, BibDatabaseWriter.SaveType saveType, SelfContainedSaveOrder saveOrder, @Nullable FileState committedState) throws SaveException {
         DialogPane pane = new DialogPane();
         VBox vbox = new VBox();
         vbox.getChildren().addAll(
@@ -329,6 +348,12 @@ public class SaveDatabaseAction {
                     encoding,
                     OS.ENCODINGS);
             if (newEncoding.isPresent()) {
+                if (committedState != null && !committedState.equals(FileState.read(file))) {
+                    // Another program saved the file while the encoding dialogs were open; the retry would take that
+                    // version as its baseline and overwrite it, so it is aborted like any other concurrent-save
+                    // conflict
+                    throw new SaveException(new FileChangedException(file));
+                }
                 // Make sure to remember which encoding we used.
                 libraryTab.getBibDatabaseContext().getMetaData().setEncoding(newEncoding.get(), ChangePropagation.DO_NOT_POST_EVENT);
 

--- a/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -30,6 +30,7 @@ import org.jabref.gui.util.FileDialogConfiguration;
 import org.jabref.logic.exporter.AtomicFileWriter;
 import org.jabref.logic.exporter.BibDatabaseWriter;
 import org.jabref.logic.exporter.BibWriter;
+import org.jabref.logic.exporter.FileChangedException;
 import org.jabref.logic.exporter.SaveException;
 import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
@@ -132,7 +133,7 @@ public class SaveDatabaseAction {
     }
 
     /// @param file the new file name to save the database to. This is stored in the database context of the panel upon successful save.
-    /// @return true on successful save
+     /// @return true on successful save
     boolean saveAs(Path file, SaveDatabaseMode mode) {
         BibDatabaseContext context = libraryTab.getBibDatabaseContext();
 
@@ -258,6 +259,7 @@ public class SaveDatabaseAction {
                 = new SelfContainedSaveConfiguration(saveOrder, false, saveType, preferences.getLibraryPreferences().shouldAlwaysReformatOnSave());
         BibDatabaseContext bibDatabaseContext = libraryTab.getBibDatabaseContext();
         synchronized (bibDatabaseContext) {
+            Set<Character> encodingProblems = Set.of();
             try (AtomicFileWriter fileWriter = new AtomicFileWriter(file, encoding, saveConfiguration.shouldMakeBackup())) {
                 BibWriter bibWriter = new BibWriter(fileWriter, bibDatabaseContext.getDatabase().getNewLineSeparator());
                 BibDatabaseWriter databaseWriter = new BibDatabaseWriter(
@@ -278,13 +280,18 @@ public class SaveDatabaseAction {
 
                 libraryTab.registerUndoableChanges(databaseWriter.getSaveActionsFieldChanges());
 
-                if (fileWriter.hasEncodingProblems()) {
-                    saveWithDifferentEncoding(file, selectedOnly, encoding, fileWriter.getEncodingProblems(), saveType, saveOrder);
-                }
+                encodingProblems = fileWriter.getEncodingProblems();
             } catch (UnsupportedCharsetException ex) {
                 throw new SaveException(Localization.lang("Character encoding '%0' is not supported.", encoding.displayName()), ex);
+            } catch (FileChangedException ex) {
+                throw new SaveException(Localization.lang("The library file was modified by another program while saving. To avoid overwriting those changes, your changes were not saved. Please review the changes on disk and save again."), ex);
             } catch (IOException ex) {
                 throw new SaveException("Problems saving: " + ex, ex);
+            }
+            // Deliberately outside the try-with-resources: the retry must run after the writer above committed its
+            // content, otherwise the writer's close() would overwrite the re-encoded file with the problematic one
+            if (!encodingProblems.isEmpty()) {
+                saveWithDifferentEncoding(file, selectedOnly, encoding, encodingProblems, saveType, saveOrder);
             }
             return true;
         }

--- a/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -348,17 +348,27 @@ public class SaveDatabaseAction {
                     encoding,
                     OS.ENCODINGS);
             if (newEncoding.isPresent()) {
-                if (committedState != null && !committedState.equals(FileState.read(file))) {
-                    // Another program saved the file while the encoding dialogs were open; the retry would take that
-                    // version as its baseline and overwrite it, so it is aborted like any other concurrent-save
-                    // conflict
-                    throw new SaveException(new FileChangedException(file));
-                }
+                ensureFileUnchangedWhileDialogsWereOpen(file, committedState);
                 // Make sure to remember which encoding we used.
                 libraryTab.getBibDatabaseContext().getMetaData().setEncoding(newEncoding.get(), ChangePropagation.DO_NOT_POST_EVENT);
 
                 saveDatabase(file, selectedOnly, newEncoding.get(), saveType, saveOrder);
+                return;
             }
+        }
+        // No retry happened ("Ignore", or the encoding choice was cancelled), so the first write is the result of the
+        // save — unless another program overwrote it while the dialogs were open, in which case reporting success
+        // would mark the library as saved although the file on disk no longer contains it
+        ensureFileUnchangedWhileDialogsWereOpen(file, committedState);
+    }
+
+    /// The encoding dialogs can stay open for a long time. A save that another program completes in that window must
+    /// not be overwritten by the retry (it would take that version as its baseline) and must not be reported as our
+    /// own successful save. Aborting through the regular concurrent-save-conflict path keeps the library marked as
+    /// changed and offers the external-changes review flow.
+    private static void ensureFileUnchangedWhileDialogsWereOpen(Path file, @Nullable FileState committedState) throws SaveException {
+        if (committedState != null && !committedState.equals(FileState.read(file))) {
+            throw new SaveException(new FileChangedException(file));
         }
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -133,7 +133,7 @@ public class SaveDatabaseAction {
     }
 
     /// @param file the new file name to save the database to. This is stored in the database context of the panel upon successful save.
-     /// @return true on successful save
+    /// @return true on successful save
     boolean saveAs(Path file, SaveDatabaseMode mode) {
         BibDatabaseContext context = libraryTab.getBibDatabaseContext();
 
@@ -225,6 +225,7 @@ public class SaveDatabaseAction {
 
         libraryTab.suspendChangeMonitor();
 
+        boolean fileChangedDuringSave = false;
         try {
             Charset encoding = libraryTab.getBibDatabaseContext()
                                          .getMetaData()
@@ -243,13 +244,24 @@ public class SaveDatabaseAction {
             dialogService.notify(Localization.lang("Library saved"));
             return success;
         } catch (SaveException ex) {
-            LOGGER.error("A problem occurred when trying to save the file {}", targetPath, ex);
-            dialogService.showErrorDialogAndWait(Localization.lang("Save library"), Localization.lang("Could not save file."), ex);
+            if (ex.getCause() instanceof FileChangedException) {
+                LOGGER.info("Library {} was modified by another program while saving; save aborted", targetPath, ex);
+                fileChangedDuringSave = true;
+            } else {
+                LOGGER.error("A problem occurred when trying to save the file {}", targetPath, ex);
+                dialogService.showErrorDialogAndWait(Localization.lang("Save library"), Localization.lang("Could not save file."), ex);
+            }
             return false;
         } finally {
             libraryTab.resumeChangeMonitor();
             // release panel from save status
             libraryTab.setSaving(false);
+            if (fileChangedDuringSave) {
+                dialogService.notify(Localization.lang("Library was not saved: the file was modified by another program."));
+                // The change monitor was suspended during the save and thus never saw the concurrent write; trigger
+                // the scan manually so the user gets the standard external-changes review flow
+                libraryTab.scanForExternalChanges();
+            }
         }
     }
 
@@ -283,8 +295,6 @@ public class SaveDatabaseAction {
                 encodingProblems = fileWriter.getEncodingProblems();
             } catch (UnsupportedCharsetException ex) {
                 throw new SaveException(Localization.lang("Character encoding '%0' is not supported.", encoding.displayName()), ex);
-            } catch (FileChangedException ex) {
-                throw new SaveException(Localization.lang("The library file was modified by another program while saving. To avoid overwriting those changes, your changes were not saved. Please review the changes on disk and save again."), ex);
             } catch (IOException ex) {
                 throw new SaveException("Problems saving: " + ex, ex);
             }

--- a/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -258,9 +258,13 @@ public class SaveDatabaseAction {
             libraryTab.setSaving(false);
             if (fileChangedDuringSave) {
                 dialogService.notify(Localization.lang("Library was not saved: the file was modified by another program."));
-                // The change monitor was suspended during the save and thus never saw the concurrent write; trigger
-                // the scan manually so the user gets the standard external-changes review flow
-                libraryTab.scanForExternalChanges();
+                if (libraryTab.getBibDatabaseContext().getDatabasePath().filter(targetPath::equals).isPresent()) {
+                    // The change monitor was suspended during the save and thus never saw the concurrent write;
+                    // trigger the scan manually so the user gets the standard external-changes review flow. Only for
+                    // plain saves: during "Save as", the context (and thus the monitor) still points to the old path,
+                    // so a scan would not compare against the file that conflicted.
+                    libraryTab.scanForExternalChanges();
+                }
             }
         }
     }

--- a/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -6,8 +6,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -41,6 +39,7 @@ import org.jabref.logic.os.OS;
 import org.jabref.logic.shared.DatabaseLocation;
 import org.jabref.logic.shared.prefs.SharedDatabasePreferences;
 import org.jabref.logic.util.StandardFileType;
+import org.jabref.logic.util.io.FileSnapshot;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.event.ChangePropagation;
 import org.jabref.model.entry.BibEntryTypesManager;
@@ -125,7 +124,7 @@ public class SaveDatabaseAction {
     public void saveSelectedAsPlain() {
         askForSavePath().ifPresent(path -> {
             try {
-                saveDatabase(path, true, StandardCharsets.UTF_8, BibDatabaseWriter.SaveType.PLAIN_BIBTEX, getSaveOrder());
+                saveDatabase(path, true, StandardCharsets.UTF_8, BibDatabaseWriter.SaveType.PLAIN_BIBTEX, getSaveOrder(), null);
                 preferences.getLastFilesOpenedPreferences().getFileHistory().newFile(path);
                 dialogService.notify(Localization.lang("Saved selected to '%0'.", path.toString()));
             } catch (SaveException ex) {
@@ -238,14 +237,12 @@ public class SaveDatabaseAction {
             // Make sure to remember which encoding we used
             libraryTab.getBibDatabaseContext().getMetaData().setEncoding(encoding, ChangePropagation.DO_NOT_POST_EVENT);
 
-            boolean success = saveDatabase(targetPath, false, encoding, BibDatabaseWriter.SaveType.WITH_JABREF_META_DATA, getSaveOrder());
+            FileSnapshot committedState = saveDatabase(targetPath, false, encoding, BibDatabaseWriter.SaveType.WITH_JABREF_META_DATA, getSaveOrder(), null);
 
-            if (success) {
-                libraryTab.getUndoManager().markUnchanged();
-                libraryTab.resetChangedProperties();
-            }
+            libraryTab.getUndoManager().markUnchanged();
+            libraryTab.resetChangedProperties(committedState);
             dialogService.notify(Localization.lang("Library saved"));
-            return success;
+            return true;
         } catch (SaveException ex) {
             if (ex.getCause() instanceof FileChangedException) {
                 LOGGER.info("Library {} was modified by another program while saving; save aborted", targetPath, ex);
@@ -266,14 +263,17 @@ public class SaveDatabaseAction {
         }
     }
 
-    private boolean saveDatabase(Path file, boolean selectedOnly, Charset encoding, BibDatabaseWriter.SaveType saveType, SelfContainedSaveOrder saveOrder) throws SaveException {
+    /// @return the state of the file as committed by this save (or by its encoding retry), `null` when unreadable
+    @Nullable
+    private FileSnapshot saveDatabase(Path file, boolean selectedOnly, Charset encoding, BibDatabaseWriter.SaveType saveType, SelfContainedSaveOrder saveOrder, @Nullable FileSnapshot expectedState) throws SaveException {
         // if this code is adapted, please also adapt org.jabref.logic.autosaveandbackup.BackupManager.performBackup
         SelfContainedSaveConfiguration saveConfiguration
                 = new SelfContainedSaveConfiguration(saveOrder, false, saveType, preferences.getLibraryPreferences().shouldAlwaysReformatOnSave());
         BibDatabaseContext bibDatabaseContext = libraryTab.getBibDatabaseContext();
         synchronized (bibDatabaseContext) {
             Set<Character> encodingProblems = Set.of();
-            try (AtomicFileWriter fileWriter = new AtomicFileWriter(file, encoding, saveConfiguration.shouldMakeBackup())) {
+            AtomicFileWriter fileWriter = createFileWriter(file, encoding, saveConfiguration.shouldMakeBackup(), expectedState);
+            try (fileWriter) {
                 BibWriter bibWriter = new BibWriter(fileWriter, bibDatabaseContext.getDatabase().getNewLineSeparator());
                 BibDatabaseWriter databaseWriter = new BibDatabaseWriter(
                         bibWriter,
@@ -299,32 +299,30 @@ public class SaveDatabaseAction {
             } catch (IOException ex) {
                 throw new SaveException("Problems saving: " + ex, ex);
             }
+            FileSnapshot committedState = fileWriter.getCommittedTargetFileState();
             // Deliberately outside the try-with-resources: the retry must run after the writer above committed its
             // content, otherwise the writer's close() would overwrite the re-encoded file with the problematic one
             if (!encodingProblems.isEmpty()) {
-                saveWithDifferentEncoding(file, selectedOnly, encoding, encodingProblems, saveType, saveOrder, FileState.read(file));
+                FileSnapshot retriedState = saveWithDifferentEncoding(file, selectedOnly, encoding, encodingProblems, saveType, saveOrder, committedState);
+                if (retriedState != null) {
+                    committedState = retriedState;
+                }
             }
-            return true;
+            return committedState;
         }
     }
 
-    /// Size and modification time of the library file as committed by the save above, used to detect a concurrent
-    /// save while the encoding dialogs of [#saveWithDifferentEncoding] are open. `null` when the attributes cannot be
-    /// read, which disables the detection.
-    private record FileState(long size, FileTime lastModified) {
-        @Nullable
-        static FileState read(Path file) {
-            try {
-                BasicFileAttributes attributes = Files.readAttributes(file, BasicFileAttributes.class);
-                return new FileState(attributes.size(), attributes.lastModifiedTime());
-            } catch (IOException exception) {
-                LOGGER.debug("Could not read attributes of {}", file, exception);
-                return null;
-            }
+    private static AtomicFileWriter createFileWriter(Path file, Charset encoding, boolean keepBackup, @Nullable FileSnapshot expectedState) throws SaveException {
+        try {
+            return new AtomicFileWriter(file, encoding, keepBackup, expectedState);
+        } catch (IOException ex) {
+            throw new SaveException("Problems saving: " + ex, ex);
         }
     }
 
-    private void saveWithDifferentEncoding(Path file, boolean selectedOnly, Charset encoding, Set<Character> encodingProblems, BibDatabaseWriter.SaveType saveType, SelfContainedSaveOrder saveOrder, @Nullable FileState committedState) throws SaveException {
+    /// @return the state committed by the retry, or `null` when no retry happened and the first write stands
+    @Nullable
+    private FileSnapshot saveWithDifferentEncoding(Path file, boolean selectedOnly, Charset encoding, Set<Character> encodingProblems, BibDatabaseWriter.SaveType saveType, SelfContainedSaveOrder saveOrder, @Nullable FileSnapshot committedState) throws SaveException {
         DialogPane pane = new DialogPane();
         VBox vbox = new VBox();
         vbox.getChildren().addAll(
@@ -348,27 +346,20 @@ public class SaveDatabaseAction {
                     encoding,
                     OS.ENCODINGS);
             if (newEncoding.isPresent()) {
-                ensureFileUnchangedWhileDialogsWereOpen(file, committedState);
                 // Make sure to remember which encoding we used.
                 libraryTab.getBibDatabaseContext().getMetaData().setEncoding(newEncoding.get(), ChangePropagation.DO_NOT_POST_EVENT);
 
-                saveDatabase(file, selectedOnly, newEncoding.get(), saveType, saveOrder);
-                return;
+                // The committed state of the first write is the retry's expected baseline, so its writer detects a
+                // save that another program completed while the dialogs above were open
+                return saveDatabase(file, selectedOnly, newEncoding.get(), saveType, saveOrder, committedState);
             }
         }
         // No retry happened ("Ignore", or the encoding choice was cancelled), so the first write is the result of the
         // save — unless another program overwrote it while the dialogs were open, in which case reporting success
         // would mark the library as saved although the file on disk no longer contains it
-        ensureFileUnchangedWhileDialogsWereOpen(file, committedState);
-    }
-
-    /// The encoding dialogs can stay open for a long time. A save that another program completes in that window must
-    /// not be overwritten by the retry (it would take that version as its baseline) and must not be reported as our
-    /// own successful save. Aborting through the regular concurrent-save-conflict path keeps the library marked as
-    /// changed and offers the external-changes review flow.
-    private static void ensureFileUnchangedWhileDialogsWereOpen(Path file, @Nullable FileState committedState) throws SaveException {
-        if (committedState != null && !committedState.equals(FileState.read(file))) {
+        if (committedState != null && !committedState.matches(file)) {
             throw new SaveException(new FileChangedException(file));
         }
+        return null;
     }
 }

--- a/jabgui/src/test/java/org/jabref/gui/collab/DatabaseChangeMonitorTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/collab/DatabaseChangeMonitorTest.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.collab;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -17,9 +18,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class DatabaseChangeMonitorTest {
@@ -49,5 +53,96 @@ class DatabaseChangeMonitorTest {
         monitor.unregister();
 
         verify(fileUpdateMonitor).removeListener(eq(originalPath), eq(listenerCaptor.getValue()));
+    }
+
+    private DatabaseChangeMonitor createMonitor(Path monitoredPath, FileUpdateMonitor fileUpdateMonitor, TaskExecutor taskExecutor) {
+        BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
+        when(databaseContext.getDatabasePath()).thenReturn(Optional.of(monitoredPath));
+        return new DatabaseChangeMonitor(
+                databaseContext,
+                fileUpdateMonitor,
+                taskExecutor,
+                mock(DialogService.class),
+                mock(GuiPreferences.class),
+                mock(UndoManager.class),
+                mock(StateManager.class));
+    }
+
+    @Test
+    void suspendChangeDetectionKeepsWatchingAndRescansOnResume(@TempDir Path tempDir) {
+        Path monitoredPath = tempDir.resolve("library.bib");
+        FileUpdateMonitor fileUpdateMonitor = mock(FileUpdateMonitor.class);
+        TaskExecutor taskExecutor = mock(TaskExecutor.class);
+        DatabaseChangeMonitor monitor = createMonitor(monitoredPath, fileUpdateMonitor, taskExecutor);
+
+        monitor.suspendChangeDetection();
+        monitor.fileUpdated();
+
+        verify(fileUpdateMonitor, never()).removeListener(eq(monitoredPath), eq(monitor));
+        verifyNoInteractions(taskExecutor);
+
+        monitor.resumeChangeDetection();
+
+        verify(taskExecutor).execute(any());
+    }
+
+    @Test
+    void multipleFileUpdatesDuringSuspensionScheduleOneScanOnResume(@TempDir Path tempDir) {
+        Path monitoredPath = tempDir.resolve("library.bib");
+        TaskExecutor taskExecutor = mock(TaskExecutor.class);
+        DatabaseChangeMonitor monitor = createMonitor(monitoredPath, mock(FileUpdateMonitor.class), taskExecutor);
+
+        monitor.suspendChangeDetection();
+        monitor.fileUpdated();
+        monitor.fileUpdated();
+
+        verifyNoInteractions(taskExecutor);
+
+        monitor.resumeChangeDetection();
+
+        verify(taskExecutor).execute(any());
+    }
+
+    @Test
+    void fileUpdateSchedulesScanWhenFileChanged(@TempDir Path tempDir) throws Exception {
+        Path monitoredPath = tempDir.resolve("library.bib");
+        Files.writeString(monitoredPath, "@misc{a,}");
+        TaskExecutor taskExecutor = mock(TaskExecutor.class);
+        DatabaseChangeMonitor monitor = createMonitor(monitoredPath, mock(FileUpdateMonitor.class), taskExecutor);
+
+        Files.writeString(monitoredPath, "@misc{a,}\n@misc{b,}");
+        monitor.fileUpdated();
+
+        verify(taskExecutor).execute(any());
+    }
+
+    @Test
+    void fileUpdateSkipsScanWhenFileUnchanged(@TempDir Path tempDir) throws Exception {
+        Path monitoredPath = tempDir.resolve("library.bib");
+        Files.writeString(monitoredPath, "@misc{a,}");
+        TaskExecutor taskExecutor = mock(TaskExecutor.class);
+        DatabaseChangeMonitor monitor = createMonitor(monitoredPath, mock(FileUpdateMonitor.class), taskExecutor);
+
+        monitor.fileUpdated();
+        monitor.resumeChangeDetection();
+
+        verifyNoInteractions(taskExecutor);
+    }
+
+    @Test
+    void markConsistentWithDiskSuppressesScanForOwnSave(@TempDir Path tempDir) throws Exception {
+        Path monitoredPath = tempDir.resolve("library.bib");
+        Files.writeString(monitoredPath, "@misc{a,}");
+        TaskExecutor taskExecutor = mock(TaskExecutor.class);
+        DatabaseChangeMonitor monitor = createMonitor(monitoredPath, mock(FileUpdateMonitor.class), taskExecutor);
+
+        monitor.suspendChangeDetection();
+        // Simulate JabRef's own save: the file changes, then is marked consistent before the monitor resumes
+        Files.writeString(monitoredPath, "@misc{a,}\n@misc{b,}");
+        monitor.markConsistentWithDisk();
+        monitor.fileUpdated();
+        monitor.resumeChangeDetection();
+
+        verifyNoInteractions(taskExecutor);
     }
 }

--- a/jabgui/src/test/java/org/jabref/gui/collab/DatabaseChangeMonitorTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/collab/DatabaseChangeMonitorTest.java
@@ -69,13 +69,15 @@ class DatabaseChangeMonitorTest {
     }
 
     @Test
-    void suspendChangeDetectionKeepsWatchingAndRescansOnResume(@TempDir Path tempDir) {
+    void suspendChangeDetectionKeepsWatchingAndRescansOnResume(@TempDir Path tempDir) throws Exception {
         Path monitoredPath = tempDir.resolve("library.bib");
+        Files.writeString(monitoredPath, "@misc{a,}");
         FileUpdateMonitor fileUpdateMonitor = mock(FileUpdateMonitor.class);
         TaskExecutor taskExecutor = mock(TaskExecutor.class);
         DatabaseChangeMonitor monitor = createMonitor(monitoredPath, fileUpdateMonitor, taskExecutor);
 
         monitor.suspendChangeDetection();
+        Files.writeString(monitoredPath, "@misc{a,}\n@misc{b,}");
         monitor.fileUpdated();
 
         verify(fileUpdateMonitor, never()).removeListener(eq(monitoredPath), eq(monitor));
@@ -87,12 +89,14 @@ class DatabaseChangeMonitorTest {
     }
 
     @Test
-    void multipleFileUpdatesDuringSuspensionScheduleOneScanOnResume(@TempDir Path tempDir) {
+    void multipleFileUpdatesDuringSuspensionScheduleOneScanOnResume(@TempDir Path tempDir) throws Exception {
         Path monitoredPath = tempDir.resolve("library.bib");
+        Files.writeString(monitoredPath, "@misc{a,}");
         TaskExecutor taskExecutor = mock(TaskExecutor.class);
         DatabaseChangeMonitor monitor = createMonitor(monitoredPath, mock(FileUpdateMonitor.class), taskExecutor);
 
         monitor.suspendChangeDetection();
+        Files.writeString(monitoredPath, "@misc{a,}\n@misc{b,}");
         monitor.fileUpdated();
         monitor.fileUpdated();
 
@@ -139,7 +143,7 @@ class DatabaseChangeMonitorTest {
         monitor.suspendChangeDetection();
         // Simulate JabRef's own save: the file changes, then is marked consistent before the monitor resumes
         Files.writeString(monitoredPath, "@misc{a,}\n@misc{b,}");
-        monitor.markConsistentWithDisk();
+        monitor.markConsistentWithDisk(null);
         monitor.fileUpdated();
         monitor.resumeChangeDetection();
 

--- a/jabgui/src/test/java/org/jabref/gui/exporter/SaveDatabaseActionTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/exporter/SaveDatabaseActionTest.java
@@ -49,6 +49,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -192,6 +193,30 @@ class SaveDatabaseActionTest {
 
         assertEquals("external content", Files.readString(file));
         assertFalse(result);
+    }
+
+    @Test
+    @ExtendWith(ApplicationExtension.class)
+    void ignoredEncodingProblemsReportFailureWhenFileWasSavedExternallyWhileDialogWasOpen() throws Exception {
+        BibEntry entry = new BibEntry().withField(StandardField.AUTHOR, "Café");
+        entry.setChanged(true);
+        BibDatabase database = new BibDatabase(List.of(entry));
+        saveDatabaseAction = createSaveDatabaseActionForBibDatabase(database);
+        when(dbContext.getMetaData().getEncoding()).thenReturn(Optional.of(StandardCharsets.US_ASCII));
+        // While the encoding-problems dialog is open, another program saves the file; the user then clicks "Ignore".
+        // The committed first write no longer is the file's content, so the save must not be reported as successful.
+        when(dialogService.showCustomDialogAndWait(any(String.class), any(DialogPane.class), any(ButtonType.class), any(ButtonType.class)))
+                .thenAnswer(invocation -> {
+                    Files.writeString(file, "external content");
+                    ButtonType ignore = invocation.getArgument(2);
+                    return Optional.of(ignore);
+                });
+
+        boolean result = saveDatabaseAction.save();
+
+        assertEquals("external content", Files.readString(file));
+        assertFalse(result);
+        verify(libraryTab, never()).resetChangedProperties();
     }
 
     @Test

--- a/jabgui/src/test/java/org/jabref/gui/exporter/SaveDatabaseActionTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/exporter/SaveDatabaseActionTest.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.exporter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -9,6 +10,8 @@ import java.util.stream.Collectors;
 
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.DialogPane;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.LibraryTab;
@@ -37,6 +40,8 @@ import org.jabref.model.metadata.SaveOrder;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -162,6 +167,30 @@ class SaveDatabaseActionTest {
     void saveShouldNotSaveDatabaseIfPathNotSet() {
         when(dbContext.getDatabasePath()).thenReturn(Optional.empty());
         boolean result = saveDatabaseAction.save();
+        assertFalse(result);
+    }
+
+    @Test
+    @ExtendWith(ApplicationExtension.class)
+    void encodingRetryAbortsWhenFileWasSavedExternallyWhileDialogWasOpen() throws Exception {
+        BibEntry entry = new BibEntry().withField(StandardField.AUTHOR, "Café");
+        entry.setChanged(true);
+        BibDatabase database = new BibDatabase(List.of(entry));
+        saveDatabaseAction = createSaveDatabaseActionForBibDatabase(database);
+        when(dbContext.getMetaData().getEncoding()).thenReturn(Optional.of(StandardCharsets.US_ASCII));
+        // "Café" is not encodable in US-ASCII, so the encoding-problems dialog opens. While it is open, another
+        // program saves the file; the user then chooses to retry with a different encoding.
+        when(dialogService.showCustomDialogAndWait(any(String.class), any(DialogPane.class), any(ButtonType.class), any(ButtonType.class)))
+                .thenAnswer(invocation -> {
+                    Files.writeString(file, "external content");
+                    ButtonType tryDifferentEncoding = invocation.getArgument(3);
+                    return Optional.of(tryDifferentEncoding);
+                });
+        when(dialogService.showChoiceDialogAndWait(any(), any(), any(), any(), any())).thenReturn(Optional.of(StandardCharsets.UTF_8));
+
+        boolean result = saveDatabaseAction.save();
+
+        assertEquals("external content", Files.readString(file));
         assertFalse(result);
     }
 

--- a/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -113,7 +113,7 @@ public class AtomicFileOutputStream extends FilterOutputStream {
     /// Creates a new output stream to write to or replace the file at the specified path.
     ///
     /// @param path       the path of the file to write to or replace
-     /// @param keepBackup whether to keep the backup file (.sav) after a successful write process
+    /// @param keepBackup whether to keep the backup file (.sav) after a successful write process
     public AtomicFileOutputStream(Path path, boolean keepBackup) throws IOException {
         this(path, createTemporaryFile(path), keepBackup, AtomicFileOutputStream::moveAtomically, AtomicFileOutputStream::copyReplacingExisting);
     }
@@ -197,6 +197,7 @@ public class AtomicFileOutputStream extends FilterOutputStream {
     /// opened. Comparison is based on size and modification time, so a concurrent write within the file system's
     /// timestamp resolution that also keeps the size identical goes undetected. There is also an unavoidable race
     /// between this check and the subsequent commit; the check is therefore repeated as late as possible.
+    // [impl->req~logic.exporter.concurrent-save-detection~1]
     private void ensureTargetFileUnchanged() throws FileChangedException {
         if (targetFileSnapshot == null) {
             return;

--- a/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -122,9 +122,9 @@ public class AtomicFileOutputStream extends FilterOutputStream {
     /// @param path          the path of the file to write to or replace
     /// @param keepBackup    whether to keep the backup file (.sav) after a successful write process
     /// @param expectedState the state the target file is expected to (still) be in when this stream commits — a
-    ///                      snapshot from an earlier point of the same logical operation, so that a concurrent write
-    ///                      landing before this stream was even opened is still detected; `null` to verify against
-    ///                      the state at stream creation
+    ///                                           snapshot from an earlier point of the same logical operation, so that a concurrent write
+    ///                                           landing before this stream was even opened is still detected; `null` to verify against
+    ///                                           the state at stream creation
     public AtomicFileOutputStream(Path path, boolean keepBackup, @Nullable FileSnapshot expectedState) throws IOException {
         this(path, createTemporaryFile(path), keepBackup, expectedState, AtomicFileOutputStream::moveAtomically, AtomicFileOutputStream::copyReplacingExisting);
     }

--- a/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -10,9 +10,12 @@ import java.nio.channels.FileChannel;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
 import java.util.Set;
@@ -47,6 +50,9 @@ import org.slf4j.LoggerFactory;
 /// original file untouched).
 /// 2. If anything goes wrong while copying the temporary file to the target file, the backup of the original file is
 /// kept.
+/// 3. If the target file was modified by another process between opening this stream and committing it (e.g. a second
+/// JabRef instance saving the same library), the commit is aborted with a [FileChangedException], leaving the other
+/// process's version of the file untouched.
 ///
 /// Implementation inspired by code from [Marty Lamb](https://github.com/martylamb/atomicfileoutputstream/blob/master/src/main/java/com/martiansoftware/io/AtomicFileOutputStream.java) and [Apache](https://github.com/apache/zookeeper/blob/master/src/java/main/org/apache/zookeeper/common/AtomicFileOutputStream.java).
 @NullMarked
@@ -83,7 +89,16 @@ public class AtomicFileOutputStream extends FilterOutputStream {
 
     private final FileCopyOperation backupFileCopyOperation;
 
+    /// State of the target file when this stream was opened. `null` if the attributes could not be read, in which case
+    /// concurrent-change detection is disabled for this write.
+    @Nullable private final TargetFileSnapshot targetFileSnapshot;
+
     private boolean errorDuringWrite = false;
+
+    /// Existence, size, and modification time of the target file, used to detect writes by other processes.
+    private record TargetFileSnapshot(boolean exists, long size, @Nullable FileTime lastModifiedTime) {
+        private static final TargetFileSnapshot ABSENT = new TargetFileSnapshot(false, -1, null);
+    }
 
     @FunctionalInterface
     interface FileMoveOperation {
@@ -98,7 +113,7 @@ public class AtomicFileOutputStream extends FilterOutputStream {
     /// Creates a new output stream to write to or replace the file at the specified path.
     ///
     /// @param path       the path of the file to write to or replace
-    /// @param keepBackup whether to keep the backup file (.sav) after a successful write process
+     /// @param keepBackup whether to keep the backup file (.sav) after a successful write process
     public AtomicFileOutputStream(Path path, boolean keepBackup) throws IOException {
         this(path, createTemporaryFile(path), keepBackup, AtomicFileOutputStream::moveAtomically, AtomicFileOutputStream::copyReplacingExisting);
     }
@@ -162,6 +177,34 @@ public class AtomicFileOutputStream extends FilterOutputStream {
         this.temporaryFileChannel = temporaryFileChannel;
         this.fileMoveOperation = fileMoveOperation;
         this.backupFileCopyOperation = backupFileCopyOperation;
+        this.targetFileSnapshot = snapshotTargetFile(path);
+    }
+
+    @Nullable
+    private static TargetFileSnapshot snapshotTargetFile(Path targetFile) {
+        try {
+            BasicFileAttributes attributes = Files.readAttributes(targetFile, BasicFileAttributes.class);
+            return new TargetFileSnapshot(true, attributes.size(), attributes.lastModifiedTime());
+        } catch (NoSuchFileException exception) {
+            return TargetFileSnapshot.ABSENT;
+        } catch (IOException exception) {
+            LOGGER.warn("Could not read attributes of {}. Concurrent-change detection is disabled for this write.", targetFile, exception);
+            return null;
+        }
+    }
+
+    /// Best-effort lost-update guard: detects whether another process modified the target file after this stream was
+    /// opened. Comparison is based on size and modification time, so a concurrent write within the file system's
+    /// timestamp resolution that also keeps the size identical goes undetected. There is also an unavoidable race
+    /// between this check and the subsequent commit; the check is therefore repeated as late as possible.
+    private void ensureTargetFileUnchanged() throws FileChangedException {
+        if (targetFileSnapshot == null) {
+            return;
+        }
+        TargetFileSnapshot currentState = snapshotTargetFile(targetFile);
+        if (currentState != null && !targetFileSnapshot.equals(currentState)) {
+            throw new FileChangedException(targetFile);
+        }
     }
 
     private static Path createTemporaryFile(Path targetFile) throws IOException {
@@ -242,6 +285,9 @@ public class AtomicFileOutputStream extends FilterOutputStream {
                 return;
             }
 
+            // Check before creating the backup, so that no backup of a concurrently written file is left behind
+            ensureTargetFileUnchanged();
+
             boolean mustOverwriteTargetInPlace = targetHasHardLinks() || Files.isSymbolicLink(targetFile);
 
             // We successfully wrote everything to the temporary file, lets copy it to the correct place
@@ -261,6 +307,10 @@ public class AtomicFileOutputStream extends FilterOutputStream {
                     }
                 }
             }
+
+            // Re-check right before the commit: creating the backup of a large file can take a while, so the first
+            // check may be long in the past by now
+            ensureTargetFileUnchanged();
 
             if (mustOverwriteTargetInPlace) {
                 if (!backupCreated) {

--- a/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -10,18 +10,16 @@ import java.nio.channels.FileChannel;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
 import java.util.Set;
 
 import org.jabref.logic.os.OS;
 import org.jabref.logic.util.BackupFileType;
+import org.jabref.logic.util.io.FileSnapshot;
 import org.jabref.logic.util.io.FileUtil;
 
 import org.jspecify.annotations.NullMarked;
@@ -89,16 +87,16 @@ public class AtomicFileOutputStream extends FilterOutputStream {
 
     private final FileCopyOperation backupFileCopyOperation;
 
-    /// State of the target file when this stream was opened. `null` if the attributes could not be read, in which case
-    /// concurrent-change detection is disabled for this write.
-    @Nullable private final TargetFileSnapshot targetFileSnapshot;
+    /// The state the target file must still be in when this stream commits: an inherited baseline (see the
+    /// [#AtomicFileOutputStream(Path,boolean,FileSnapshot)] constructor), or the state at stream creation. `null` if
+    /// the attributes could not be read, in which case concurrent-change detection is disabled for this write.
+    @Nullable private final FileSnapshot expectedTargetFileState;
+
+    /// State of the target file right after a successful commit; `null` before the commit, after an aborted or failed
+    /// one, and when the attributes could not be read.
+    @Nullable private FileSnapshot committedTargetFileState;
 
     private boolean errorDuringWrite = false;
-
-    /// Existence, size, and modification time of the target file, used to detect writes by other processes.
-    private record TargetFileSnapshot(boolean exists, long size, @Nullable FileTime lastModifiedTime) {
-        private static final TargetFileSnapshot ABSENT = new TargetFileSnapshot(false, -1, null);
-    }
 
     @FunctionalInterface
     interface FileMoveOperation {
@@ -115,26 +113,41 @@ public class AtomicFileOutputStream extends FilterOutputStream {
     /// @param path       the path of the file to write to or replace
     /// @param keepBackup whether to keep the backup file (.sav) after a successful write process
     public AtomicFileOutputStream(Path path, boolean keepBackup) throws IOException {
-        this(path, createTemporaryFile(path), keepBackup, AtomicFileOutputStream::moveAtomically, AtomicFileOutputStream::copyReplacingExisting);
+        this(path, keepBackup, null);
+    }
+
+    /// Creates a new output stream to write to or replace the file at the specified path, verifying against an
+    /// inherited baseline instead of the file's state at stream creation.
+    ///
+    /// @param path          the path of the file to write to or replace
+    /// @param keepBackup    whether to keep the backup file (.sav) after a successful write process
+    /// @param expectedState the state the target file is expected to (still) be in when this stream commits — a
+    ///                      snapshot from an earlier point of the same logical operation, so that a concurrent write
+    ///                      landing before this stream was even opened is still detected; `null` to verify against
+    ///                      the state at stream creation
+    public AtomicFileOutputStream(Path path, boolean keepBackup, @Nullable FileSnapshot expectedState) throws IOException {
+        this(path, createTemporaryFile(path), keepBackup, expectedState, AtomicFileOutputStream::moveAtomically, AtomicFileOutputStream::copyReplacingExisting);
     }
 
     /// The temporary file is opened as a [FileChannel], because the channel is needed for [FileChannel#force(boolean)].
     /// `Files.newOutputStream(...)` returns a `sun.nio.ch.ChannelOutputStream`, which does not offer it.
-    private AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, boolean keepBackup, FileMoveOperation fileMoveOperation, FileCopyOperation backupFileCopyOperation) throws IOException {
+    private AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, boolean keepBackup, @Nullable FileSnapshot expectedState, FileMoveOperation fileMoveOperation, FileCopyOperation backupFileCopyOperation) throws IOException {
         this(path,
                 pathOfTemporaryFile,
                 FileChannel.open(pathOfTemporaryFile, StandardOpenOption.WRITE),
                 keepBackup,
+                expectedState,
                 fileMoveOperation,
                 backupFileCopyOperation);
     }
 
-    private AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, FileChannel temporaryFileChannel, boolean keepBackup, FileMoveOperation fileMoveOperation, FileCopyOperation backupFileCopyOperation) throws IOException {
+    private AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, FileChannel temporaryFileChannel, boolean keepBackup, @Nullable FileSnapshot expectedState, FileMoveOperation fileMoveOperation, FileCopyOperation backupFileCopyOperation) throws IOException {
         this(path,
                 pathOfTemporaryFile,
                 Channels.newOutputStream(temporaryFileChannel),
                 temporaryFileChannel,
                 keepBackup,
+                expectedState,
                 fileMoveOperation,
                 backupFileCopyOperation);
     }
@@ -159,7 +172,7 @@ public class AtomicFileOutputStream extends FilterOutputStream {
 
     /// Required for proper testing
     AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, OutputStream temporaryFileOutputStream, boolean keepBackup, FileMoveOperation fileMoveOperation, FileCopyOperation backupFileCopyOperation) throws IOException {
-        this(path, pathOfTemporaryFile, temporaryFileOutputStream, null, keepBackup, fileMoveOperation, backupFileCopyOperation);
+        this(path, pathOfTemporaryFile, temporaryFileOutputStream, null, keepBackup, null, fileMoveOperation, backupFileCopyOperation);
     }
 
     private AtomicFileOutputStream(Path path,
@@ -167,6 +180,7 @@ public class AtomicFileOutputStream extends FilterOutputStream {
                                    OutputStream temporaryFileOutputStream,
                                    @Nullable FileChannel temporaryFileChannel,
                                    boolean keepBackup,
+                                   @Nullable FileSnapshot expectedState,
                                    FileMoveOperation fileMoveOperation,
                                    FileCopyOperation backupFileCopyOperation) throws IOException {
         super(temporaryFileOutputStream);
@@ -177,35 +191,33 @@ public class AtomicFileOutputStream extends FilterOutputStream {
         this.temporaryFileChannel = temporaryFileChannel;
         this.fileMoveOperation = fileMoveOperation;
         this.backupFileCopyOperation = backupFileCopyOperation;
-        this.targetFileSnapshot = snapshotTargetFile(path);
+        this.expectedTargetFileState = expectedState != null ? expectedState : FileSnapshot.read(path);
     }
 
-    @Nullable
-    private static TargetFileSnapshot snapshotTargetFile(Path targetFile) {
-        try {
-            BasicFileAttributes attributes = Files.readAttributes(targetFile, BasicFileAttributes.class);
-            return new TargetFileSnapshot(true, attributes.size(), attributes.lastModifiedTime());
-        } catch (NoSuchFileException exception) {
-            return TargetFileSnapshot.ABSENT;
-        } catch (IOException exception) {
-            LOGGER.warn("Could not read attributes of {}. Concurrent-change detection is disabled for this write.", targetFile, exception);
-            return null;
-        }
-    }
-
-    /// Best-effort lost-update guard: detects whether another process modified the target file after this stream was
-    /// opened. Comparison is based on size and modification time, so a concurrent write within the file system's
-    /// timestamp resolution that also keeps the size identical goes undetected. There is also an unavoidable race
-    /// between this check and the subsequent commit; the check is therefore repeated as late as possible.
+    /// Best-effort lost-update guard: detects whether another process modified the target file after the expected
+    /// baseline state was captured. See [FileSnapshot] for the limits of the comparison; additionally, there is an
+    /// unavoidable race between this check and the subsequent commit, so the check is repeated as late as possible.
+    /// An unreadable current state does not abort the write (the commit itself will surface real I/O problems).
     // [impl->req~logic.exporter.concurrent-save-detection~1]
     private void ensureTargetFileUnchanged() throws FileChangedException {
-        if (targetFileSnapshot == null) {
+        if (expectedTargetFileState == null) {
             return;
         }
-        TargetFileSnapshot currentState = snapshotTargetFile(targetFile);
-        if (currentState != null && !targetFileSnapshot.equals(currentState)) {
+        FileSnapshot currentState = FileSnapshot.read(targetFile);
+        if (currentState != null && !expectedTargetFileState.equals(currentState)) {
             throw new FileChangedException(targetFile);
         }
+    }
+
+    /// Returns the state of the target file as written by this stream, captured immediately after the successful
+    /// commit. Callers spanning a longer logical operation (e.g. a save that may be retried with a different encoding
+    /// after a user dialog) can pass it as the expected state of a follow-up stream, so that the whole operation is
+    /// guarded against concurrent writes — including the time between the two streams.
+    ///
+    /// @return the committed state, or `null` when the stream did not commit (yet) or the attributes could not be read
+    @Nullable
+    public FileSnapshot getCommittedTargetFileState() {
+        return committedTargetFileState;
     }
 
     private static Path createTemporaryFile(Path targetFile) throws IOException {
@@ -338,6 +350,10 @@ public class AtomicFileOutputStream extends FilterOutputStream {
                 // Move temporary file (replace original if it exists)
                 moveTemporaryFileToTargetFile(backupCreated);
             }
+
+            // Captured directly after the commit, so the window in which a concurrent write could be mistaken for our
+            // own is as small as possible
+            committedTargetFileState = FileSnapshot.read(targetFile);
 
             // Restore file permissions
             if (FileUtil.IS_POSIX_COMPLIANT) {

--- a/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -311,7 +311,21 @@ public class AtomicFileOutputStream extends FilterOutputStream {
 
             // Re-check right before the commit: creating the backup of a large file can take a while, so the first
             // check may be long in the past by now
-            ensureTargetFileUnchanged();
+            try {
+                ensureTargetFileUnchanged();
+            } catch (FileChangedException exception) {
+                // The target is untouched, so the backup written by this aborted attempt has no recovery value (unlike
+                // on commit failures, where the backup is deliberately kept). With keepBackup, a backup file is
+                // expected to persist across saves, so the (overwritten) one is left in place.
+                if (backupCreated && !keepBackup) {
+                    try {
+                        Files.deleteIfExists(backupFile);
+                    } catch (IOException deleteException) {
+                        exception.addSuppressed(deleteException);
+                    }
+                }
+                throw exception;
+            }
 
             if (mustOverwriteTargetInPlace) {
                 if (!backupCreated) {

--- a/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -121,10 +121,7 @@ public class AtomicFileOutputStream extends FilterOutputStream {
     ///
     /// @param path          the path of the file to write to or replace
     /// @param keepBackup    whether to keep the backup file (.sav) after a successful write process
-    /// @param expectedState the state the target file is expected to (still) be in when this stream commits — a
-    ///                                           snapshot from an earlier point of the same logical operation, so that a concurrent write
-    ///                                           landing before this stream was even opened is still detected; `null` to verify against
-    ///                                           the state at stream creation
+    /// @param expectedState the state the target file is expected to (still) be in when this stream commits — a snapshot from an earlier point of the same logical operation, so that a concurrent write landing before this stream was even opened is still detected; `null` to verify against the state at stream creation
     public AtomicFileOutputStream(Path path, boolean keepBackup, @Nullable FileSnapshot expectedState) throws IOException {
         this(path, createTemporaryFile(path), keepBackup, expectedState, AtomicFileOutputStream::moveAtomically, AtomicFileOutputStream::copyReplacingExisting);
     }

--- a/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileWriter.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileWriter.java
@@ -9,6 +9,10 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.jabref.logic.util.io.FileSnapshot;
+
+import org.jspecify.annotations.Nullable;
+
 /// Writer that similar to the built-in {@link java.io.FileWriter} but uses the {@link AtomicFileOutputStream} as the
 /// underlying output stream. In this way, we make sure that the errors during the write process do not destroy the
 /// contents of the target file.
@@ -16,6 +20,7 @@ import java.util.TreeSet;
 /// was problematic can be retrieved by {@link #getEncodingProblems()}.
 public class AtomicFileWriter extends OutputStreamWriter {
 
+    private final AtomicFileOutputStream outputStream;
     private final CharsetEncoder encoder;
     private final Set<Character> problemCharacters = new TreeSet<>();
 
@@ -24,8 +29,24 @@ public class AtomicFileWriter extends OutputStreamWriter {
     }
 
     public AtomicFileWriter(Path file, Charset encoding, boolean keepBackup) throws IOException {
-        super(new AtomicFileOutputStream(file, keepBackup), encoding);
+        this(file, encoding, keepBackup, null);
+    }
+
+    /// @param expectedState see [AtomicFileOutputStream#AtomicFileOutputStream(Path,boolean,FileSnapshot)]
+    public AtomicFileWriter(Path file, Charset encoding, boolean keepBackup, @Nullable FileSnapshot expectedState) throws IOException {
+        this(new AtomicFileOutputStream(file, keepBackup, expectedState), encoding);
+    }
+
+    private AtomicFileWriter(AtomicFileOutputStream outputStream, Charset encoding) {
+        super(outputStream, encoding);
+        this.outputStream = outputStream;
         encoder = encoding.newEncoder();
+    }
+
+    /// See [AtomicFileOutputStream#getCommittedTargetFileState()]; remains accessible after [#close()].
+    @Nullable
+    public FileSnapshot getCommittedTargetFileState() {
+        return outputStream.getCommittedTargetFileState();
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/exporter/FileChangedException.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/FileChangedException.java
@@ -1,0 +1,16 @@
+package org.jabref.logic.exporter;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.jspecify.annotations.NullMarked;
+
+/// Thrown when the target file of an [AtomicFileOutputStream] was modified by another process between opening the
+/// stream and committing it. The commit is aborted so that the other process's changes are not overwritten silently.
+@NullMarked
+public class FileChangedException extends IOException {
+
+    public FileChangedException(Path targetFile) {
+        super("File " + targetFile + " was modified by another process while it was being written. The write was aborted to not overwrite the concurrent changes.");
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/util/io/FileSnapshot.java
+++ b/jablib/src/main/java/org/jabref/logic/util/io/FileSnapshot.java
@@ -1,0 +1,54 @@
+package org.jabref.logic.util.io;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/// Existence, size, and modification time of a file at one point in time — a version stamp for optimistic concurrency
+/// control on files: capture a snapshot before a multi-step operation, compare against a fresh one before committing,
+/// and treat a mismatch as a concurrent modification by another process.
+///
+/// The comparison is best-effort: a concurrent write within the file system's timestamp resolution that also keeps
+/// the size identical goes undetected.
+///
+/// @param exists           whether the file existed; when `false`, size and modification time carry no meaning
+/// @param size             the file size in bytes, `-1` when the file did not exist
+/// @param lastModifiedTime the modification time, `null` when the file did not exist
+@NullMarked
+public record FileSnapshot(boolean exists, long size, @Nullable FileTime lastModifiedTime) {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileSnapshot.class);
+
+    private static final FileSnapshot ABSENT = new FileSnapshot(false, -1, null);
+
+    /// Captures the current state of the given file. A missing file yields a snapshot with `exists() == false`.
+    ///
+    /// @return the snapshot, or `null` when the attributes could not be read (detection should then be disabled
+    /// rather than misreporting a conflict)
+    @Nullable
+    public static FileSnapshot read(Path file) {
+        try {
+            BasicFileAttributes attributes = Files.readAttributes(file, BasicFileAttributes.class);
+            return new FileSnapshot(true, attributes.size(), attributes.lastModifiedTime());
+        } catch (NoSuchFileException exception) {
+            return ABSENT;
+        } catch (IOException exception) {
+            LOGGER.warn("Could not read attributes of {}", file, exception);
+            return null;
+        }
+    }
+
+    /// Best-effort check whether the given file still is in the state captured by this snapshot. An unreadable current
+    /// state counts as a mismatch.
+    public boolean matches(Path file) {
+        return this.equals(read(file));
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/util/io/FileSnapshot.java
+++ b/jablib/src/main/java/org/jabref/logic/util/io/FileSnapshot.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 /// @param lastModifiedTime the modification time, `null` when the file did not exist
 @NullMarked
 public record FileSnapshot(boolean exists, long size, @Nullable FileTime lastModifiedTime) {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(FileSnapshot.class);
 
     private static final FileSnapshot ABSENT = new FileSnapshot(false, -1, null);

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -2178,6 +2178,7 @@ Dismiss\ changes=Dismiss changes
 The\ library\ has\ been\ modified.=The library has been modified.
 Library\ '%0'\ has\ been\ modified.=Library '%0' has been modified.
 The\ library\ has\ been\ modified\ by\ another\ program.=The library has been modified by another program.
+The\ library\ file\ was\ modified\ by\ another\ program\ while\ saving.\ To\ avoid\ overwriting\ those\ changes,\ your\ changes\ were\ not\ saved.\ Please\ review\ the\ changes\ on\ disk\ and\ save\ again.=The library file was modified by another program while saving. To avoid overwriting those changes, your changes were not saved. Please review the changes on disk and save again.
 Save\ changes=Save changes
 Discard\ changes=Discard changes
 

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -2178,7 +2178,7 @@ Dismiss\ changes=Dismiss changes
 The\ library\ has\ been\ modified.=The library has been modified.
 Library\ '%0'\ has\ been\ modified.=Library '%0' has been modified.
 The\ library\ has\ been\ modified\ by\ another\ program.=The library has been modified by another program.
-The\ library\ file\ was\ modified\ by\ another\ program\ while\ saving.\ To\ avoid\ overwriting\ those\ changes,\ your\ changes\ were\ not\ saved.\ Please\ review\ the\ changes\ on\ disk\ and\ save\ again.=The library file was modified by another program while saving. To avoid overwriting those changes, your changes were not saved. Please review the changes on disk and save again.
+Library\ was\ not\ saved\:\ the\ file\ was\ modified\ by\ another\ program.=Library was not saved: the file was modified by another program.
 Save\ changes=Save changes
 Discard\ changes=Discard changes
 

--- a/jablib/src/test/java/org/jabref/logic/exporter/AtomicFileOutputStreamTest.java
+++ b/jablib/src/test/java/org/jabref/logic/exporter/AtomicFileOutputStreamTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
+import org.jabref.logic.util.io.FileSnapshot;
 import org.jabref.logic.util.io.FileUtil;
 
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
@@ -137,6 +139,34 @@ class AtomicFileOutputStreamTest {
 
         assertEquals("changed during backup", Files.readString(targetFile));
         assertFalse(Files.exists(atomicFileOutputStream.getBackup()));
+    }
+
+    @Test
+    void inheritedBaselineDetectsChangePredatingStreamCreation(@TempDir Path tempDir) throws IOException {
+        Path targetFile = tempDir.resolve("inherited-baseline.txt");
+        Files.writeString(targetFile, FIFTY_CHARS);
+        FileSnapshot baseline = FileSnapshot.read(targetFile);
+        // The concurrent write happens before the stream is opened — only the inherited baseline can detect it
+        Files.writeString(targetFile, "changed before stream creation");
+
+        AtomicFileOutputStream atomicFileOutputStream = new AtomicFileOutputStream(targetFile, false, baseline);
+        atomicFileOutputStream.write(FIVE_THOUSAND_CHARS.getBytes());
+
+        assertThrows(FileChangedException.class, atomicFileOutputStream::close);
+        assertEquals("changed before stream creation", Files.readString(targetFile));
+    }
+
+    @Test
+    void committedTargetFileStateMatchesFileAfterSuccessfulClose(@TempDir Path tempDir) throws IOException {
+        Path targetFile = tempDir.resolve("committed-state.txt");
+        Files.writeString(targetFile, FIFTY_CHARS);
+
+        AtomicFileOutputStream atomicFileOutputStream = new AtomicFileOutputStream(targetFile);
+        assertNull(atomicFileOutputStream.getCommittedTargetFileState());
+        atomicFileOutputStream.write(FIVE_THOUSAND_CHARS.getBytes());
+        atomicFileOutputStream.close();
+
+        assertEquals(FileSnapshot.read(targetFile), atomicFileOutputStream.getCommittedTargetFileState());
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/exporter/AtomicFileOutputStreamTest.java
+++ b/jablib/src/test/java/org/jabref/logic/exporter/AtomicFileOutputStreamTest.java
@@ -64,6 +64,7 @@ class AtomicFileOutputStreamTest {
         assertEquals(FIVE_THOUSAND_CHARS, Files.readString(targetFile));
     }
 
+    // [utest->req~logic.exporter.concurrent-save-detection~1]
     @Test
     void interleavedSavesDoNotOverwriteEachOther(@TempDir Path tempDir) throws IOException {
         Path targetFile = tempDir.resolve("simultaneous-save.txt");

--- a/jablib/src/test/java/org/jabref/logic/exporter/AtomicFileOutputStreamTest.java
+++ b/jablib/src/test/java/org/jabref/logic/exporter/AtomicFileOutputStreamTest.java
@@ -8,7 +8,9 @@ import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import org.jabref.logic.util.io.FileUtil;
 
@@ -63,7 +65,7 @@ class AtomicFileOutputStreamTest {
     }
 
     @Test
-    void interleavedSavesUseSeparateTemporaryFiles(@TempDir Path tempDir) throws IOException {
+    void interleavedSavesDoNotOverwriteEachOther(@TempDir Path tempDir) throws IOException {
         Path targetFile = tempDir.resolve("simultaneous-save.txt");
         Files.writeString(targetFile, FIFTY_CHARS);
 
@@ -75,8 +77,51 @@ class AtomicFileOutputStreamTest {
         firstSave.close();
         assertEquals("first", Files.readString(targetFile));
 
-        secondSave.close();
-        assertEquals("second", Files.readString(targetFile));
+        // The save finishing last must not win: it would overwrite the content committed by the first save
+        assertThrows(FileChangedException.class, secondSave::close);
+        assertEquals("first", Files.readString(targetFile));
+        try (Stream<Path> remainingFiles = Files.list(tempDir)) {
+            // Neither a temporary nor a backup file of the aborted save is left behind
+            assertEquals(List.of(targetFile), remainingFiles.toList());
+        }
+    }
+
+    @Test
+    void externalChangeOfTargetAbortsSave(@TempDir Path tempDir) throws IOException {
+        Path targetFile = tempDir.resolve("externally-changed.txt");
+        Files.writeString(targetFile, FIFTY_CHARS);
+
+        AtomicFileOutputStream atomicFileOutputStream = new AtomicFileOutputStream(targetFile);
+        atomicFileOutputStream.write(FIVE_THOUSAND_CHARS.getBytes());
+        Files.writeString(targetFile, "externally changed");
+
+        assertThrows(FileChangedException.class, atomicFileOutputStream::close);
+        assertEquals("externally changed", Files.readString(targetFile));
+    }
+
+    @Test
+    void externalCreationOfTargetAbortsSave(@TempDir Path tempDir) throws IOException {
+        Path targetFile = tempDir.resolve("externally-created.txt");
+
+        AtomicFileOutputStream atomicFileOutputStream = new AtomicFileOutputStream(targetFile);
+        atomicFileOutputStream.write(FIVE_THOUSAND_CHARS.getBytes());
+        Files.writeString(targetFile, "externally created");
+
+        assertThrows(FileChangedException.class, atomicFileOutputStream::close);
+        assertEquals("externally created", Files.readString(targetFile));
+    }
+
+    @Test
+    void externalDeletionOfTargetAbortsSave(@TempDir Path tempDir) throws IOException {
+        Path targetFile = tempDir.resolve("externally-deleted.txt");
+        Files.writeString(targetFile, FIFTY_CHARS);
+
+        AtomicFileOutputStream atomicFileOutputStream = new AtomicFileOutputStream(targetFile);
+        atomicFileOutputStream.write(FIVE_THOUSAND_CHARS.getBytes());
+        Files.delete(targetFile);
+
+        assertThrows(FileChangedException.class, atomicFileOutputStream::close);
+        assertFalse(Files.exists(targetFile));
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/exporter/AtomicFileOutputStreamTest.java
+++ b/jablib/src/test/java/org/jabref/logic/exporter/AtomicFileOutputStreamTest.java
@@ -113,6 +113,33 @@ class AtomicFileOutputStreamTest {
     }
 
     @Test
+    void externalChangeDuringBackupCreationLeavesNoBackupBehind(@TempDir Path tempDir) throws IOException {
+        Path targetFile = tempDir.resolve("changed-during-backup.txt");
+        Path temporaryFile = tempDir.resolve("changed-during-backup.txt.tmp");
+        Files.writeString(targetFile, FIFTY_CHARS);
+
+        AtomicFileOutputStream atomicFileOutputStream = new AtomicFileOutputStream(
+                targetFile,
+                temporaryFile,
+                Files.newOutputStream(temporaryFile),
+                false,
+                (source, target) -> {
+                    throw new AssertionError("The aborted save must not commit");
+                },
+                (source, target) -> {
+                    Files.copy(source, target);
+                    // Simulate a concurrent writer hitting the target while the backup copy is running
+                    Files.writeString(source, "changed during backup");
+                });
+        atomicFileOutputStream.write(FIVE_THOUSAND_CHARS.getBytes());
+
+        assertThrows(FileChangedException.class, atomicFileOutputStream::close);
+
+        assertEquals("changed during backup", Files.readString(targetFile));
+        assertFalse(Files.exists(atomicFileOutputStream.getBackup()));
+    }
+
+    @Test
     void externalDeletionOfTargetAbortsSave(@TempDir Path tempDir) throws IOException {
         Path targetFile = tempDir.resolve("externally-deleted.txt");
         Files.writeString(targetFile, FIFTY_CHARS);


### PR DESCRIPTION
### 🤖 Summary

When two JabRef instances (e.g., on two machines sharing a `.bib` file on a network share) save the same library at overlapping times, the save finishing last silently overwrote the other instance's changes — and on the in-place overwrite path introduced for hard links / non-atomic file systems, two concurrent writers could even interleave into a corrupted file. `AtomicFileOutputStream` now snapshots the target file's existence, size, and modification time when the stream is opened and verifies it again before committing; on a mismatch it aborts with the new `FileChangedException`, leaving the concurrently written file intact. Instead of an exception dialog, the user gets a proper flow: `SaveDatabaseAction` shows a "Library was not saved: the file was modified by another program." notification, and the standard "External changes detected" review flow is offered for the concurrent write. The user's changes stay in memory: they can review/merge the external changes and save again.

This PR also integrates #16613 (co-authored by @Siedlerchr) and therefore closes it: `DatabaseChangeMonitor` now stays registered during saves and only defers event handling, scanning once on resume — so filesystem events arriving mid-save are no longer lost (previously the monitor was unregistered and recreated, silently dropping them). On top of #16613's approach, a cheap size+modification-time guard skips the full library parse whenever the file still matches the last state known to be consistent with memory (library load, successful save, all external changes merged) — so JabRef's own writes do not cause a re-parse of a large library after every save, and the post-save scan only runs when something external actually changed the file. As a drive-by, the different-encoding retry in `SaveDatabaseAction` was moved out of the writer's try-with-resources, because the outer writer's `close()` previously re-committed the badly encoded content *after* the re-encoded save (and would now trip the conflict detection).

The guard state is modeled explicitly as optimistic concurrency control: a single public value type `org.jabref.logic.util.io.FileSnapshot` (existence + size + mtime — the version stamp) is the one implementation of the baseline concept and flows through the layers instead of being re-derived. `AtomicFileOutputStream` verifies the target against an expected snapshot before committing (accepting an inherited baseline, so a follow-up writer can span a longer logical operation such as the encoding-retry) and exposes the snapshot of what it committed; `SaveDatabaseAction` threads that committed snapshot through the encoding dialogs into the retry writer and finally into `LibraryTab.resetChangedProperties(FileSnapshot)` → `DatabaseChangeMonitor.markConsistentWithDisk(...)`, so the monitor knows the post-save disk state without re-reading the file. The detection is best-effort (size + mtime, subject to file system timestamp resolution), which is documented on `FileSnapshot` and in a new requirement `req~logic.exporter.concurrent-save-detection~1`.

The encoding-problems dialogs are covered by the same mechanism: an external save landing while they are open (they can sit for hours) aborts the retry — and, without a retry ("Ignore"/cancel), aborts reporting success — through the regular conflict path, with regression tests for both.

`jabref-contrib-policy:4.2:reviewed​:ok`

**Analogies:** This PR is like honey, because a save should preserve everything the bees (both instances) collected instead of letting one hive raid the other. It is like chocolate, because atomic commits should stay whole — nobody wants two half-melted bars swirled into one. And it is like the moon, because two writers orbiting the same file must not eclipse each other's changes.

### Steps to test

1. Open a reasonably large library (the bigger, the longer the save window; tens of thousands of entries make it easy to hit).
2. Make a change in JabRef so the library is marked as modified.
3. Save (Ctrl+S) and, while the save is running, modify the `.bib` file externally (e.g. `echo "% external" >> library.bib` in a terminal — a loop appending every 100 ms makes the timing trivial).
4. JabRef aborts the save and shows the notifications below: the save was not performed, and the standard "External changes detected" notification offers "Review changes" to merge the concurrent modifications. The externally modified file is left untouched, and your changes remain in memory, so after reviewing you can simply save again.
5. Regression check: a normal save without concurrent modification still works ("Library saved").

The two notifications the aborted save produces (captured from a live run with a 60k-entry library and a shell loop appending to the file during the save):

![Save aborted: "Library was not saved: the file was modified by another program." plus the standard "External changes detected" notification](https://raw.githubusercontent.com/JabRef/jabref-koppor/assets-concurrent-save-conflict/concurrent-save-notifications.png)

The interleaved two-writers scenario is covered by unit tests in `AtomicFileOutputStreamTest` (`interleavedSavesDoNotOverwriteEachOther`, `externalChangeOfTargetAbortsSave`, `externalCreationOfTargetAbortsSave`, `externalDeletionOfTargetAbortsSave`).

### Related issues and pull requests

Closes #16613 — its "keep external change detection active while saving" approach is integrated here (with an added size+mtime guard that avoids re-parsing the library after every save), so that PR is superseded by this one.

Related: #16610, #7718 (the in-place save fallback for hard links / non-atomic file systems enlarged the window in which concurrent writers could corrupt the file; this PR adds the missing lost-update guard). No existing issue found for the silent lost-update itself.

### AI usage

Claude Code (model claude-fable-5) — investigation, implementation, and tests were AI-generated under human direction (AIL3); reviewed and owned by the contributor.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead. (The only null checks are on values declared `@Nullable`, consistent with the existing checks in `AtomicFileOutputStream`.)
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [x] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [/] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [x] No `catch (Exception e)` — only specific exceptions are caught.
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [x] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [x] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks. (New snapshot type is a `record`; `Set.of()` used in `SaveDatabaseAction`.)
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [x] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [x] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation. (The new message has no variable parts.)

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [x] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [x] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.

## 2. Verification commands

- [x] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [x] `./gradlew modernizer` (run for the touched modules `jablib` and `jabgui`).
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [x] `./gradlew javadoc` (run for the touched modules `jablib` and `jabgui`).
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed — run on the changed `CHANGELOG.md` and `docs/requirements/save.md`).
- [/] Only if formatting is still off after `rewriteRun`: `docker run ... intellij-format` (no Docker available; formatted with local IntelliJ IDEA using `.idea/codeStyles/Project.xml` instead).

## 3. Documentation

- [x] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Link the issue if one exists; link the PR only when no issue exists.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept the PR link (no `closes`/`fixes` for merely-similar issues; #8235/#7307 concern the external-changes notification, not the lost update on save).
- [x] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (new `docs/requirements/save.md`, traced via `[impl->req~logic.exporter.concurrent-save-detection~1]` and `[utest->...]`; `./gradlew traceRequirements` passes).
- [/] Developer documentation under `docs/` updated if behavior or architecture changed (the save strategy is documented in the `AtomicFileOutputStream` Javadoc, which was updated).

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [x] If `CHANGELOG.md` used a `TODO` placeholder, it was replaced with the real PR-number link after PR creation, then committed and pushed.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en) (no user documentation describes concurrent saving; the new error message is self-explanatory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
