### PR TITLE
Fix layout issues in Citation tab UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - Resolving of Math Subject Classification (MSC) needs to be activated in the references now. [#15883](https://github.com/JabRef/jabref/pull/15883)
 - We improved JabRef's startup performance by loading MSC codes only when activated. [#15883](https://github.com/JabRef/jabref/pull/15883)
 - Embedded postgres is no longer started with JabRef unless "Experimental search (Postgres)" is enabled in General preferences. [#12844](https://github.com/JabRef/jabref/issues/12844)
+- We reworked the layout of `Citations` Tab: the citation fetcher selection is now above both panels, and the progress indicator no longer overlaps the surrounding controls. [#16548](https://github.com/JabRef/jabref/issues/16548)
 
 ### Fixed
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -778,6 +778,7 @@ public class CitationRelationsTab extends EntryEditorTab {
         BorderPane searchContainer = getPaneAndStartSearch(entry);
 
         BorderPane root = new BorderPane();
+        root.setId("citationRelationsTab");
         root.setCenter(searchContainer);
         root.setBottom(sciteResultsPane);
         root.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -499,7 +499,7 @@ public class CitationRelationsTab extends EntryEditorTab {
         styleFetchedListView(citedByListView, citedByComponents);
         styleFetchedListView(citingListView, citingComponents);
 
-        // Create BorderPane to act as the main wrapper for the tab's upper section.
+        // The fetcher applies to both panels, so it belongs above the split, not inside the left panel's header.
         BorderPane pane = new BorderPane();
         pane.setTop(fetcherBar);
         pane.setCenter(container);

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -45,7 +45,6 @@ import javafx.scene.input.Dragboard;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
-import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
@@ -366,11 +365,12 @@ public class CitationRelationsTab extends EntryEditorTab {
         return bottomLine;
     }
 
-    /// Method to create main SplitPane holding all lists, buttons and labels for tab and starts search
+    /// Method to create main pane holding the fetcher selection, all lists, buttons, and labels
+    /// for tab, and starts the search
     ///
     /// @param entry BibEntry which is currently selected in JabRef Database
-    /// @return SplitPane to display
-    private SplitPane getPaneAndStartSearch(BibEntry entry) {
+    /// @return BorderPane to display
+    private BorderPane getPaneAndStartSearch(BibEntry entry) {
         // Create Layout Containers
         VBox citingVBox = new VBox();
         VBox citedByVBox = new VBox();
@@ -378,10 +378,12 @@ public class CitationRelationsTab extends EntryEditorTab {
         citedByVBox.setFillWidth(true);
         citingVBox.setAlignment(Pos.TOP_CENTER);
         citedByVBox.setAlignment(Pos.TOP_CENTER);
-        AnchorPane citingHBox = new AnchorPane();
-        citingHBox.setPrefHeight(40);
-        AnchorPane citedByHBox = new AnchorPane();
-        citedByHBox.setPrefHeight(40);
+        HBox citingHBox = new HBox();
+        citingHBox.getStyleClass().add("citation-panel-header");
+        citingHBox.setAlignment(Pos.CENTER_LEFT);
+        HBox citedByHBox = new HBox();
+        citedByHBox.getStyleClass().add("citation-panel-header");
+        citedByHBox.setAlignment(Pos.CENTER_LEFT);
 
         // Create Headings
         // See ADR-0047
@@ -410,10 +412,8 @@ public class CitationRelationsTab extends EntryEditorTab {
         // Create refresh Buttons for both sides
         Button refreshCitingButton = ControlHelper.iconButton(IconTheme.JabRefIcons.REFRESH);
         refreshCitingButton.setTooltip(new Tooltip(Localization.lang("Restart search")));
-        styleTopBarNode(refreshCitingButton, 15.0);
         Button refreshCitedByButton = ControlHelper.iconButton(IconTheme.JabRefIcons.REFRESH);
         refreshCitedByButton.setTooltip(new Tooltip(Localization.lang("Restart search")));
-        styleTopBarNode(refreshCitedByButton, 15.0);
 
         fetcherCombo = new ComboBox<>(
                 FXCollections.observableList(List.of(CitationFetcherType.values()))
@@ -423,7 +423,6 @@ public class CitationRelationsTab extends EntryEditorTab {
         new ViewModelListCellFactory<CitationFetcherType>()
                 .withText(CitationFetcherType::getName)
                 .install(fetcherCombo);
-        styleTopBarNode(fetcherCombo, 75.0);
         fetcherCombo.valueProperty().bindBidirectional(entryEditorPreferences.citationFetcherTypeProperty());
 
         // Add context menus to labels for opening API URLs
@@ -434,30 +433,27 @@ public class CitationRelationsTab extends EntryEditorTab {
         Button abortCitingButton = ControlHelper.iconButton(IconTheme.JabRefIcons.CLOSE);
         abortCitingButton.getGraphic().resize(30, 30);
         abortCitingButton.setTooltip(new Tooltip(Localization.lang("Cancel search")));
-        styleTopBarNode(abortCitingButton, 15.0);
         Button abortCitedButton = ControlHelper.iconButton(IconTheme.JabRefIcons.CLOSE);
         abortCitedButton.getGraphic().resize(30, 30);
         abortCitedButton.setTooltip(new Tooltip(Localization.lang("Cancel search")));
-        styleTopBarNode(abortCitedButton, 15.0);
 
         ProgressIndicator citingProgress = new ProgressIndicator();
         citingProgress.setMaxSize(25, 25);
-        styleTopBarNode(citingProgress, 50.0);
         ProgressIndicator citedByProgress = new ProgressIndicator();
         citedByProgress.setMaxSize(25, 25);
-        styleTopBarNode(citedByProgress, 50.0);
 
         // Create import buttons for both sides
         Button importCitingButton = ControlHelper.iconButton(IconTheme.JabRefIcons.ADD_ENTRY);
         importCitingButton.setTooltip(new Tooltip(Localization.lang("Add selected entry(s) to library")));
-        styleTopBarNode(importCitingButton, 50.0);
         Button importCitedByButton = ControlHelper.iconButton(IconTheme.JabRefIcons.ADD_ENTRY);
         importCitedByButton.setTooltip(new Tooltip(Localization.lang("Add selected entry(s) to library")));
-        styleTopBarNode(importCitedByButton, 50.0);
         hideNodes(importCitingButton, importCitedByButton);
 
-        citingHBox.getChildren().addAll(citingLabel, fetcherCombo, refreshCitingButton, importCitingButton, citingProgress, abortCitingButton);
-        citedByHBox.getChildren().addAll(citedByLabel, refreshCitedByButton, importCitedByButton, citedByProgress, abortCitedButton);
+        citingHBox.getChildren().addAll(citingLabel, citingProgress, importCitingButton, refreshCitingButton, abortCitingButton);
+        citedByHBox.getChildren().addAll(citedByLabel, citedByProgress, importCitedByButton, refreshCitedByButton, abortCitedButton);
+        HBox fetcherBar = new HBox(new Label(Localization.lang("Citation fetcher")), fetcherCombo);
+        fetcherBar.getStyleClass().add("citation-fetcher-bar");
+        fetcherBar.setAlignment(Pos.CENTER_LEFT);
 
         VBox.setVgrow(citingListView, Priority.ALWAYS);
         VBox.setVgrow(citedByListView, Priority.ALWAYS);
@@ -498,14 +494,23 @@ public class CitationRelationsTab extends EntryEditorTab {
 
         // Create SplitPane to hold all nodes above
         SplitPane container = new SplitPane(citingVBox, citedByVBox);
+        container.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);
+        container.setMinSize(0, 0);
         styleFetchedListView(citedByListView, citedByComponents);
         styleFetchedListView(citingListView, citingComponents);
+
+        // Create BorderPane to act as the main wrapper for the tab's upper section.
+        BorderPane pane = new BorderPane();
+        pane.setTop(fetcherBar);
+        pane.setCenter(container);
+        pane.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);
+        pane.setMinSize(0, 0);
 
         // switch to the tab will not trigger refresh from the remote
         searchForRelations(citingComponents, citedByComponents, false);
         searchForRelations(citedByComponents, citingComponents, false);
 
-        return container;
+        return pane;
     }
 
     /// Styles a given CheckListView to display BibEntries either with a hyperlink or an add button.
@@ -705,7 +710,7 @@ public class CitationRelationsTab extends EntryEditorTab {
     /// @param tooltipText tooltip text
     private void styleLabel(Label label, String tooltipText) {
         label.getStyleClass().add("padding-5px");
-        label.setAlignment(Pos.CENTER);
+        label.setAlignment(Pos.CENTER_LEFT);
         label.setTooltip(new Tooltip(tooltipText));
         label.setMaxWidth(Double.MAX_VALUE);
     }
@@ -756,15 +761,6 @@ public class CitationRelationsTab extends EntryEditorTab {
         return contextMenu;
     }
 
-    /// Method to style refresh buttons
-    ///
-    /// @param node node to style
-    private void styleTopBarNode(Node node, double offset) {
-        AnchorPane.setTopAnchor(node, 0.0);
-        AnchorPane.setBottomAnchor(node, 0.0);
-        AnchorPane.setRightAnchor(node, offset);
-    }
-
     @Override
     protected void bindToEntry(BibEntry entry) {
         citationsRelationsTabViewModel.bindToEntry(entry);
@@ -779,12 +775,10 @@ public class CitationRelationsTab extends EntryEditorTab {
             citedByTask = null;
         }
 
-        SplitPane splitPane = getPaneAndStartSearch(entry);
-        splitPane.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);
-        splitPane.setMinSize(0, 0);
+        BorderPane searchContainer = getPaneAndStartSearch(entry);
 
         BorderPane root = new BorderPane();
-        root.setCenter(splitPane);
+        root.setCenter(searchContainer);
         root.setBottom(sciteResultsPane);
         root.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);
 
@@ -900,7 +894,7 @@ public class CitationRelationsTab extends EntryEditorTab {
                 Label placeholder = new Label(labelText);
                 placeholder.setWrapText(true);
                 citationComponents.listView().setPlaceholder(placeholder);
-                citationComponents.refreshButton().setVisible(true);
+                showNodes(citationComponents.refreshButton());
                 dialogService.notify(isCites
                                      ? Localization.lang("Error while fetching cited entries.")
                                      : Localization.lang("Error while fetching citing entries."));
@@ -996,11 +990,17 @@ public class CitationRelationsTab extends EntryEditorTab {
     }
 
     private void hideNodes(Node... nodes) {
-        Arrays.stream(nodes).forEach(node -> node.setVisible(false));
+        Arrays.stream(nodes).forEach(node -> {
+            node.setVisible(false);
+            node.setManaged(false);
+        });
     }
 
     private void showNodes(Node... nodes) {
-        Arrays.stream(nodes).forEach(node -> node.setVisible(true));
+        Arrays.stream(nodes).forEach(node -> {
+            node.setVisible(true);
+            node.setManaged(true);
+        });
     }
 
     /// Function to import selected entries to the database. Also writes the entries to import to the CITING/CITED field

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -778,7 +778,7 @@ public class CitationRelationsTab extends EntryEditorTab {
         BorderPane searchContainer = getPaneAndStartSearch(entry);
 
         BorderPane root = new BorderPane();
-        root.setId("citationRelationsTab");
+        root.setId("citationRelationsTabRoot");
         root.setCenter(searchContainer);
         root.setBottom(sciteResultsPane);
         root.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -146,7 +146,6 @@ public class CitationRelationsTab extends EntryEditorTab {
         this.stateManager = stateManager;
         setText(EntryEditorTabModel.BuiltIn.CITATION_INFORMATION.displayName());
         setTooltip(new Tooltip(Localization.lang("Show articles related by citation")));
-        setId("citationRelationsTab");
 
         this.entryTypesManager = bibEntryTypesManager;
         this.duplicateCheck = new DuplicateCheck(entryTypesManager);

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -1791,6 +1791,16 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-padding: 0.5em 0em 0.5em 0em;
 }
 
+.citation-fetcher-bar {
+    -fx-padding: 0.4em 0.6em 0.4em 0.6em;
+    -fx-spacing: 0.6em;
+}
+
+.citation-panel-header {
+    -fx-padding: 0em 0.6em 0em 0.2em;
+    -fx-spacing: 0.5em;
+}
+
 /* JournalInfo */
 .journalInfo {
     -fx-background-color: -jr-background-alt;

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -1791,12 +1791,12 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-padding: 0.5em 0em 0.5em 0em;
 }
 
-#citationRelationsTab .citation-fetcher-bar {
+#citationRelationsTabRoot .citation-fetcher-bar {
     -fx-padding: 0.4em 0.6em 0.4em 0.6em;
     -fx-spacing: 0.6em;
 }
 
-#citationRelationsTab .citation-panel-header {
+#citationRelationsTabRoot .citation-panel-header {
     -fx-padding: 0em 0.6em 0em 0.2em;
     -fx-spacing: 0.5em;
 }

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -1791,12 +1791,12 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-padding: 0.5em 0em 0.5em 0em;
 }
 
-.citation-fetcher-bar {
+#citationRelationsTab .citation-fetcher-bar {
     -fx-padding: 0.4em 0.6em 0.4em 0.6em;
     -fx-spacing: 0.6em;
 }
 
-.citation-panel-header {
+#citationRelationsTab .citation-panel-header {
     -fx-padding: 0em 0.6em 0em 0.2em;
     -fx-spacing: 0.5em;
 }

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -1778,16 +1778,16 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-alignment: center;
 }
 
-#citationRelationsTab .addEntryButton {
+#citationRelationsTabRoot .addEntryButton {
     -fx-font-size: 2em;
 }
 
-#citationRelationsTab .addEntryButton:selected {
+#citationRelationsTabRoot .addEntryButton:selected {
     -fx-background-color: transparent;
     -fx-fill: -jr-selected;
 }
 
-#citationRelationsTab .entry-container {
+#citationRelationsTabRoot .entry-container {
     -fx-padding: 0.5em 0em 0.5em 0em;
 }
 

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -3625,3 +3625,4 @@ Specify\ a\ subcommand\ (reset,\ import,\ export).=Specify a subcommand (reset, 
 Specify\ a\ subcommand\ (update).=Specify a subcommand (update).
 The\ format\ option\ must\ contain\ either\ 'xmp'\ or\ 'bibtex-attachment'.=The format option must contain either 'xmp' or 'bibtex-attachment'.
 Importer\ for\ the\ Hayagriva\ YAML\ format.=Importer for the Hayagriva YAML format.
+Citation\ fetcher=Citation fetcher

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -3109,6 +3109,7 @@ Works=Works
 Metrics\:=Metrics:
 Relations\ provided\ by\ Semantic\ Scholar=Relations provided by Semantic Scholar
 Metrics\ provided\ by\ scite.ai=Metrics provided by scite.ai
+Citation\ fetcher=Citation fetcher
 
 Citations\ relations\ local\ storage\ time-to-live\ (in\ days)=Citations relations local storage time-to-live (in days)
 An\ error\ occurred\ while\ opening\ citation\ relations\ storage=An error occurred while opening citation relations storage
@@ -3625,4 +3626,3 @@ Specify\ a\ subcommand\ (reset,\ import,\ export).=Specify a subcommand (reset, 
 Specify\ a\ subcommand\ (update).=Specify a subcommand (update).
 The\ format\ option\ must\ contain\ either\ 'xmp'\ or\ 'bibtex-attachment'.=The format option must contain either 'xmp' or 'bibtex-attachment'.
 Importer\ for\ the\ Hayagriva\ YAML\ format.=Importer for the Hayagriva YAML format.
-Citation\ fetcher=Citation fetcher


### PR DESCRIPTION
closes #16548 

### PR Description

This PR addresses UI layout issue with `Citations` tab.

### Steps to test

1. Open Jabref
2. Select `New example library` from `Welcome` tab
3. Double click on any entry and switch to `Citations` Tab
4. While the two searches run, the progress spinners have clear space on both sides

**Before**

<img width="1618" height="695" alt="before" src="https://github.com/user-attachments/assets/b60c8ee2-9f4a-4f3a-ab1b-0a7b66fdce0d" />


**After**

<img width="1617" height="883" alt="after" src="https://github.com/user-attachments/assets/5f781813-6243-40af-a19d-81f946e04d6a" />


### AI usage

`cloud-opus-5` for research

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
