### PR TITLE
Fix add-file-link dialog focus on macOS #16549

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/DialogService.java
+++ b/jabgui/src/main/java/org/jabref/gui/DialogService.java
@@ -15,6 +15,7 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.DialogPane;
+import javafx.stage.Window;
 import javafx.util.StringConverter;
 
 import org.jabref.gui.util.BaseDialog;
@@ -230,6 +231,13 @@ public interface DialogService extends NotificationService {
     ///
     /// @return the selected file or an empty {@link Optional} if no file has been selected
     Optional<Path> showFileOpenDialog(FileDialogConfiguration fileDialogConfiguration);
+
+    /// Shows a new file open dialog owned by the given window.
+    ///
+    /// @param fileDialogConfiguration The configuration for the file dialog
+    /// @param owner The window which owns the file dialog
+    /// @return the selected file or an empty {@link Optional} if no file has been selected
+    Optional<Path> showFileOpenDialog(FileDialogConfiguration fileDialogConfiguration, Window owner);
 
     /// Shows a new file open dialog. The method doesn't return until the
     /// displayed open dialog is dismissed. The return value specifies

--- a/jabgui/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/jabgui/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -483,8 +483,13 @@ public class JabRefDialogService implements DialogService {
 
     @Override
     public Optional<Path> showFileOpenDialog(FileDialogConfiguration fileDialogConfiguration) {
+        return showFileOpenDialog(fileDialogConfiguration, mainWindow);
+    }
+
+    @Override
+    public Optional<Path> showFileOpenDialog(FileDialogConfiguration fileDialogConfiguration, Window owner) {
         FileChooser chooser = getConfiguredFileChooser(fileDialogConfiguration);
-        File file = chooser.showOpenDialog(mainWindow);
+        File file = chooser.showOpenDialog(owner);
         Optional.ofNullable(chooser.getSelectedExtensionFilter()).ifPresent(fileDialogConfiguration::setSelectedExtensionFilter);
         return Optional.ofNullable(file).map(File::toPath);
     }

--- a/jabgui/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialog.java
@@ -90,7 +90,7 @@ public class LinkedFileEditDialog extends BaseDialog<LinkedFile> {
 
     @FXML
     private void openBrowseDialog(ActionEvent event) {
-        viewModel.openBrowseDialog();
+        viewModel.openBrowseDialog(getDialogPane().getScene().getWindow());
     }
 
     private void onDialogShow(DialogEvent event) {

--- a/jabgui/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialogViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialogViewModel.java
@@ -14,6 +14,7 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
+import javafx.stage.Window;
 
 import org.jabref.gui.AbstractViewModel;
 import org.jabref.gui.DialogService;
@@ -83,6 +84,10 @@ public class LinkedFileEditDialogViewModel extends AbstractViewModel {
     }
 
     public void openBrowseDialog() {
+        openBrowseDialog(null);
+    }
+
+    public void openBrowseDialog(Window owner) {
         String fileText = link.get();
 
         Optional<Path> file = FileUtil.find(database, fileText, filePreferences);
@@ -95,7 +100,10 @@ public class LinkedFileEditDialogViewModel extends AbstractViewModel {
                 .withInitialFileName(fileName)
                 .build();
 
-        dialogService.showFileOpenDialog(fileDialogConfiguration).ifPresent(this::checkForBadFileNameAndAdd);
+        Optional<Path> selectedFile = owner == null
+            ? dialogService.showFileOpenDialog(fileDialogConfiguration)
+            : dialogService.showFileOpenDialog(fileDialogConfiguration, owner);
+        selectedFile.ifPresent(this::checkForBadFileNameAndAdd);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
- Make the native file chooser owned by the active linked-file dialog.
- Prevent the add-file-link window from briefly disappearing after file selection.
- Preserve existing main-window ownership for other file chooser usages.
- Editor diagnostics pass; Gradle validation was inconclusive due to terminal issues.