### PR TITLE
Fix formatting in `IfPlural`

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/layout/format/IfPlural.java
+++ b/jablib/src/main/java/org/jabref/logic/layout/format/IfPlural.java
@@ -5,14 +5,12 @@ import java.util.List;
 import org.jabref.logic.layout.AbstractParamLayoutFormatter;
 
 /// This formatter takes two arguments and examines the field text.
-/// If the field text represents multiple individuals, that is it contains the string "and"
-/// then the field text is replaced with the first argument, otherwise it is replaced with the second.
-/// For example:
+/// If the field text represents multiple individuals (i.e., it contains the string `and`),
+/// then the field text is replaced with the first argument,
+/// otherwise it is replaced with the second.
 ///
-///
-/// \format[IfPlural(Eds.,Ed.)]{\editor}
-///
-/// Should expand to 'Eds.' if the document has more than one editor and 'Ed.' if it only has one.
+/// For example, `\format[IfPlural(Eds.,Ed.)]{\editor}`
+/// should expand to `Eds.` if the document has more than one editor and `Ed.` if it only has one.
 public class IfPlural extends AbstractParamLayoutFormatter {
 
     private String pluralText;

--- a/jablib/src/main/java/org/jabref/logic/layout/format/IfPlural.java
+++ b/jablib/src/main/java/org/jabref/logic/layout/format/IfPlural.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.layout.format;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.jabref.logic.layout.AbstractParamLayoutFormatter;
 
@@ -12,6 +13,8 @@ import org.jabref.logic.layout.AbstractParamLayoutFormatter;
 /// For example, `\format[IfPlural(Eds.,Ed.)]{\editor}`
 /// should expand to `Eds.` if the document has more than one editor and `Ed.` if it only has one.
 public class IfPlural extends AbstractParamLayoutFormatter {
+
+    private static final Pattern AND_PATTERN = Pattern.compile("\\sand\\s");
 
     private String pluralText;
     private String singularText;
@@ -32,7 +35,7 @@ public class IfPlural extends AbstractParamLayoutFormatter {
         if ((fieldText == null) || fieldText.isEmpty() || (pluralText == null)) {
             return ""; // TODO: argument missing or invalid. Print an error message here?
         }
-        if (fieldText.matches(".*\\sand\\s.*")) {
+        if (AND_PATTERN.matcher(fieldText).find()) {
             return pluralText;
         } else {
             return singularText;

--- a/jablib/src/main/java/org/jabref/logic/layout/format/IfPlural.java
+++ b/jablib/src/main/java/org/jabref/logic/layout/format/IfPlural.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.jabref.logic.layout.AbstractParamLayoutFormatter;
 
 /// This formatter takes two arguments and examines the field text.
-/// If the field text represents multiple individuals (i.e., it contains the string `and`),
+/// If the field text represents multiple individuals (i.e., it contains the string ` and ` - "and" with surrounding spaces),
 /// then the field text is replaced with the first argument,
 /// otherwise it is replaced with the second.
 ///


### PR DESCRIPTION
### Summary

IntelliJ has issues when formatting IfPlural (introduces spaces). This is OK, because we did not use backticks.

### Steps to test

Run IntelliJ formatter on `jablib/src/main/java/org/jabref/logic/layout/format/IfPlural.java`.

### Related issues and pull requests

Auto format PRs:

- https://github.com/JabRef/jabref-koppor/pull/663
- https://github.com/JabRef/jabref-koppor/pull/716

### AI usage

🧠 AKA AIL0

**Edit** More AI because of Pattern thing -> that was AIL4

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
