### PR TITLE
Update PR template (no screenshots, CHANGELOG.md)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -91,6 +91,5 @@ _____
 - [.] I manually tested my changes in running JabRef (always required)
 - [.] I added JUnit tests for changes (if applicable)
 - [.] I added screenshots in the PR description (if change is visible to the user)
-- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
-- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
+- [.] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
 - [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -141,8 +141,8 @@ jobs:
 
           LINE_COUNT=$(echo "$BOXES" | wc -l)
 
-          if [ "$LINE_COUNT" -ne 8 ]; then
-            echo "❌ Found $LINE_COUNT lines instead of 8 required lines"
+          if [ "$LINE_COUNT" -ne 7 ]; then
+            echo "❌ Found $LINE_COUNT lines instead of 7 required lines"
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -493,12 +493,33 @@ PR body — **must** be built from `.github/PULL_REQUEST_TEMPLATE.md`:
 
 - Add a CHANGELOG.md entry only if the change is visible to the user.
 - The CHANGELOG.md entry should be for end users (and not programmers).
+- **One line, maximum 20 words, one sentence.** If one sentence is truly not enough, use two — never more. No sub-bullets, no code blocks.
+- **Describe what changed for the user, never why or how it was implemented.** No class names, method names, or internals.
+- Start the entry with `We added` / `We changed` / `We fixed` / `We removed`, and place it under the matching `### Added` / `### Changed` / `### Fixed` / `### Removed` heading in `## [Unreleased]`.
 - Do not add extra blank lines in CHANGELOG.md
+- Do not reorder or reword existing entries, and do not create a new version heading.
 - CHANGELOG.md entries link the issue number when an issue exists; the PR number is used only as a fallback when there is no issue.
 - When no issue is known and the PR is not yet created, use `TODO` as the issue/PR reference placeholder — never invent a fake number.
 - Before using `TODO`, search <https://github.com/JabRef/jabref/issues> and <https://github.com/JabRef/jabref-koppor/issues> for a matching issue. Link it only on a confident match; otherwise list candidates for human review and keep `TODO`. Never use `closes`/`fixes` keywords for a merely-similar issue.
 - User documentation is available in a separate repository <https://github.com/JabRef/user-documentation>.
 - No AI-disclosure comments inside source code
+
+### CHANGELOG.md example
+
+Good:
+
+```markdown
+- We fixed an issue where the entry editor lost focus after saving a library. [#1234](https://github.com/JabRef/jabref/issues/1234)
+```
+
+Bad — explains the implementation, names internals, too long:
+
+```markdown
+- We fixed a bug in the entry editor where, due to a race condition in the JavaFX
+  focus handling inside `EntryEditor#setFocus`, the focus was lost after the library
+  was saved. This was especially annoying for users who ... The fix introduces a
+  guard flag that ...
+```
 
 ### Developer documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -493,7 +493,7 @@ PR body — **must** be built from `.github/PULL_REQUEST_TEMPLATE.md`:
 
 - Add a CHANGELOG.md entry only if the change is visible to the user.
 - The CHANGELOG.md entry should be for end users (and not programmers).
-- **One line, maximum 20 words, one sentence.** If one sentence is truly not enough, use two — never more. No sub-bullets, no code blocks.
+- **One sentence, maximum 20 words.** No sub-bullets, no code blocks.
 - **Describe what changed for the user, never why or how it was implemented.** No class names, method names, or internals.
 - Start the entry with `We added` / `We changed` / `We fixed` / `We removed`, and place it under the matching `### Added` / `### Changed` / `### Fixed` / `### Removed` heading in `## [Unreleased]`.
 - Do not add extra blank lines in CHANGELOG.md


### PR DESCRIPTION
### Summary

Screenshots are be done by AI - no need to burn tokens.

CHANGELOG entries were too long

### AI usage

Some AI

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
