### PR TITLE
Update LOBIDIsbnFetcherTest to the record lobid now returns

### DIFF
--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/isbntobibtex/LOBIDIsbnFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/isbntobibtex/LOBIDIsbnFetcherTest.java
@@ -38,12 +38,12 @@ class LOBIDIsbnFetcherTest extends AbstractIsbnFetcherTest {
                 .withField(StandardField.LANGUAGE, "Englisch")
                 .withField(StandardField.AUTHOR, "Bloch, Joshua")
                 .withField(StandardField.LOCATION, "Upper Saddle River, NJ [u.a.]")
-                .withField(StandardField.EDITION, "2. ed")
+                .withField(StandardField.EDITION, "2. ed., rev. and updated for Java SE 6, 14. print")
                 .withField(StandardField.ISBN, "9780321356680")
                 .withField(StandardField.TYPE, "BibliographicResource, Book")
-                .withField(StandardField.KEYWORDS, "Java Standard Edition 6, Java <Programmiersprache>")
-                .withField(StandardField.URL, "http://lobid.org/resources/991000506229708980")
-                .withField(StandardField.TITLEADDON, "[revised and updated for Java SE 6]");
+                .withField(StandardField.KEYWORDS, "Java (Programmiersprache)")
+                .withField(StandardField.URL, "http://lobid.org/resources/990212853550206441")
+                .withField(StandardField.ABSTRACT, "Mit Literaturangaben");
 
         fetcher = new LOBIDIsbnFetcher(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS));
     }


### PR DESCRIPTION
### Summary

lobid returns a different catalogue record for ISBN 9780321356680 than when the test was written — the resource id in the URL changed — so both `searchById` tests fail on main. This updates `edition`, `keywords` and `url` to the returned record, drops `titleaddon` (no longer present) and adds the `abstract` it now carries. The fetcher output is correct; only the expected entry was stale.

### Steps to test

`./gradlew :jablib:fetcherTest --tests "*LOBIDIsbnFetcherTest*"` — 8 tests, 2 failures before, 0 after. No UI change.

### Related issues and pull requests

Closes #16666

### AI usage

Claude Code (Anthropic, Claude Opus 5), used assistively — it ran the failing test, and I read the assertion diff and updated the expected fields. AIL2.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

Only `[x]` where actually verified; `[/]` where a test-data change cannot apply.

**1. Code self-review** — the diff is four field values in an existing test fixture.
- [/] Nullability items (`== null`, `requireNonNull`, `@NullMarked`, `Optional`, `isBlank`) — no code paths changed
- [/] Exceptions items — none touched
- [x] `BibEntry` built with withers — unchanged, still `withField`
- [/] Modern Java, precompiled `Pattern`, `BackgroundTask`, Markdown Javadoc — not touched
- [x] No commented-out code, no trivial comments, no AI-disclosure comments in source
- [/] User-facing text / localization — none
- [/] Security (HTML escaping) — none
- [x] Tests assert object contents with plain JUnit `assertEquals`, no `@DisplayName`, no caught exceptions
- [x] Fetcher tests hit the live endpoints — unchanged, still live; nothing mocked

**2. Verification commands**
- [x] `./gradlew :jablib:checkstyleTest` — BUILD SUCCESSFUL
- [x] `./gradlew :jablib:fetcherTest --tests "*LOBIDIsbnFetcherTest*"` — 8 tests, 0 failures
- [ ] `:jablib:check`, `modernizer`, `rewriteDryRun`, `javadoc` — not run locally (disk limits on my machine); relying on CI rather than ticking them
- [/] `markdownlint` — no Markdown changed
- [/] IntelliJ format container — formatting unchanged

**3. Documentation**
- [/] `CHANGELOG.md` — CONTRIBUTING exempts changes not visible to the user; this is test-only
- [x] Searched jabref/issues for a related issue; none existed, so filed #16666 and linked it
- [/] `docs/requirements/` — not a feature or significant bug fix
- [/] Developer documentation — no behavior or architecture change

**4. Pull request**
- [x] Body built from the template, sections filled
- [x] All checklist items kept and marked
- [x] All HTML comments removed
- [x] Created with `gh pr create --body-file`
- [/] CHANGELOG `TODO` placeholder — no changelog entry

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required) — test-only change with no runtime effect; verified via `fetcherTest` instead
- [/] I added JUnit tests for changes (if applicable) — updates an existing test
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
