### PR TITLE
Label PRs without bot comments as ready-for-review

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -228,7 +228,7 @@ jobs:
               echo "No bot comments - removed label changes-required and added ready-for-review" >> $GITHUB_STEP_SUMMARY
             else
               echo "No bot comments, but PR is draft, has changes requested, or is already further in review - adding label no-bot-comments"
-              gh issue --repo $REPO edit $PR_NUMBER --remove-label "status: changes-required,status: stale" --add-label "status: no-bot-comments"
+              gh issue --repo $REPO edit $PR_NUMBER --remove-label "status: changes-required,status: stale,status: ready-for-review" --add-label "status: no-bot-comments"
               echo "No bot comments - removed label changes-required and added no-bot-comments" >> $GITHUB_STEP_SUMMARY
             fi
           fi

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -216,9 +216,21 @@ jobs:
             gh issue --repo $REPO edit $PR_NUMBER --remove-label "status: ready-for-review,status: no-bot-comments,status: stale" --add-label "status: changes-required"
             echo "Bot comments - added label changes-required" >> $GITHUB_STEP_SUMMARY
           else
-            echo "No bot comments - removing label changes-required and adding no-bot-comments"
-            gh issue --repo $REPO edit $PR_NUMBER --remove-label "status: changes-required,status: stale" --add-label "status: no-bot-comments"
-            echo "No bot comments - removed label changes-required and added no-bot-comments" >> $GITHUB_STEP_SUMMARY
+            # A PR without bot comments is ready for review unless it is a draft, a human requested changes,
+            # or it already progressed further in the review process.
+            PR_STATE=$(gh pr view --repo $REPO $PR_NUMBER --json isDraft,reviewDecision,labels \
+              --jq 'if .isDraft or .reviewDecision == "CHANGES_REQUESTED"
+                       or ([.labels[].name] | any(. == "status: awaiting-second-review" or . == "status: to-be-merged"))
+                    then "not-ready" else "ready" end')
+            if [ "$PR_STATE" = "ready" ]; then
+              echo "No bot comments and PR is ready for review - adding label ready-for-review"
+              gh issue --repo $REPO edit $PR_NUMBER --remove-label "status: changes-required,status: stale,status: no-bot-comments" --add-label "status: ready-for-review"
+              echo "No bot comments - removed label changes-required and added ready-for-review" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "No bot comments, but PR is draft, has changes requested, or is already further in review - adding label no-bot-comments"
+              gh issue --repo $REPO edit $PR_NUMBER --remove-label "status: changes-required,status: stale" --add-label "status: no-bot-comments"
+              echo "No bot comments - removed label changes-required and added no-bot-comments" >> $GITHUB_STEP_SUMMARY
+            fi
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

🤖 PR Description

"Comment on PR" labels PRs without bot comments as `status: no-bot-comments` — and stops there, so a PR that is actually reviewable never gets `status: ready-for-review` from the bot. This changes the "no bot comments" branch: if the PR is not a draft, no reviewer requested changes (`reviewDecision != CHANGES_REQUESTED`), and it is not already at `status: awaiting-second-review` / `status: to-be-merged`, it now gets `status: ready-for-review` (replacing `status: no-bot-comments`). Otherwise the behavior is unchanged and `status: no-bot-comments` stays.

This is not a concurrency issue: the workflow simply never added `ready-for-review`. A review requesting changes that lands before CI finishes is caught by the `reviewDecision` check; one that lands after is still handled by "Adapt PR status labels (Move)".

**Analogies:** Like honey, this sweetens the reviewer queue by surfacing PRs that are actually ready. Like chocolate, it is a small piece with a noticeable effect. Like the moon, it only shows one face — `ready-for-review` or `no-bot-comments`, never both.

`jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

1. Open a PR from a fork, wait for "Source Code Tests" to finish without bot comments → PR gets `status: ready-for-review`.
2. Convert the PR to draft (or request changes as a reviewer), push again → PR gets `status: no-bot-comments` instead.

The `jq` filter was checked against live PR data: #16646 (`to-be-merged`) → not ready; #16620 (changes requested) → not ready; #16530 (draft) → not ready; #16667 → ready.

### Related issues and pull requests

Closes _____ (no issue; maintainer request)

### AI usage

Claude Code (model claude-fable-5), AIL4 — AI-generated from a maintainer's description, reviewed by the maintainer.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow
- [/] No `== null` / `!= null` checks — JSpecify annotations used instead.
- [/] No `Objects.requireNonNull(...)`.
- [/] New classes annotated with `@NullMarked`.
- [/] `Optional` consumed with `ifPresent` / `map` / `orElseThrow`.
- [/] `StringUtil.isBlank(...)` used.

### Exceptions
- [/] No `catch (Exception e)`.
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)`.
- [/] Logged exceptions passed as the last logger argument.

### Style and idioms
- [/] New `BibEntry` objects built with withers.
- [/] Modern Java used.
- [/] Regexes use a precompiled `Pattern`.
- [/] Background work uses `BackgroundTask`.
- [x] No commented-out code, no trivial comments, no AI-disclosure comments in source.
- [/] Markdown Javadoc uses Markdown syntax.

### User-facing text
- [/] All user-facing text localized.
- [/] Sentence case; no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders.

### Security
- [/] User-controlled data HTML-escaped.

### Tests
- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have tests.
- [/] Tests assert object contents, plain JUnit asserts, no `@DisplayName`, `@TempDir`.
- [/] Fetcher tests hit live endpoints.

## 2. Verification commands
- [/] `./gradlew :jablib:check` (workflow-only change).
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [/] `./gradlew modernizer`.
- [/] `./gradlew --no-configuration-cache :rewriteDryRun`.
- [/] `./gradlew javadoc`.
- [/] `npx markdownlint-cli2` (no Markdown changed).
- [/] intellij-format.

## 3. Documentation
- [/] `CHANGELOG.md` entry (not user-visible).
- [x] Searched issues; none matching.
- [/] Requirement added to `docs/requirements/`.
- [/] Developer documentation under `docs/` updated.

## 4. Pull request
- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked.
- [x] All HTML comments removed.
- [x] PR created with `gh pr create --body-file`.
- [/] `CHANGELOG.md` `TODO` placeholder replaced.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
