### PR TITLE
docs: fix typos in developer docs and VM scripts

### DIFF
--- a/docs/code-howtos/faq.md
+++ b/docs/code-howtos/faq.md
@@ -87,7 +87,7 @@ This test is triggered when any kind of documentation is touched (be it the JabR
 ### Failing <b>Fetcher</b> tests
 
 Fetcher tests are run when any file in the `.../fetcher` directory has been touched. If you have changed any fetcher logic, check if the changes are correct. You can look for more details on how to locally [run fetcher tests](https://devdocs.jabref.org/code-howtos/testing.html#fetchers-in-tests).
-Otherwise, since these tests depend on remote services, their failure can also be caused by the network or an external server, and thus can be ignored in the context of your contribution. For more information, you can look at [commiting and pushing changes to fetcher tests](https://devdocs.jabref.org/code-howtos/fetchers.html#committing-and-pushing-changes-to-fetcher-files).
+Otherwise, since these tests depend on remote services, their failure can also be caused by the network or an external server, and thus can be ignored in the context of your contribution. For more information, you can look at [committing and pushing changes to fetcher tests](https://devdocs.jabref.org/code-howtos/fetchers.html#committing-and-pushing-changes-to-fetcher-files).
 
 ## Gradle outputs
 

--- a/docs/code-howtos/openoffice/ooresult-ooerror/ooresult-alternatives.md
+++ b/docs/code-howtos/openoffice/ooresult-ooerror/ooresult-alternatives.md
@@ -89,7 +89,7 @@ In either case, the code becomes littered with exception handling code.
 We might push the try-catch into its own function.\
 If the wrapper is called multiple times, this may reduce duplication of the catch-and-assign-message part.
 
-We can show an error dialog here: `title` carries some information from the caller, the exeption caught brings some from below.
+We can show an error dialog here: `title` carries some information from the caller, the exception caught brings some from below.
 
 We still need to notify the action handler (the caller) about failure. Since we have shown the dialog, we do not need to provide a message.
 
@@ -366,7 +366,7 @@ Constraints:
 * `JabRefException` expects a localized message. Or we need to remember which `JabRefException` instances are localized and which need to be caught for localizing the message.
 * At the bottom we usually have very little information on higher level contexts: at a failure like `NoSuchProperty` we cannot tell which set of properties did we look in and why.\
   For messages originating too deeply, we might want to override or extend the message anyway.
-* for each exeption we might want to handle programmatically, we need a variant based on `JabRefException`
+* for each exception we might want to handle programmatically, we need a variant based on `JabRefException`
 
 So we might end up:
 

--- a/jablib/src/test/resources/testbib/issue-12274/README.md
+++ b/jablib/src/test/resources/testbib/issue-12274/README.md
@@ -2,7 +2,7 @@
 
 This is an example for [#12274](https://github.com/JabRef/jabref/issues/12274).
 
-## Example 1: Straight-foward-case
+## Example 1: Straight-forward-case
 
 1. Open JabRef.
 2. Open `issue-12274.bib`.

--- a/scripts/vms/windows10/README.md
+++ b/scripts/vms/windows10/README.md
@@ -11,7 +11,7 @@ One has to install the [JabRef Browser Extension](https://addons.mozilla.org/en-
 
 ### "Waiting for machine to reboot..."
 
-In case Vagrant reports "Waiting for machine to reboot..." and nothing happens, one has to "power off" the machine, execute `vagrant destory`, and then run `vagrant up` again.
+In case Vagrant reports "Waiting for machine to reboot..." and nothing happens, one has to "power off" the machine, execute `vagrant destroy`, and then run `vagrant up` again.
 
 ### `fatal: early EOF`
 

--- a/scripts/vms/windows11/README.md
+++ b/scripts/vms/windows11/README.md
@@ -11,7 +11,7 @@ One has to install the [JabRef Browser Extension](https://addons.mozilla.org/en-
 
 ### "Waiting for machine to reboot..."
 
-In case Vagrant reports "Waiting for machine to reboot..." and nothing happens, one has to "power off" the machine, execute `vagrant destory`, and then run `vagrant up` again.
+In case Vagrant reports "Waiting for machine to reboot..." and nothing happens, one has to "power off" the machine, execute `vagrant destroy`, and then run `vagrant up` again.
 
 ### `fatal: early EOF`
 


### PR DESCRIPTION
Six typo fixes across developer docs and scripts:

| File | Fix |
|---|---|
| `docs/code-howtos/faq.md:90` | `commiting` → `committing` |
| `docs/code-howtos/openoffice/ooresult-ooerror/ooresult-alternatives.md:92,369` | `exeption` → `exception` |
| `jablib/src/test/resources/testbib/issue-12274/README.md:5` | `Straight-foward` → `forward` |
| `scripts/vms/windows10/README.md:14` | `destory` → `destroy` |
| `scripts/vms/windows11/README.md:14` | `destory` → `destroy` |

Documentation prose only — no code, test data, or Vagrant commands changed.
