### PR TITLE
Restore ready-for-review once a merge conflict is resolved

### DIFF
--- a/.github/workflows/on-pr-opened-updated.yml
+++ b/.github/workflows/on-pr-opened-updated.yml
@@ -17,6 +17,7 @@ jobs:
     name: Conflicts with target branch
     runs-on: ubuntu-slim
     permissions:
+      actions: write
       contents: write
       issues: write
       pull-requests: write
@@ -183,9 +184,11 @@ jobs:
 
           exit 1
 
-      # The conflict comment is the marker that "status: changes-required" came from this workflow
-      # and not from a reviewer - without it, labels are left alone.
-      - name: Restore labels after conflict resolved
+      # Only if this workflow had flagged a conflict (its comment is the marker), not on every push.
+      # "Comment on PR" then does the rest: ghprcomment deletes the conflict comment (no job of this
+      # run fails), and the status labels are re-evaluated with the full rule set - other bot
+      # comments, active Qodo threads, draft, review decision - instead of duplicating it here.
+      - name: Re-evaluate status labels after conflict resolved
         if: steps.check_mergeable.outputs.mergeable == 'MERGEABLE'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -193,26 +196,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
           set -exo pipefail
-
-          COMMENT_IDS=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
-            --jq '.[] | select(.body | contains("Conflicts with target branch")) | .id')
-          if [ -z "$COMMENT_IDS" ]; then
-            exit 0
-          fi
-          for id in $COMMENT_IDS; do
-            gh api -X DELETE "repos/$GH_REPO/issues/comments/$id"
-          done
-
-          # Same readiness rule as in "Comment on PR": a draft, a human "changes requested", or a PR
-          # already further in review must not be flipped back to ready-for-review.
-          READY=$(gh pr view "$PR_NUMBER" --json isDraft,reviewDecision,labels \
-            --jq 'if .isDraft or .reviewDecision == "CHANGES_REQUESTED"
-                     or ([.labels[].name] | any(. == "status: awaiting-second-review" or . == "status: to-be-merged"))
-                  then "not-ready" else "ready" end')
-          if [ "$READY" = "ready" ]; then
-            gh issue edit "$PR_NUMBER" --remove-label "status: changes-required" --add-label "status: ready-for-review"
-            echo "✅ Conflict resolved - restored ready-for-review" >> $GITHUB_STEP_SUMMARY
-          else
-            gh issue edit "$PR_NUMBER" --remove-label "status: changes-required"
-            echo "✅ Conflict resolved - removed changes-required" >> $GITHUB_STEP_SUMMARY
+          if gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate --jq '.[].body' | grep -q "Conflicts with target branch"; then
+            gh workflow run "Comment on PR" --ref main --field pr_number="$PR_NUMBER" --field workflow_run_id="$GITHUB_RUN_ID"
           fi

--- a/.github/workflows/on-pr-opened-updated.yml
+++ b/.github/workflows/on-pr-opened-updated.yml
@@ -170,7 +170,7 @@ jobs:
           Please [merge `upstream/main`](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork#syncing-a-fork-branch-from-the-command-line) with your code. For a step-by-step guide to resolve merge conflicts, see <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line>.
 
           <!-- ghprcomment
-          On PR opened/updated (check)
+          On PR opened/updated
           Conflicts with target branch
           -->
           EOF
@@ -182,3 +182,37 @@ jobs:
           fi;
 
           exit 1
+
+      # The conflict comment is the marker that "status: changes-required" came from this workflow
+      # and not from a reviewer - without it, labels are left alone.
+      - name: Restore labels after conflict resolved
+        if: steps.check_mergeable.outputs.mergeable == 'MERGEABLE'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          set -exo pipefail
+
+          COMMENT_IDS=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '.[] | select(.body | contains("Conflicts with target branch")) | .id')
+          if [ -z "$COMMENT_IDS" ]; then
+            exit 0
+          fi
+          for id in $COMMENT_IDS; do
+            gh api -X DELETE "repos/$GH_REPO/issues/comments/$id"
+          done
+
+          # Same readiness rule as in "Comment on PR": a draft, a human "changes requested", or a PR
+          # already further in review must not be flipped back to ready-for-review.
+          READY=$(gh pr view "$PR_NUMBER" --json isDraft,reviewDecision,labels \
+            --jq 'if .isDraft or .reviewDecision == "CHANGES_REQUESTED"
+                     or ([.labels[].name] | any(. == "status: awaiting-second-review" or . == "status: to-be-merged"))
+                  then "not-ready" else "ready" end')
+          if [ "$READY" = "ready" ]; then
+            gh issue edit "$PR_NUMBER" --remove-label "status: changes-required" --add-label "status: ready-for-review"
+            echo "✅ Conflict resolved - restored ready-for-review" >> $GITHUB_STEP_SUMMARY
+          else
+            gh issue edit "$PR_NUMBER" --remove-label "status: changes-required"
+            echo "✅ Conflict resolved - removed changes-required" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/on-pr-opened-updated.yml
+++ b/.github/workflows/on-pr-opened-updated.yml
@@ -196,6 +196,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
           set -exo pipefail
-          if gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate --jq '.[].body' | grep -q "Conflicts with target branch"; then
+          MARKER=$'<!-- ghprcomment\nOn PR opened/updated\nConflicts with target branch\n-->'
+          if gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate --jq '.[].body' | grep -qzF -- "$MARKER"; then
             gh workflow run "Comment on PR" --ref main --field pr_number="$PR_NUMBER" --field workflow_run_id="$GITHUB_RUN_ID"
           fi

--- a/.github/workflows/on-pr-opened-updated.yml
+++ b/.github/workflows/on-pr-opened-updated.yml
@@ -197,6 +197,8 @@ jobs:
         run: |
           set -exo pipefail
           MARKER=$'<!-- ghprcomment\nOn PR opened/updated\nConflicts with target branch\n-->'
-          if gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate --jq '.[].body' | grep -qzF -- "$MARKER"; then
+          # File, not pipe: "grep -q" exits on the first match and would SIGPIPE "gh", which pipefail turns into a skip.
+          gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate --jq '.[].body' > comments.txt
+          if grep -qzF -- "$MARKER" comments.txt; then
             gh workflow run "Comment on PR" --ref main --field pr_number="$PR_NUMBER" --field workflow_run_id="$GITHUB_RUN_ID"
           fi


### PR DESCRIPTION
### Summary

🤖 When the nightly conflict check flags a PR, it swaps `status: ready-for-review` for `status: changes-required` — but after the author merges `main`, nothing swaps the labels back or removes the conflict comment for PRs whose branch lives in `JabRef/jabref` (the re-labeling only ever ran for fork PRs, and only after "Source Code Tests"). The conflict check now cleans up after itself as soon as the PR is mergeable again, and the nightly comment's marker now matches the ghprcomment config so it is also cleaned up on fork PRs.

Analogies: Like honey, the label now flows back on its own; like chocolate, it is gone as soon as the conflict is; like the moon, ready-for-review returns after the dark phase.

`jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

1. Take an open PR from a `JabRef/jabref` branch and run "Rerun PR merge conflicts check" while it conflicts with `main`: it gets `status: changes-required` and the conflict comment.
2. Merge `main` into the PR branch and push.
3. The conflict comment is deleted and `status: ready-for-review` is back (unless the PR is a draft or a reviewer requested changes).

### Related issues and pull requests

Closes _____

### AI usage

Claude Code (model claude-fable-5), AIL4 — I reviewed, understood, and take ownership of the change.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

Not applicable: no Java code changed (workflow YAML only).

### Nullability and control flow

- [/] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [/] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [/] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [/] No `catch (Exception e)` — only specific exceptions are caught.
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [/] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [/] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [/] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.
- [/] Fetcher tests hit the live endpoints — the remote API is not mocked or stubbed (automated-review suggestions to mock it are rejected on purpose).

## 2. Verification commands

Not applicable: no Java or Markdown changed; the new step's `gh`/`jq` queries were dry-run against PR #16672.

- [/] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [/] `./gradlew modernizer`.
- [/] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [/] `./gradlew javadoc`.
- [/] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.

## 3. Documentation

Not applicable: CI-internal change.

- [/] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Link the issue if one exists; link the PR only when no issue exists. Use `TODO` as the placeholder when neither is known yet — never a fake number.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [/] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder (no issue confidently identified yet — an existing issue link always stays), it was replaced with the real PR-number link after PR creation, then committed and pushed. If an issue is identified or created later, the link is switched to the issue.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTbQBU3HCD4HDbQjGCsRLC
