### PR TITLE
Fix button placement at commit dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added BibTeX syntax highlighting to the Source tab and Import entries dialog. [#15897](https://github.com/JabRef/jabref/issues/15897)
 - We added an option to include currently selected entries when creating a new explicit group. [#16588](https://github.com/JabRef/jabref/pull/16588)
 
+### Fixed
+
+- The "Show diff" button in the Git commit dialog now appears in the same row as the other buttons. [#16730](https://github.com/JabRef/jabref/issues/16730)
+
+
 ### Changed
 
 - We reworked the appearance preferences: you now choose a theme (e.g. "JabRef", "Primer") and a color scheme ("Follow System", "Light", "Dark") separately; the "Use System Preference" checkbox is gone. [#15625](https://github.com/JabRef/jabref/issues/15625)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - The "Show diff" button in the Git commit dialog now appears in the same row as the other buttons. [#16730](https://github.com/JabRef/jabref/issues/16730)
 
-
 ### Changed
 
 - We reworked the appearance preferences: you now choose a theme (e.g. "JabRef", "Primer") and a color scheme ("Follow System", "Light", "Dark") separately; the "Use System Preference" checkbox is gone. [#15625](https://github.com/JabRef/jabref/issues/15625)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added BibTeX syntax highlighting to the Source tab and Import entries dialog. [#15897](https://github.com/JabRef/jabref/issues/15897)
 - We added an option to include currently selected entries when creating a new explicit group. [#16588](https://github.com/JabRef/jabref/pull/16588)
 
-### Fixed
-
-- The "Show diff" button in the Git commit dialog now appears in the same row as the other buttons. [#16730](https://github.com/JabRef/jabref/issues/16730)
-
 ### Changed
 
 - We reworked the appearance preferences: you now choose a theme (e.g. "JabRef", "Primer") and a color scheme ("Follow System", "Light", "Dark") separately; the "Use System Preference" checkbox is gone. [#15625](https://github.com/JabRef/jabref/issues/15625)
@@ -101,6 +97,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed the "Show diff" button placement in the Git commit dialog. [#16730](https://github.com/JabRef/jabref/issues/16730)
 - We fixed freezing while scrolling results in the Search for unlinked local files dialog. [#16696](https://github.com/JabRef/jabref/pull/16696)
 - We fixed an issue where "File > Git > Commit" refused to commit when the repository had no remote or the remote could not be reached. [#16720](https://github.com/JabRef/jabref/pull/16720)
 - We fixed the unreadable hit count on group badges that turn green because they contain selected entries. [#16700](https://github.com/JabRef/jabref/pull/16700)

--- a/jabgui/src/main/java/org/jabref/gui/git/GitCommitDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/git/GitCommitDialogView.java
@@ -3,7 +3,9 @@ package org.jabref.gui.git;
 import java.util.List;
 
 import javafx.application.Platform;
+import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.TextArea;
 
@@ -29,6 +31,7 @@ public class GitCommitDialogView extends BaseDialog<Void> {
 
     @FXML private TextArea commitMessage;
     @FXML private ButtonType commitButton;
+    @FXML private ButtonType showDiffButton;
 
     private GitCommitDialogViewModel viewModel;
 
@@ -45,6 +48,12 @@ public class GitCommitDialogView extends BaseDialog<Void> {
         ViewLoader.view(this)
                   .load()
                   .setAsDialogPane(this);
+        
+        Button showDiff = (Button) this.getDialogPane().lookupButton(showDiffButton);
+        showDiff.addEventFilter(ActionEvent.ACTION, event -> {
+            event.consume();
+            showDiff();
+        });
     }
 
     @FXML
@@ -82,7 +91,6 @@ public class GitCommitDialogView extends BaseDialog<Void> {
     }
 
     // [impl->req~ux.git-commit.preview-current-library~1]
-    @FXML
     private void showDiff() {
         viewModel.diffTask()
                  .onSuccess(this::openDiffDialog)

--- a/jabgui/src/main/java/org/jabref/gui/git/GitCommitDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/git/GitCommitDialogView.java
@@ -48,7 +48,6 @@ public class GitCommitDialogView extends BaseDialog<Void> {
         ViewLoader.view(this)
                   .load()
                   .setAsDialogPane(this);
-        
         Button showDiff = (Button) this.getDialogPane().lookupButton(showDiffButton);
         showDiff.addEventFilter(ActionEvent.ACTION, event -> {
             event.consume();

--- a/jabgui/src/main/resources/org/jabref/gui/git/GitCommitDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/git/GitCommitDialog.fxml
@@ -6,8 +6,6 @@
 <?import javafx.scene.control.DialogPane?>
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.control.Button?>
 <DialogPane
         xmlns="http://javafx.com/javafx"
         xmlns:fx="http://javafx.com/fxml"
@@ -20,10 +18,6 @@
                 <Insets top="20" right="20" bottom="20" left="20"/>
             </padding>
 
-            <HBox alignment="CENTER_RIGHT">
-                <Button fx:id="showDiffButton" text="%Show diff" onAction="#showDiff"/>
-            </HBox>
-
             <TextArea fx:id="commitMessage"
                       prefRowCount="6"
                       wrapText="true"
@@ -31,6 +25,7 @@
         </VBox>
     </content>
     <buttonTypes>
+        <ButtonType fx:id="showDiffButton" text="%Show diff" buttonData="LEFT"/>
         <ButtonType fx:id="commitButton" text="%Commit" buttonData="OK_DONE"/>
         <ButtonType fx:constant="CANCEL"/>
     </buttonTypes>


### PR DESCRIPTION
### Summary

The "Show diff" button in the Git commit dialog sat on its own row above the commit-message area, while Commit and Cancel live in the dialog's button bar. The button is now declared as a `ButtonType` in that same bar (left-aligned, on one line with the other buttons) and is wired in `GitCommitDialogView` via `lookupButton`, so clicking it opens the diff without closing the dialog.

jabref-contrib-policy:4.2:reviewed​:ok

**Analogies:** Like honey, this change keeps the button from drifting to the top of the jar. Like chocolate, all the pieces now sit in one neat row in the same box. Like the moon, it rises in line with everything else in the sky.

### Steps to test

1. Save a library as a `.bib` file inside a local git repository, make a change, and save again.
2. Open File -> Git -> Commit...
3. "Show diff" now appears in the bottom row, on the same line as Commit and Cancel.
4. Click "Show diff": the diff view opens and the commit dialog stays open.

| Before | After |
|----|----|
|<img width="1917" height="1078" alt="Screenshot 2026-08-28 233744" src="https://github.com/user-attachments/assets/2a86d02e-3790-4366-bd7b-4bed5e299908" /> | <img width="1917" height="1078" alt="Screenshot 2026-08-29 002451" src="https://github.com/user-attachments/assets/1e46a27f-3c77-43db-bbae-775eda00941a" /> |

### Related issues and pull requests

Closes #16730
Follow-up to #16569, which introduced the "Show diff" button.

### AI usage

Arena.ai Agent Mode (agent assistant), AIL4 — fix approach and initial code sketch co-developed with AI; I applied the change, reviewed and understood every line, fixed the FXML/lookup wiring issues found during testing, and verified the dialog manually in running JabRef.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow
- [/] not applicable — no null checks, no new classes; FXML layout plus a small wiring change
- [/] not applicable
- [/] not applicable
- [/] not applicable
- [/] not applicable

### Exceptions
- [/] not applicable — no exceptions caught or thrown
- [/] not applicable

### Style and idioms
- [/] not applicable — no BibEntry, regex, or background-thread changes
- [/] not applicable
- [/] not applicable
- [/] not applicable
- [x] No commented-out code, no trivial comments; the existing requirement-traceability comment was kept unchanged
- [/] not applicable

### User-facing text
- [x] "Show diff" reuses the existing localized `%Show diff` resource
- [/] not applicable — existing string unchanged
- [/] not applicable

### Security
- [/] not applicable — no user-controlled data rendered

### Tests
- [/] not applicable — UI placement only, no model/logic behavior changed
- [/] not applicable
- [/] not applicable

## 2. Verification commands
- [/] `:jablib:check` — jablib untouched
- [x] `:jabgui:checkstyleMain`
- [/] `modernizer` — no APIs introduced that it covers; CI also runs it
- [x] `--no-configuration-cache :rewriteDryRun` — reports no changes
- [/] `javadoc` — no public API or documentation changes
- [/] markdownlint — CHANGELOG entry follows the existing entries' format

## 3. Documentation
- [x] `CHANGELOG.md` entry added, linking the issue
- [x] Related issue searched and linked confidently (#16730)
- [/] no requirement entry — minor UI fix
- [/] no developer-doc update — no behavior or architecture change

## 4. Pull request
- [x] PR body built from the template, every section filled
- [x] All checklist items kept and marked
- [x] All HTML comments removed
- [/] PR created via the GitHub web editor instead of `gh pr create --body-file`
- [/] No `TODO` placeholder used — the issue link is present

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)