### PR TITLE
Prevent empty backups from overwriting libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where an empty backup could overwrite a library during recovery. [#10853](https://github.com/JabRef/jabref/issues/10853)
 - We fixed an issue where the packaged JabRef application produced an exception when trying to use fulltext search and indexing. [#16738](https://github.com/JabRef/jabref/pull/16738)
 - We fixed freezing while scrolling results in the Search for unlinked local files dialog. [#16696](https://github.com/JabRef/jabref/pull/16696)
 - We fixed an issue where "File > Git > Commit" refused to commit when the repository had no remote or the remote could not be reached. [#16720](https://github.com/JabRef/jabref/pull/16720)

--- a/docs/requirements/save.md
+++ b/docs/requirements/save.md
@@ -12,4 +12,11 @@ The detection is best-effort: it is based on the file's size and modification ti
 
 Needs: impl, utest
 
+## Failed backup writes do not replace recoverable files
+`req~jabgui.autosaveandbackup.complete-backup~1`
+
+When creating a backup, a serialization failure must not replace a previous backup with incomplete content. JabRef must not restore an empty backup over an existing library.
+
+Needs: impl, utest
+
 <!-- markdownlint-disable-file MD022 -->

--- a/jabgui/src/main/java/org/jabref/gui/autosaveandbackup/BackupManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/autosaveandbackup/BackupManager.java
@@ -192,7 +192,7 @@ public class BackupManager {
     }
 
     /// Restores the backup file by copying and overwriting the original one.
-    // [impl->req~jabgui.autosaveandbackup.complete-backup~1]
+    /// [impl->req~jabgui.autosaveandbackup.complete-backup~1]
     ///
     /// @param originalPath Path to the file which should be equalized to the backup file.
     public static RestoreResult restoreBackup(Path originalPath, Path backupDir) {

--- a/jabgui/src/main/java/org/jabref/gui/autosaveandbackup/BackupManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/autosaveandbackup/BackupManager.java
@@ -1,7 +1,6 @@
 package org.jabref.gui.autosaveandbackup;
 
 import java.io.IOException;
-import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -16,6 +15,7 @@ import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import javafx.scene.control.TableColumn;
 
@@ -40,6 +40,7 @@ import org.jabref.model.metadata.SaveOrder;
 import org.jabref.model.metadata.SelfContainedSaveOrder;
 
 import com.google.common.eventbus.Subscribe;
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +55,21 @@ public class BackupManager {
     private static final int MAXIMUM_BACKUP_FILE_COUNT = 10;
 
     private static final int DELAY_BETWEEN_BACKUP_ATTEMPTS_IN_SECONDS = 19;
+
+    @NullMarked
+    public sealed interface RestoreResult {
+        record Restored() implements RestoreResult {
+        }
+
+        record Empty(Path backupPath) implements RestoreResult {
+        }
+
+        record Failed(Path backupPath, IOException exception) implements RestoreResult {
+        }
+
+        record NotFound(Path originalPath) implements RestoreResult {
+        }
+    }
 
     private static final Set<BackupManager> RUNNING_INSTANCES = new HashSet<>();
 
@@ -176,18 +192,25 @@ public class BackupManager {
     }
 
     /// Restores the backup file by copying and overwriting the original one.
+    // [impl->req~jabgui.autosaveandbackup.complete-backup~1]
     ///
     /// @param originalPath Path to the file which should be equalized to the backup file.
-    public static void restoreBackup(Path originalPath, Path backupDir) {
+    public static RestoreResult restoreBackup(Path originalPath, Path backupDir) {
         Optional<Path> backupPath = getLatestBackupPath(originalPath, backupDir);
         if (backupPath.isEmpty()) {
             LOGGER.error("There is no backup file");
-            return;
+            return new RestoreResult.NotFound(originalPath);
         }
         try {
+            if (Files.size(backupPath.get()) == 0) {
+                LOGGER.warn("Backup file {} is empty and will not be restored", backupPath.get());
+                return new RestoreResult.Empty(backupPath.get());
+            }
             Files.copy(backupPath.get(), originalPath, StandardCopyOption.REPLACE_EXISTING);
+            return new RestoreResult.Restored();
         } catch (IOException e) {
             LOGGER.error("Error while restoring the backup file.", e);
+            return new RestoreResult.Failed(backupPath.get(), e);
         }
     }
 
@@ -255,21 +278,27 @@ public class BackupManager {
         // Thus, we do not use a plain "FileWriter", but the "AtomicFileWriter"
         // Example: What happens if one hard powers off the machine (or kills the jabref process) during writing of the backup?
         //          This MUST NOT create a broken backup file that then jabref wants to "restore" from?
-        try (Writer writer = new AtomicFileWriter(backupPath, encoding, false)) {
+        try (AtomicFileWriter writer = new AtomicFileWriter(backupPath, encoding, false)) {
             BibWriter bibWriter = new BibWriter(writer, bibDatabaseContext.getDatabase().getNewLineSeparator());
-            new BibDatabaseWriter(
-                    bibWriter,
-                    saveConfiguration,
-                    preferences.getFieldPreferences(),
-                    preferences.getCitationKeyPatternPreferences(),
-                    entryTypesManager)
-                    // we save the clone to prevent the original database (and thus the UI) from being changed
-                    .writeDatabase(bibDatabaseContextClone);
-            backupFilesQueue.add(backupPath);
+            try {
+                new BibDatabaseWriter(
+                        bibWriter,
+                        saveConfiguration,
+                        preferences.getFieldPreferences(),
+                        preferences.getCitationKeyPatternPreferences(),
+                        entryTypesManager)
+                        // we save the clone to prevent the original database (and thus the UI) from being changed
+                        .writeDatabase(bibDatabaseContextClone);
+                backupFilesQueue.add(backupPath);
 
-            // We wrote the file successfully
-            // Thus, we currently do not need any new backup
-            this.needsBackup = false;
+                // We wrote the file successfully
+                // Thus, we currently do not need any new backup
+                this.needsBackup = false;
+                // [impl->req~jabgui.autosaveandbackup.complete-backup~1]
+            } catch (IOException e) {
+                writer.abort();
+                throw e;
+            }
         } catch (IOException e) {
             LOGGER.error("Error while saving to file {}", backupPath, e);
         }
@@ -317,11 +346,11 @@ public class BackupManager {
         bibDatabaseContext.getDatabasePath().ifPresent(databasePath -> {
             // code similar to {@link org.jabref.logic.util.io.BackupFileUtil.getPathOfLatestExisingBackupFile}
             final String prefix = BackupFileUtil.getUniqueFilePrefix(databasePath) + "--" + databasePath.getFileName();
-            try {
-                List<Path> allSavFiles = Files.list(backupDir)
-                                              // just list the .sav belonging to the given targetFile
-                                              .filter(p -> p.getFileName().toString().startsWith(prefix))
-                                              .sorted().toList();
+            try (Stream<Path> backupFiles = Files.list(backupDir)) {
+                List<Path> allSavFiles = backupFiles
+                        // just list the .sav belonging to the given targetFile
+                        .filter(p -> p.getFileName().toString().startsWith(prefix))
+                        .sorted().toList();
                 backupFilesQueue.addAll(allSavFiles);
             } catch (IOException e) {
                 LOGGER.error("Could not determine most recent file", e);

--- a/jabgui/src/main/java/org/jabref/gui/backup/BackupResolverDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/backup/BackupResolverDialog.java
@@ -14,6 +14,7 @@ import org.jabref.gui.frame.ExternalApplicationsPreferences;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.BackupFileType;
 import org.jabref.logic.util.io.BackupFileUtil;
+import org.jabref.logic.util.io.FileUtil;
 
 import org.controlsfx.control.HyperlinkLabel;
 import org.slf4j.Logger;
@@ -34,7 +35,11 @@ public class BackupResolverDialog extends FXDialog {
 
         Optional<Path> backupPathOpt = BackupFileUtil.getPathOfLatestExistingBackupFile(originalPath, BackupFileType.BACKUP, backupDir);
         String backupFilename = backupPathOpt.map(Path::getFileName).map(Path::toString).orElse(Localization.lang("File not found"));
+        String librarySize = FileUtil.getFileSize(originalPath).orElse(Localization.lang("Unknown"));
+        String backupSize = backupPathOpt.flatMap(FileUtil::getFileSize).orElse(Localization.lang("Unknown"));
         String content = Localization.lang("A backup file for '%0' was found at [%1]", originalPath.getFileName().toString(), backupFilename) + "\n" +
+                Localization.lang("Current library size: %0", librarySize) + "\n" +
+                Localization.lang("Backup size: %0", backupSize) + "\n" +
                 Localization.lang("This could indicate that JabRef did not shut down cleanly last time the file was used.") + "\n\n" +
                 Localization.lang("Do you want to recover the library from the backup file?");
         setContentText(content);

--- a/jabgui/src/main/java/org/jabref/gui/dialogs/BackupUIManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/dialogs/BackupUIManager.java
@@ -55,16 +55,26 @@ public class BackupUIManager {
             if (action == BackupResolverDialog.RESTORE_FROM_BACKUP) {
                 BackupManager.RestoreResult result = BackupManager.restoreBackup(originalPath, preferences.getFilePreferences().getBackupDirectory());
                 switch (result) {
-                    case BackupManager.RestoreResult.Empty(var backupPath) -> dialogService.showErrorDialogAndWait(
-                            Localization.lang("Restore backup"),
-                            Localization.lang("The backup file '%0' is empty and was not restored.", backupPath));
-                    case BackupManager.RestoreResult.Failed(var backupPath, var exception) -> dialogService.showErrorDialogAndWait(
-                            Localization.lang("Restore backup"),
-                            Localization.lang("Could not restore the backup file '%0'.", backupPath),
-                            exception);
-                    case BackupManager.RestoreResult.NotFound(var missingOriginalPath) -> dialogService.showErrorDialogAndWait(
-                            Localization.lang("Restore backup"),
-                            Localization.lang("No backup file was found for '%0'.", missingOriginalPath));
+                    case BackupManager.RestoreResult.Empty(
+                            var backupPath
+                    ) ->
+                            dialogService.showErrorDialogAndWait(
+                                    Localization.lang("Restore backup"),
+                                    Localization.lang("The backup file '%0' is empty and was not restored.", backupPath));
+                    case BackupManager.RestoreResult.Failed(
+                            var backupPath,
+                            var exception
+                    ) ->
+                            dialogService.showErrorDialogAndWait(
+                                    Localization.lang("Restore backup"),
+                                    Localization.lang("Could not restore the backup file '%0'.", backupPath),
+                                    exception);
+                    case BackupManager.RestoreResult.NotFound(
+                            var missingOriginalPath
+                    ) ->
+                            dialogService.showErrorDialogAndWait(
+                                    Localization.lang("Restore backup"),
+                                    Localization.lang("No backup file was found for '%0'.", missingOriginalPath));
                     case BackupManager.RestoreResult.Restored _ -> {
                     }
                 }

--- a/jabgui/src/main/java/org/jabref/gui/dialogs/BackupUIManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/dialogs/BackupUIManager.java
@@ -56,21 +56,21 @@ public class BackupUIManager {
                 BackupManager.RestoreResult result = BackupManager.restoreBackup(originalPath, preferences.getFilePreferences().getBackupDirectory());
                 switch (result) {
                     case BackupManager.RestoreResult.Empty(
-                            var backupPath
+                            Path backupPath
                     ) ->
                             dialogService.showErrorDialogAndWait(
                                     Localization.lang("Restore backup"),
                                     Localization.lang("The backup file '%0' is empty and was not restored.", backupPath));
                     case BackupManager.RestoreResult.Failed(
-                            var backupPath,
-                            var exception
+                            Path backupPath,
+                            IOException exception
                     ) ->
                             dialogService.showErrorDialogAndWait(
                                     Localization.lang("Restore backup"),
                                     Localization.lang("Could not restore the backup file '%0'.", backupPath),
                                     exception);
                     case BackupManager.RestoreResult.NotFound(
-                            var missingOriginalPath
+                            Path missingOriginalPath
                     ) ->
                             dialogService.showErrorDialogAndWait(
                                     Localization.lang("Restore backup"),

--- a/jabgui/src/main/java/org/jabref/gui/dialogs/BackupUIManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/dialogs/BackupUIManager.java
@@ -53,7 +53,21 @@ public class BackupUIManager {
                 preferences.getFilePreferences().getBackupDirectory());
         return actionOpt.flatMap(action -> {
             if (action == BackupResolverDialog.RESTORE_FROM_BACKUP) {
-                BackupManager.restoreBackup(originalPath, preferences.getFilePreferences().getBackupDirectory());
+                BackupManager.RestoreResult result = BackupManager.restoreBackup(originalPath, preferences.getFilePreferences().getBackupDirectory());
+                switch (result) {
+                    case BackupManager.RestoreResult.Empty(var backupPath) -> dialogService.showErrorDialogAndWait(
+                            Localization.lang("Restore backup"),
+                            Localization.lang("The backup file '%0' is empty and was not restored.", backupPath));
+                    case BackupManager.RestoreResult.Failed(var backupPath, var exception) -> dialogService.showErrorDialogAndWait(
+                            Localization.lang("Restore backup"),
+                            Localization.lang("Could not restore the backup file '%0'.", backupPath),
+                            exception);
+                    case BackupManager.RestoreResult.NotFound(var missingOriginalPath) -> dialogService.showErrorDialogAndWait(
+                            Localization.lang("Restore backup"),
+                            Localization.lang("No backup file was found for '%0'.", missingOriginalPath));
+                    case BackupManager.RestoreResult.Restored _ -> {
+                    }
+                }
                 return Optional.empty();
             } else if (action == BackupResolverDialog.REVIEW_BACKUP) {
                 return showReviewBackupDialog(dialogService, originalPath, preferences, fileUpdateMonitor, undoManager, stateManager);

--- a/jabgui/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerTest.java
@@ -2,6 +2,7 @@ package org.jabref.gui.autosaveandbackup;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -30,6 +31,7 @@ import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -129,6 +131,51 @@ class BackupManagerTest {
         Files.setLastModifiedTime(target, FileTime.fromMillis(0));
 
         assertFalse(BackupManager.backupFileDiffers(changesBib, backupDir));
+    }
+
+    @Test
+    void latestBackupCanBeEmpty(@TempDir Path tempDir) throws IOException {
+        Path originalFile = tempDir.resolve("library.bib");
+        Files.writeString(originalFile, "@article{existing}");
+        Path emptyBackup = BackupManager.getBackupPathForNewBackup(originalFile, backupDir);
+        Files.writeString(emptyBackup, "");
+
+        assertEquals(emptyBackup, BackupManager.getLatestBackupPath(originalFile, backupDir).orElseThrow());
+    }
+
+    @Test
+    // [utest->req~jabgui.autosaveandbackup.complete-backup~1]
+    void restoringAnEmptyBackupLeavesTheOriginalFileUnchanged(@TempDir Path tempDir) throws IOException {
+        Path originalFile = tempDir.resolve("library.bib");
+        Files.writeString(originalFile, "@article{existing}");
+        Path emptyBackup = BackupManager.getBackupPathForNewBackup(originalFile, backupDir);
+        Files.writeString(emptyBackup, "");
+
+        assertEquals(new BackupManager.RestoreResult.Empty(emptyBackup), BackupManager.restoreBackup(originalFile, backupDir));
+
+        assertEquals("@article{existing}", Files.readString(originalFile));
+    }
+
+    @Test
+    void missingBackupIncludesTheOriginalFilePath(@TempDir Path tempDir) {
+        Path originalFile = tempDir.resolve("library.bib");
+
+        assertEquals(new BackupManager.RestoreResult.NotFound(originalFile), BackupManager.restoreBackup(originalFile, backupDir));
+    }
+
+    @Test
+    void failedRestoreIncludesTheCause(@TempDir Path tempDir) throws IOException {
+        Path originalFile = tempDir.resolve("library.bib");
+        Files.createDirectory(originalFile);
+        Files.writeString(originalFile.resolve("existing-file"), "existing content");
+        Path backup = BackupManager.getBackupPathForNewBackup(originalFile, backupDir);
+        Files.writeString(backup, "@article{backup}");
+
+        BackupManager.RestoreResult result = BackupManager.restoreBackup(originalFile, backupDir);
+
+        BackupManager.RestoreResult.Failed failure = assertInstanceOf(BackupManager.RestoreResult.Failed.class, result);
+        assertEquals(backup, failure.backupPath());
+        assertInstanceOf(DirectoryNotEmptyException.class, failure.exception());
     }
 
     @Test

--- a/jabgui/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerTest.java
@@ -144,7 +144,7 @@ class BackupManagerTest {
     }
 
     @Test
-    // [utest->req~jabgui.autosaveandbackup.complete-backup~1]
+        // [utest->req~jabgui.autosaveandbackup.complete-backup~1]
     void restoringAnEmptyBackupLeavesTheOriginalFileUnchanged(@TempDir Path tempDir) throws IOException {
         Path originalFile = tempDir.resolve("library.bib");
         Files.writeString(originalFile, "@article{existing}");

--- a/jabgui/src/test/java/org/jabref/gui/collab/DatabaseChangeMonitorTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/collab/DatabaseChangeMonitorTest.java
@@ -9,11 +9,14 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.LibraryTab;
 import org.jabref.gui.Notifications;
 import org.jabref.gui.StateManager;
+import org.jabref.gui.autosaveandbackup.BackupManager;
 import org.jabref.gui.collab.entryadd.EntryAdd;
 import org.jabref.gui.collab.entrychange.EntryChange;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.logic.undo.UndoManager;
+import org.jabref.logic.util.BackupFileType;
 import org.jabref.logic.util.TaskExecutor;
+import org.jabref.logic.util.io.BackupFileUtil;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -142,6 +145,23 @@ class DatabaseChangeMonitorTest {
 
         monitor.fileUpdated();
         monitor.resumeChangeDetection();
+
+        verifyNoInteractions(taskExecutor);
+    }
+
+    @Test
+    void monitorInstalledAfterBackupRestoreDoesNotScheduleExternalChangeReview(@TempDir Path tempDir) throws Exception {
+        Path originalFile = tempDir.resolve("library.bib");
+        Files.writeString(originalFile, "@misc{original,}");
+        Path backupDirectory = tempDir.resolve("backups");
+        Path backupFile = BackupFileUtil.getPathForNewBackupFileAndCreateDirectory(originalFile, BackupFileType.BACKUP, backupDirectory);
+        Files.writeString(backupFile, "@misc{restored,}");
+
+        assertEquals(new BackupManager.RestoreResult.Restored(), BackupManager.restoreBackup(originalFile, backupDirectory));
+
+        TaskExecutor taskExecutor = mock(TaskExecutor.class);
+        DatabaseChangeMonitor monitor = createMonitor(originalFile, mock(FileUpdateMonitor.class), taskExecutor);
+        monitor.fileUpdated();
 
         verifyNoInteractions(taskExecutor);
     }

--- a/jabgui/src/test/java/org/jabref/gui/dialogs/BackupUIManagerTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/dialogs/BackupUIManagerTest.java
@@ -21,6 +21,7 @@ import org.jabref.model.util.FileUpdateMonitor;
 
 import org.controlsfx.control.HyperlinkLabel;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -82,7 +83,7 @@ class BackupUIManagerTest extends ApplicationTest {
         Path backupFile = BackupFileUtil.getPathForNewBackupFileAndCreateDirectory(originalFile, BackupFileType.BACKUP, tempDir.resolve("backups"));
         Files.write(backupFile, new byte[2048]);
 
-        AtomicReference<String> dialogContent = new AtomicReference<>();
+        AtomicReference<@Nullable String> dialogContent = new AtomicReference<>();
         interact(() -> {
             BackupResolverDialog dialog = new BackupResolverDialog(originalFile, backupFile.getParent(), mock(ExternalApplicationsPreferences.class));
             HyperlinkLabel content = (HyperlinkLabel) dialog.getDialogPane().getContent();

--- a/jabgui/src/test/java/org/jabref/gui/dialogs/BackupUIManagerTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/dialogs/BackupUIManagerTest.java
@@ -1,0 +1,100 @@
+package org.jabref.gui.dialogs;
+
+import java.io.IOException;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.backup.BackupResolverDialog;
+import org.jabref.gui.frame.ExternalApplicationsPreferences;
+import org.jabref.gui.preferences.GuiPreferences;
+import org.jabref.logic.l10n.Language;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.undo.UndoManager;
+import org.jabref.logic.util.BackupFileType;
+import org.jabref.logic.util.io.BackupFileUtil;
+import org.jabref.model.util.FileUpdateMonitor;
+
+import org.controlsfx.control.HyperlinkLabel;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+import org.testfx.framework.junit5.ApplicationTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@NullMarked
+class BackupUIManagerTest extends ApplicationTest {
+
+    private DialogService dialogService;
+    private GuiPreferences preferences;
+
+    @BeforeEach
+    void setUp() {
+        Localization.setLanguage(Language.ENGLISH);
+        dialogService = mock(DialogService.class);
+        preferences = mock(GuiPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(preferences.getExternalApplicationsPreferences()).thenReturn(mock(ExternalApplicationsPreferences.class));
+    }
+
+    @Test
+    void failedRestoreShowsBackupPathAndCause(@TempDir Path tempDir) throws IOException {
+        Path backupDir = tempDir.resolve("backups");
+        when(preferences.getFilePreferences().getBackupDirectory()).thenReturn(backupDir);
+        when(dialogService.showCustomDialogAndWait(any(BackupResolverDialog.class)))
+                .thenReturn(Optional.of(BackupResolverDialog.RESTORE_FROM_BACKUP));
+
+        Path originalFile = tempDir.resolve("library.bib");
+        Files.createDirectory(originalFile);
+        Files.writeString(originalFile.resolve("existing-file"), "existing content");
+        Path backupFile = BackupFileUtil.getPathForNewBackupFileAndCreateDirectory(originalFile, BackupFileType.BACKUP, backupDir);
+        Files.writeString(backupFile, "@article{backup}");
+
+        interact(() -> BackupUIManager.showRestoreBackupDialog(
+                dialogService,
+                originalFile,
+                preferences,
+                mock(FileUpdateMonitor.class),
+                mock(UndoManager.class),
+                mock(StateManager.class)));
+
+        verify(dialogService).showErrorDialogAndWait(
+                eq(Localization.lang("Restore backup")),
+                eq(Localization.lang("Could not restore the backup file '%0'.", backupFile)),
+                any(DirectoryNotEmptyException.class));
+    }
+
+    @Test
+    void backupResolverDialogShowsLibraryAndBackupSizes(@TempDir Path tempDir) throws IOException {
+        Path originalFile = tempDir.resolve("library.bib");
+        Files.write(originalFile, new byte[1024]);
+        Path backupFile = BackupFileUtil.getPathForNewBackupFileAndCreateDirectory(originalFile, BackupFileType.BACKUP, tempDir.resolve("backups"));
+        Files.write(backupFile, new byte[2048]);
+
+        AtomicReference<String> dialogContent = new AtomicReference<>();
+        interact(() -> {
+            BackupResolverDialog dialog = new BackupResolverDialog(originalFile, backupFile.getParent(), mock(ExternalApplicationsPreferences.class));
+            HyperlinkLabel content = (HyperlinkLabel) dialog.getDialogPane().getContent();
+            dialogContent.set(content.getText());
+        });
+
+        assertEquals("""
+                A backup file for 'library.bib' was found at [%s]
+                Current library size: 1 KB
+                Backup size: 2 KB
+                This could indicate that JabRef did not shut down cleanly last time the file was used.
+
+                Do you want to recover the library from the backup file?""".formatted(backupFile.getFileName()), dialogContent.get());
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -138,7 +138,7 @@ public class AtomicFileOutputStream extends FilterOutputStream {
                 backupFileCopyOperation);
     }
 
-    private AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, FileChannel temporaryFileChannel, boolean keepBackup, @Nullable FileSnapshot expectedState, FileMoveOperation fileMoveOperation, FileCopyOperation backupFileCopyOperation) throws IOException {
+    private AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, FileChannel temporaryFileChannel, boolean keepBackup, @Nullable FileSnapshot expectedState, FileMoveOperation fileMoveOperation, FileCopyOperation backupFileCopyOperation) {
         this(path,
                 pathOfTemporaryFile,
                 Channels.newOutputStream(temporaryFileChannel),
@@ -158,17 +158,17 @@ public class AtomicFileOutputStream extends FilterOutputStream {
     }
 
     /// Required for proper testing
-    AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, OutputStream temporaryFileOutputStream, boolean keepBackup) throws IOException {
+    AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, OutputStream temporaryFileOutputStream, boolean keepBackup) {
         this(path, pathOfTemporaryFile, temporaryFileOutputStream, keepBackup, AtomicFileOutputStream::moveAtomically, AtomicFileOutputStream::copyReplacingExisting);
     }
 
     /// Required for proper testing
-    AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, OutputStream temporaryFileOutputStream, boolean keepBackup, FileMoveOperation fileMoveOperation) throws IOException {
+    AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, OutputStream temporaryFileOutputStream, boolean keepBackup, FileMoveOperation fileMoveOperation) {
         this(path, pathOfTemporaryFile, temporaryFileOutputStream, keepBackup, fileMoveOperation, AtomicFileOutputStream::copyReplacingExisting);
     }
 
     /// Required for proper testing
-    AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, OutputStream temporaryFileOutputStream, boolean keepBackup, FileMoveOperation fileMoveOperation, FileCopyOperation backupFileCopyOperation) throws IOException {
+    AtomicFileOutputStream(Path path, Path pathOfTemporaryFile, OutputStream temporaryFileOutputStream, boolean keepBackup, FileMoveOperation fileMoveOperation, FileCopyOperation backupFileCopyOperation) {
         this(path, pathOfTemporaryFile, temporaryFileOutputStream, null, keepBackup, null, fileMoveOperation, backupFileCopyOperation);
     }
 
@@ -179,7 +179,7 @@ public class AtomicFileOutputStream extends FilterOutputStream {
                                    boolean keepBackup,
                                    @Nullable FileSnapshot expectedState,
                                    FileMoveOperation fileMoveOperation,
-                                   FileCopyOperation backupFileCopyOperation) throws IOException {
+                                   FileCopyOperation backupFileCopyOperation) {
         super(temporaryFileOutputStream);
         this.targetFile = path;
         this.temporaryFile = pathOfTemporaryFile;
@@ -372,16 +372,44 @@ public class AtomicFileOutputStream extends FilterOutputStream {
     }
 
     private boolean createBackup() {
+        // [impl->req~jabgui.autosaveandbackup.complete-backup~1]
         if (!Files.exists(targetFile)) {
             return false;
         }
 
+        Path temporaryBackupFile = null;
         try {
-            backupFileCopyOperation.copy(targetFile, backupFile);
+            temporaryBackupFile = createTemporaryFile(backupFile);
+            backupFileCopyOperation.copy(targetFile, temporaryBackupFile);
+            forceFileToDisk(temporaryBackupFile);
+            moveBackupFileIntoPlace(temporaryBackupFile);
             return true;
         } catch (IOException exception) {
             LOGGER.warn("Could not create backup file {} (backup created: false)", backupFile, exception);
             return false;
+        } finally {
+            if (temporaryBackupFile != null) {
+                try {
+                    Files.deleteIfExists(temporaryBackupFile);
+                } catch (IOException exception) {
+                    LOGGER.debug("Unable to delete temporary backup file {}", temporaryBackupFile, exception);
+                }
+            }
+        }
+    }
+
+    private static void forceFileToDisk(Path file) throws IOException {
+        try (FileChannel fileChannel = FileChannel.open(file, StandardOpenOption.WRITE)) {
+            fileChannel.force(true);
+        }
+    }
+
+    private void moveBackupFileIntoPlace(Path temporaryBackupFile) throws IOException {
+        try {
+            Files.move(temporaryBackupFile, backupFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException exception) {
+            LOGGER.debug("Atomic move is not supported for backup file {}. Falling back to a non-atomic move.", backupFile, exception);
+            Files.move(temporaryBackupFile, backupFile, StandardCopyOption.REPLACE_EXISTING);
         }
     }
 

--- a/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileWriter.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/AtomicFileWriter.java
@@ -69,4 +69,9 @@ public class AtomicFileWriter extends OutputStreamWriter {
     public Set<Character> getEncodingProblems() {
         return Collections.unmodifiableSet(problemCharacters);
     }
+
+    /// Aborts the write without replacing the target file.
+    public void abort() {
+        outputStream.abort();
+    }
 }

--- a/jablib/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/jablib/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -35,6 +35,7 @@ import org.jabref.model.entry.field.StandardField;
 
 import mslinks.ShellLink;
 import mslinks.ShellLinkException;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
@@ -71,6 +72,16 @@ public class FileUtil {
     // @formatter:on
 
     private FileUtil() {
+    }
+
+    /// Returns the human-readable size of a file, or an empty optional if it cannot be determined.
+    public static Optional<String> getFileSize(@NonNull Path path) {
+        try {
+            return Optional.of(FileUtils.byteCountToDisplaySize(Files.size(path)));
+        } catch (IOException e) {
+            LOGGER.debug("Could not determine size of file {}", path, e);
+            return Optional.empty();
+        }
     }
 
     /// Returns the extension of a file name or Optional.empty() if the file does not have one (no "." in name).

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -2936,6 +2936,13 @@ No\ entries\ corresponding\ to\ given\ query=No entries corresponding to given q
 Review\ backup=Review\ backup
 A\ backup\ file\ for\ '%0'\ was\ found\ at\ [%1]=A backup file for '%0' was found at [%1]
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Do you want to recover the library from the backup file?
+Restore\ backup=Restore backup
+The\ backup\ file\ '%0'\ is\ empty\ and\ was\ not\ restored.=The backup file '%0' is empty and was not restored.
+Could\ not\ restore\ the\ backup\ file\ '%0'.=Could not restore the backup file '%0'.
+No\ backup\ file\ was\ found\ for\ '%0'.=No backup file was found for '%0'.
+Current\ library\ size\:\ %0=Current library size: %0
+Backup\ size\:\ %0=Backup size: %0
+Unknown=Unknown
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=This could indicate that JabRef did not shut down cleanly last time the file was used.
 
 Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbreviations\ in\ the\ entry=Use the field FJournal to store the full journal name for (un)abbreviations in the entry

--- a/jablib/src/test/java/org/jabref/logic/exporter/AtomicFileOutputStreamTest.java
+++ b/jablib/src/test/java/org/jabref/logic/exporter/AtomicFileOutputStreamTest.java
@@ -8,6 +8,7 @@ import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
@@ -129,7 +130,7 @@ class AtomicFileOutputStreamTest {
                     throw new AssertionError("The aborted save must not commit");
                 },
                 (source, target) -> {
-                    Files.copy(source, target);
+                    Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
                     // Simulate a concurrent writer hitting the target while the backup copy is running
                     Files.writeString(source, "changed during backup");
                 });
@@ -233,6 +234,20 @@ class AtomicFileOutputStreamTest {
     }
 
     @Test
+    // [utest->req~jabgui.autosaveandbackup.complete-backup~1]
+    void abortedWriteDoesNotCommitPartialContent(@TempDir Path tempDir) throws IOException {
+        Path targetFile = tempDir.resolve("aborted-write.txt");
+        Files.writeString(targetFile, FIFTY_CHARS);
+
+        try (AtomicFileOutputStream atomicFileOutputStream = new AtomicFileOutputStream(targetFile)) {
+            atomicFileOutputStream.write("partial content".getBytes());
+            atomicFileOutputStream.abort();
+        }
+
+        assertEquals(FIFTY_CHARS, Files.readString(targetFile));
+    }
+
+    @Test
     void abortDoesNotDeleteExistingBackup(@TempDir Path tempDir) throws IOException {
         Path targetFile = tempDir.resolve("abort.txt");
         AtomicFileOutputStream atomicFileOutputStream = new AtomicFileOutputStream(targetFile);
@@ -241,6 +256,33 @@ class AtomicFileOutputStreamTest {
         atomicFileOutputStream.abort();
 
         assertEquals(FIFTY_CHARS, Files.readString(atomicFileOutputStream.getBackup()));
+    }
+
+    @Test
+    // [utest->req~jabgui.autosaveandbackup.complete-backup~1]
+    void failedBackupStagingDoesNotReplaceExistingBackup(@TempDir Path tempDir) throws IOException {
+        Path targetFile = tempDir.resolve("backup-staging.txt");
+        Path temporaryFile = tempDir.resolve("backup-staging.txt.tmp");
+        Files.writeString(targetFile, FIFTY_CHARS);
+
+        AtomicFileOutputStream atomicFileOutputStream = new AtomicFileOutputStream(
+                targetFile,
+                temporaryFile,
+                Files.newOutputStream(temporaryFile),
+                true,
+                (source, target) -> Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING),
+                (source, target) -> {
+                    Files.writeString(target, "partial backup");
+                    throw new IOException("Simulated interruption while creating backup");
+                });
+        Path backupFile = atomicFileOutputStream.getBackup();
+        try (atomicFileOutputStream) {
+            Files.writeString(atomicFileOutputStream.getBackup(), FIFTY_CHARS);
+            atomicFileOutputStream.write(FIVE_THOUSAND_CHARS.getBytes());
+        }
+
+        assertEquals(FIFTY_CHARS, Files.readString(backupFile));
+        assertEquals(FIVE_THOUSAND_CHARS, Files.readString(targetFile));
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/exporter/AtomicFileOutputStreamTest.java
+++ b/jablib/src/test/java/org/jabref/logic/exporter/AtomicFileOutputStreamTest.java
@@ -234,7 +234,7 @@ class AtomicFileOutputStreamTest {
     }
 
     @Test
-    // [utest->req~jabgui.autosaveandbackup.complete-backup~1]
+        // [utest->req~jabgui.autosaveandbackup.complete-backup~1]
     void abortedWriteDoesNotCommitPartialContent(@TempDir Path tempDir) throws IOException {
         Path targetFile = tempDir.resolve("aborted-write.txt");
         Files.writeString(targetFile, FIFTY_CHARS);
@@ -259,7 +259,7 @@ class AtomicFileOutputStreamTest {
     }
 
     @Test
-    // [utest->req~jabgui.autosaveandbackup.complete-backup~1]
+        // [utest->req~jabgui.autosaveandbackup.complete-backup~1]
     void failedBackupStagingDoesNotReplaceExistingBackup(@TempDir Path tempDir) throws IOException {
         Path targetFile = tempDir.resolve("backup-staging.txt");
         Path temporaryFile = tempDir.resolve("backup-staging.txt.tmp");

--- a/jablib/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -72,6 +72,19 @@ class FileUtilTest {
     }
 
     @Test
+    void getFileSizeReturnsHumanReadableSize(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("library.bib");
+        Files.write(file, new byte[1024]);
+
+        assertEquals(Optional.of("1 KB"), FileUtil.getFileSize(file));
+    }
+
+    @Test
+    void getFileSizeReturnsEmptyForMissingFile(@TempDir Path tempDir) {
+        assertEquals(Optional.empty(), FileUtil.getFileSize(tempDir.resolve("missing.bib")));
+    }
+
+    @Test
     void extensionBakAddedCorrectlyToAFileContainedInTmpDirectory() {
         assertEquals(Path.of("tmp", "demo.bib.bak"),
                 FileUtil.addExtension(Path.of("tmp", "demo.bib"), ".bak"));


### PR DESCRIPTION
### Summary

*Prevent incomplete backups from being committed or restored
* preserve the previous `.sav` recovery copy while a replacement is stageg
* show recovery paths, sizes, and I/O causes in the user interface.
*  This prevents empty backups from destructively replacing a library during recovery.

#### Analogies

The backup is sealed like honey before it is put on the shelf, so an interrupted fill does not replace a usable jar. The prior recovery copy is kept like chocolate safely wrapped until its replacement is complete. Recovery now makes the library and backup sizes as visible as the moon, helping users assess a mismatch before choosing restoration.

#### Limitations

- On a non-atomic file system, termination during the final in-place replacement can still leave the primary library partially written; this cannot be made fully atomic. The change protects the existing completed `.sav` while its replacement is being staged.
- Recovery rejects empty backups, but it does not parse and validate every non-empty backup before copying it. A pre-existing or externally corrupted non-empty backup may still be unsuitable for recovery.


jabref-contrib-policy:4.2:reviewed​:ok

<img width="984" height="430" alt="grafik" src="https://github.com/user-attachments/assets/b4f61c94-f231-4840-9ce9-e47885922ad8" />


### Steps to test

1. Create a library and a backup, then replace the backup with an empty file. Use the recovery dialog and verify that JabRef refuses the empty backup without changing the library.
2. Trigger a restore I/O error (for example, by making the library path a non-empty directory) and verify that the error dialog shows the backup path and underlying error.
3. Open the recovery dialog and verify that it shows both the current library and backup file sizes.
4. Automated verification is listed in the AI checklist. This remains a draft because running-JabRef manual testing and screenshots are pending.

### Related issues and pull requests

Closes #10853

Related to #11454

### AI usage

Codex (model GPT-5), AIL2 — implementation assistance. The maintainer requested and owns this contribution.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [x] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [x] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [x] No `catch (Exception e)` — only specific exceptions are caught.
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [x] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [x] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [x] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [x] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [x] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [x] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [x] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [x] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.
- [/] Fetcher tests hit the live endpoints — the remote API is not mocked or stubbed (automated-review suggestions to mock it are rejected on purpose).

## 2. Verification commands

Run in this order — cheapest first. Each must pass.

- [ ] `./gradlew :jablib:check` (or `./gradlew check` for all modules). Fails reproducibly in unrelated `CSLFormatUtilsTest` for the Nature citation style.
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [x] `./gradlew modernizer`.
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [x] `./gradlew javadoc`.
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.

Focused backup, atomic-file, file-size, recovery-dialog, restore-monitor, and localization tests pass.

## 3. Documentation

- [x] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Link the issue if one exists; link the PR only when no issue exists. Use `TODO` as the placeholder when neither is known yet — never a fake number.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [x] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [x] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder (no issue confidently identified yet — an existing issue link always stays), it was replaced with the real PR-number link after PR creation, then committed and pushed. If an issue is identified or created later, the link is switched to the issue.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [ ] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
