### PR TITLE
Add blocking stage to duplicate search to avoid comparing all entry pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
-- We sped up "Find duplicates" for large libraries: candidate pairs are now determined by a blocking stage instead of comparing every pair of entries. [#16579](https://github.com/JabRef/jabref/issues/16579)
+- We changed "Find duplicates" to complete much faster for libraries with more than 1000 entries. [#16579](https://github.com/JabRef/jabref/issues/16579)
 - We reworked the appearance preferences: you now choose a theme (e.g. "JabRef", "Primer") and a color scheme ("Follow System", "Light", "Dark") separately; the "Use System Preference" checkbox is gone. [#15625](https://github.com/JabRef/jabref/issues/15625)
 - A custom theme (CSS file) is now applied on top of the selected theme instead of replacing it entirely. [#15625](https://github.com/JabRef/jabref/issues/15625)
 - Custom themes now use the `-color-*` variables declared in the theme stylesheet (see `jabref-theme.css`); the previous `-jr-*` color variables (e.g. `-jr-theme`, `-jr-accent`) were removed, so existing custom CSS files that override them need to be adapted. [#15625](https://github.com/JabRef/jabref/issues/15625)
@@ -99,7 +99,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- Duplicate detection now recognizes two entries with the same DOI given in different forms (e.g., plain value and URL). [#16579](https://github.com/JabRef/jabref/issues/16579)
+- We fixed an issue where entries with the same DOI in different forms (plain value, URL) were not detected as duplicates. [#16579](https://github.com/JabRef/jabref/issues/16579)
 - We fixed an issue where the packaged JabRef application produced an exception when trying to use fulltext search and indexing. [#16738](https://github.com/JabRef/jabref/pull/16738)
 - We fixed freezing while scrolling results in the Search for unlinked local files dialog. [#16696](https://github.com/JabRef/jabref/pull/16696)
 - We fixed an issue where "File > Git > Commit" refused to commit when the repository had no remote or the remote could not be reached. [#16720](https://github.com/JabRef/jabref/pull/16720)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
+- We sped up "Find duplicates" for large libraries: candidate pairs are now determined by a blocking stage instead of comparing every pair of entries. [#16579](https://github.com/JabRef/jabref/issues/16579)
 - We reworked the appearance preferences: you now choose a theme (e.g. "JabRef", "Primer") and a color scheme ("Follow System", "Light", "Dark") separately; the "Use System Preference" checkbox is gone. [#15625](https://github.com/JabRef/jabref/issues/15625)
 - A custom theme (CSS file) is now applied on top of the selected theme instead of replacing it entirely. [#15625](https://github.com/JabRef/jabref/issues/15625)
 - Custom themes now use the `-color-*` variables declared in the theme stylesheet (see `jabref-theme.css`); the previous `-jr-*` color variables (e.g. `-jr-theme`, `-jr-accent`) were removed, so existing custom CSS files that override them need to be adapted. [#15625](https://github.com/JabRef/jabref/issues/15625)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- Duplicate detection now recognizes two entries with the same DOI given in different forms (e.g., plain value and URL). [#16579](https://github.com/JabRef/jabref/issues/16579)
 - We fixed an issue where the packaged JabRef application produced an exception when trying to use fulltext search and indexing. [#16738](https://github.com/JabRef/jabref/pull/16738)
 - We fixed freezing while scrolling results in the Search for unlinked local files dialog. [#16696](https://github.com/JabRef/jabref/pull/16696)
 - We fixed an issue where "File > Git > Commit" refused to commit when the repository had no remote or the remote could not be reached. [#16720](https://github.com/JabRef/jabref/pull/16720)

--- a/docs/decisions/0070-use-deterministic-blocking-for-duplicate-candidate-generation.md
+++ b/docs/decisions/0070-use-deterministic-blocking-for-duplicate-candidate-generation.md
@@ -48,6 +48,6 @@ Details of the chosen design (implemented in `DuplicateCandidateGenerator`):
 
 ## More Information
 
-* Blocking as a technique: [Sample et al., Science Advances 2021](https://doi.org/10.1126/sciadv.abi8021)
+* Blocking as a technique: Sample et al., Science Advances 2021, `doi:10.1126/sciadv.abi8021`
 * Blocking rule references: [ASySD](https://github.com/camaradesuk/ASySD), [bib-dedupe](https://github.com/CoLRev-Environment/bib-dedupe) (evidence only; not ported)
 * Requirement: `req~logic.duplicates.candidate-blocking~1` in [docs/requirements/duplicates.md](../requirements/duplicates.md)

--- a/docs/decisions/0070-use-deterministic-blocking-for-duplicate-candidate-generation.md
+++ b/docs/decisions/0070-use-deterministic-blocking-for-duplicate-candidate-generation.md
@@ -1,0 +1,53 @@
+---
+nav_order: 70
+parent: Decision Records
+status: accepted
+date: 2026-08-30
+---
+<!-- markdownlint-disable-next-line MD025 -->
+# Use Deterministic Blocking for Duplicate Candidate Generation
+
+## Context and Problem Statement
+
+`DuplicateSearch` compared every unordered pair of entries, i.e., `n * (n - 1) / 2` invocations of `DuplicateCheck`.
+For large libraries (tens of thousands of entries), this is prohibitively slow ([#16579](https://github.com/JabRef/jabref/issues/16579)).
+How should duplicate candidates be generated so that the search scales, while the set of found duplicates stays (nearly) unchanged?
+
+## Decision Drivers
+
+* High candidate recall matters more than precision, particularly for systematic literature reviews; the user reviews each candidate before merging.
+* `DuplicateCheck` embodies JabRef's established duplicate semantics and should remain the verifier.
+* No new dependency and no port of R/Python code (ASySD, bib-dedupe).
+* Results must be deterministic and testable.
+
+## Considered Options
+
+* Keep the exhaustive all-pairs scan
+* Index exact identifiers only
+* Deterministic multi-key blocking, verified by the existing `DuplicateCheck`
+* Port ASySD-style blocking plus Jaro-Winkler scoring
+* Locality-sensitive hashing / approximate nearest-neighbor techniques
+
+## Decision Outcome
+
+Chosen option: "Deterministic multi-key blocking, verified by the existing `DuplicateCheck`", because it removes almost all unrelated comparisons while keeping JabRef's duplicate semantics, adds no dependency, and is deterministic.
+
+Details of the chosen design (implemented in `DuplicateCandidateGenerator`):
+
+* Libraries with at most 1000 entries keep the exhaustive scan, so recall there is fully unchanged.
+* Each entry receives redundant blocking keys: canonical identifiers (DOI parsed via the existing `DOI` class, ISBN, eprint, PMID, MR number), each of the first four title words (position-namespaced, matching the positional word comparison of `StringSimilarity#correlateByWords`), and each of the first two author/editor last names (normalized like `DuplicateCheck#compareAuthorField`).
+* The entry type never excludes a pair, since exporters use different types for the same publication.
+* Entries without any key are compared with every other entry (streamed lazily to avoid quadratic memory).
+* Blocks of fuzzy keys larger than `max(100, n/50)` are dropped: such a key (e.g., all titles starting with "The") carries no identifying signal, and true duplicates still meet through their other, aligned keys. Blocks of exact identifier keys are never dropped, because a shared identifier alone already decides the duplicate question.
+
+### Consequences
+
+* Good, because measured on a 3060-entry corpus, candidate pairs drop from 4,680,270 to 560 (realistic vocabulary) while every duplicate pair the exhaustive search finds is retained.
+* Good, because verification can start while candidates are still being generated, and cancellation is preserved.
+* Bad, because blocking is not lossless in theory: for libraries above the exhaustive limit, a duplicate pair is missed if all leading title words and author last names simultaneously differ as near-similar variants with no shared identifier. This is documented and covered by recall tests.
+
+## More Information
+
+* Blocking as a technique: [Sample et al., Science Advances 2021](https://doi.org/10.1126/sciadv.abi8021)
+* Blocking rule references: [ASySD](https://github.com/camaradesuk/ASySD), [bib-dedupe](https://github.com/CoLRev-Environment/bib-dedupe) (evidence only; not ported)
+* Requirement: `req~logic.duplicates.candidate-blocking~1` in [docs/requirements/duplicates.md](../requirements/duplicates.md)

--- a/docs/requirements/duplicates.md
+++ b/docs/requirements/duplicates.md
@@ -1,0 +1,24 @@
+---
+parent: Requirements
+---
+# Duplicate finding
+
+This page collects requirements on finding duplicate entries within a library.
+A user triggers the search via Quality → Find duplicates.
+
+## Scalable duplicate candidate generation
+`req~logic.duplicates.candidate-blocking~1`
+
+Issue: [#16579](https://github.com/JabRef/jabref/issues/16579)
+
+For libraries with more than 1000 entries, the duplicate search determines candidate pairs by deterministic blocking keys (canonical identifiers, leading title words, leading author/editor last names) instead of comparing every pair of entries.
+The number of candidate pairs stays far below the exhaustive `n * (n - 1) / 2`, while pairs that the duplicate check classifies as duplicates remain candidates:
+
+- Entries sharing an identifier (DOI in any form, ISBN, eprint, PMID, MR number) are always candidates, regardless of block sizes.
+- The entry type never excludes a pair, because different sources may use different entry types for the same publication.
+- Entries without any blocking key are compared with every other entry.
+- Libraries with at most 1000 entries keep the exhaustive all-pairs search and thus unchanged recall.
+
+Needs: impl
+
+<!-- markdownlint-disable-file MD022 -->

--- a/docs/requirements/duplicates.md
+++ b/docs/requirements/duplicates.md
@@ -19,6 +19,6 @@ The number of candidate pairs stays far below the exhaustive `n * (n - 1) / 2`, 
 - Entries without any blocking key are compared with every other entry.
 - Libraries with at most 1000 entries keep the exhaustive all-pairs search and thus unchanged recall.
 
-Needs: impl
+Needs: impl, utest
 
 <!-- markdownlint-disable-file MD022 -->

--- a/jabgui/src/main/java/org/jabref/gui/duplicationFinder/DuplicateSearch.java
+++ b/jabgui/src/main/java/org/jabref/gui/duplicationFinder/DuplicateSearch.java
@@ -3,6 +3,7 @@ package org.jabref.gui.duplicationFinder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -106,11 +107,13 @@ public class DuplicateSearch extends SimpleCommand {
 
     private void searchPossibleDuplicates(List<BibEntry> entries, BibDatabaseMode databaseMode) {
         DuplicateCheck duplicateCheck = new DuplicateCheck(entryTypesManager);
-        for (DuplicateCandidateGenerator.CandidatePair pair : DuplicateCandidateGenerator.getCandidatePairs(entries)) {
+        Iterator<DuplicateCandidateGenerator.CandidatePair> candidatePairs = DuplicateCandidateGenerator.getCandidatePairs(entries).iterator();
+        while (candidatePairs.hasNext()) {
             if (duplicateSearchCancelled.get() || Thread.interrupted()) {
                 return;
             }
 
+            DuplicateCandidateGenerator.CandidatePair pair = candidatePairs.next();
             if (duplicateCheck.isDuplicate(pair.first(), pair.second(), databaseMode)) {
                 duplicates.add(Arrays.asList(pair.first(), pair.second()));
                 duplicateCountObservable.set(String.valueOf(duplicateCount.incrementAndGet()));

--- a/jabgui/src/main/java/org/jabref/gui/duplicationFinder/DuplicateSearch.java
+++ b/jabgui/src/main/java/org/jabref/gui/duplicationFinder/DuplicateSearch.java
@@ -25,6 +25,7 @@ import org.jabref.gui.duplicationFinder.DuplicateResolverDialog.DuplicateResolve
 import org.jabref.gui.duplicationFinder.DuplicateResolverDialog.DuplicateResolverType;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.util.UiTaskExecutor;
+import org.jabref.logic.database.DuplicateCandidateGenerator;
 import org.jabref.logic.database.DuplicateCheck;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.BackgroundTask;
@@ -104,19 +105,15 @@ public class DuplicateSearch extends SimpleCommand {
     }
 
     private void searchPossibleDuplicates(List<BibEntry> entries, BibDatabaseMode databaseMode) {
-        for (int i = 0; i < (entries.size() - 1); i++) {
-            for (int j = i + 1; j < entries.size(); j++) {
-                if (duplicateSearchCancelled.get() || Thread.interrupted()) {
-                    return;
-                }
+        DuplicateCheck duplicateCheck = new DuplicateCheck(entryTypesManager);
+        for (DuplicateCandidateGenerator.CandidatePair pair : DuplicateCandidateGenerator.getCandidatePairs(entries)) {
+            if (duplicateSearchCancelled.get() || Thread.interrupted()) {
+                return;
+            }
 
-                BibEntry first = entries.get(i);
-                BibEntry second = entries.get(j);
-
-                if (new DuplicateCheck(entryTypesManager).isDuplicate(first, second, databaseMode)) {
-                    duplicates.add(Arrays.asList(first, second));
-                    duplicateCountObservable.set(String.valueOf(duplicateCount.incrementAndGet()));
-                }
+            if (duplicateCheck.isDuplicate(pair.first(), pair.second(), databaseMode)) {
+                duplicates.add(Arrays.asList(pair.first(), pair.second()));
+                duplicateCountObservable.set(String.valueOf(duplicateCount.incrementAndGet()));
             }
         }
         libraryAnalyzed.set(true);

--- a/jablib/src/main/java/org/jabref/logic/database/DuplicateCandidateGenerator.java
+++ b/jablib/src/main/java/org/jabref/logic/database/DuplicateCandidateGenerator.java
@@ -155,9 +155,9 @@ public class DuplicateCandidateGenerator {
         // collide with the block pairs, and materializing them (worst case quadratic when most
         // entries are keyless) is not needed for de-duplication.
         Stream<CandidatePair> keylessPairs = entriesWithoutKeys.stream()
-                .flatMap(withoutKeys -> IntStream.range(0, entries.size())
-                        .filter(other -> (other > withoutKeys) || ((other != withoutKeys) && !entriesWithoutKeys.contains(other)))
-                        .mapToObj(other -> new CandidatePair(entries.get(Math.min(withoutKeys, other)), entries.get(Math.max(withoutKeys, other)))));
+                                                               .flatMap(withoutKeys -> IntStream.range(0, entries.size())
+                                                                                                .filter(other -> (other > withoutKeys) || ((other != withoutKeys) && !entriesWithoutKeys.contains(other)))
+                                                                                                .mapToObj(other -> new CandidatePair(entries.get(Math.min(withoutKeys, other)), entries.get(Math.max(withoutKeys, other)))));
         return Stream.concat(blockPairs.stream(), keylessPairs);
     }
 

--- a/jablib/src/main/java/org/jabref/logic/database/DuplicateCandidateGenerator.java
+++ b/jablib/src/main/java/org/jabref/logic/database/DuplicateCandidateGenerator.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.jabref.model.entry.AuthorList;
 import org.jabref.model.entry.BibEntry;
@@ -17,6 +19,7 @@ import org.jabref.model.entry.field.FieldProperty;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
 
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +31,7 @@ import org.slf4j.LoggerFactory;
 /// (see [doi:10.1126/sciadv.abi8021](https://doi.org/10.1126/sciadv.abi8021)) assigns each entry a set
 /// of redundant blocking keys derived from its identifiers, title, and author/editor names.
 /// Only pairs sharing at least one key become candidates.
+/// See [ADR-0070](https://github.com/JabRef/jabref/blob/main/docs/decisions/0070-use-deterministic-blocking-for-duplicate-candidate-generation.md) for the rationale.
 ///
 /// The keys are chosen to mirror the signals [DuplicateCheck] relies on, so that hardly any pair
 /// that would be classified as a duplicate is skipped:
@@ -41,6 +45,9 @@ import org.slf4j.LoggerFactory;
 ///     (e.g., `InCollection` vs. `InProceedings`) for the same publication.
 ///   - Entries without any key (no identifier, title, author, or editor) are compared with all other
 ///     entries.
+///
+/// [impl->req~logic.duplicates.candidate-blocking~1]
+@NullMarked
 public class DuplicateCandidateGenerator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DuplicateCandidateGenerator.class);
@@ -56,6 +63,11 @@ public class DuplicateCandidateGenerator {
     /// Analogous bound for last names: only pairs with more than 10 persons could evade both keys.
     private static final int NAME_KEY_WORDS = 2;
 
+    /// Marks keys whose equality alone already decides the duplicate question (identifiers, ISBN).
+    /// [DuplicateCheck#isDuplicate] accepts any pair with a matching identifier, so blocks of such
+    /// keys must never be dropped, no matter how large they are.
+    private static final String EXACT_KEY_PREFIX = "id:";
+
     private static final Pattern WHITESPACE = Pattern.compile("\\s+");
     private static final Pattern NOT_LETTER_OR_DIGIT = Pattern.compile("[^\\p{L}\\p{N}]");
 
@@ -68,37 +80,33 @@ public class DuplicateCandidateGenerator {
     }
 
     /// Determines the pairs of entries that need to be checked by [DuplicateCheck#isDuplicate].
+    /// The returned stream is partially lazy, so callers can begin verifying (and cancel) without
+    /// all candidates having been materialized.
     ///
     /// @param entries the entries to search, typically a snapshot of a library
     /// @return all pairs that potentially are duplicates
-    public static List<CandidatePair> getCandidatePairs(List<BibEntry> entries) {
+    public static Stream<CandidatePair> getCandidatePairs(List<BibEntry> entries) {
         return getCandidatePairs(entries, EXHAUSTIVE_SEARCH_LIMIT);
     }
 
     /// Visible for tests to force the blocking stage with small entry lists.
-    static List<CandidatePair> getCandidatePairs(List<BibEntry> entries, int exhaustiveSearchLimit) {
+    static Stream<CandidatePair> getCandidatePairs(List<BibEntry> entries, int exhaustiveSearchLimit) {
         if (entries.size() <= exhaustiveSearchLimit) {
             return getAllPairs(entries);
         }
-        List<CandidatePair> pairs = getBlockedPairs(entries);
-        LOGGER.debug("Blocking reduced {} entries to {} candidate pairs (exhaustive search would check {} pairs)",
-                entries.size(), pairs.size(), ((long) entries.size() * (entries.size() - 1)) / 2);
-        return pairs;
+        return getBlockedPairs(entries);
     }
 
-    private static List<CandidatePair> getAllPairs(List<BibEntry> entries) {
-        List<CandidatePair> result = new ArrayList<>();
-        for (int i = 0; i < (entries.size() - 1); i++) {
-            for (int j = i + 1; j < entries.size(); j++) {
-                result.add(new CandidatePair(entries.get(i), entries.get(j)));
-            }
-        }
-        return result;
+    private static Stream<CandidatePair> getAllPairs(List<BibEntry> entries) {
+        return IntStream.range(0, entries.size() - 1)
+                        .boxed()
+                        .flatMap(first -> IntStream.range(first + 1, entries.size())
+                                                   .mapToObj(second -> new CandidatePair(entries.get(first), entries.get(second))));
     }
 
-    private static List<CandidatePair> getBlockedPairs(List<BibEntry> entries) {
+    private static Stream<CandidatePair> getBlockedPairs(List<BibEntry> entries) {
         Map<String, List<Integer>> blocks = new HashMap<>();
-        List<Integer> entriesWithoutKeys = new ArrayList<>();
+        Set<Integer> entriesWithoutKeys = new HashSet<>();
         for (int i = 0; i < entries.size(); i++) {
             Set<String> keys = getBlockingKeys(entries.get(i));
             if (keys.isEmpty()) {
@@ -110,51 +118,47 @@ public class DuplicateCandidateGenerator {
             }
         }
 
-        // Safeguard against unusually large blocks: a key shared by a large part of the library
+        // Safeguard against unusually large blocks: a fuzzy key shared by a large part of the library
         // (e.g., all titles starting with "The") carries no identifying information, but would emit
         // quadratically many pairs. True duplicates share several aligned words, so the pair still
-        // meets through its other, more discriminative keys.
+        // meets through its other, more discriminative keys. Blocks of exact identifier keys are
+        // never dropped, because a shared identifier alone already makes a pair a duplicate.
         int maximumBlockSize = Math.max(100, entries.size() / 50);
 
-        List<CandidatePair> result = new ArrayList<>();
+        List<CandidatePair> blockPairs = new ArrayList<>();
         Set<Long> seenPairs = new HashSet<>();
         for (Map.Entry<String, List<Integer>> blockEntry : blocks.entrySet()) {
-            // Stop generating candidates when the duplicate search was cancelled
             if (Thread.currentThread().isInterrupted()) {
-                return result;
+                return blockPairs.stream();
             }
             List<Integer> block = blockEntry.getValue();
-            if (block.size() > maximumBlockSize) {
+            if ((block.size() > maximumBlockSize) && !blockEntry.getKey().startsWith(EXACT_KEY_PREFIX)) {
                 LOGGER.debug("Skipping block '{}' with {} entries", blockEntry.getKey(), block.size());
                 continue;
             }
             for (int first = 0; first < (block.size() - 1); first++) {
                 for (int second = first + 1; second < block.size(); second++) {
-                    addPair(result, seenPairs, entries, block.get(first), block.get(second));
+                    int lower = Math.min(block.get(first), block.get(second));
+                    int higher = Math.max(block.get(first), block.get(second));
+                    if (seenPairs.add(((long) lower << 32) | higher)) {
+                        blockPairs.add(new CandidatePair(entries.get(lower), entries.get(higher)));
+                    }
                 }
             }
         }
+        LOGGER.debug("Blocking reduced {} entries to {} block-based candidate pairs plus {} keyless entries compared exhaustively (an exhaustive search would check {} pairs)",
+                entries.size(), blockPairs.size(), entriesWithoutKeys.size(), ((long) entries.size() * (entries.size() - 1)) / 2);
+
         // An entry without any blocking key can still be a duplicate (e.g., two entries only
         // containing the same journal and year), so it is compared with every other entry.
-        for (int withoutKeys : entriesWithoutKeys) {
-            if (Thread.currentThread().isInterrupted()) {
-                return result;
-            }
-            for (int other = 0; other < entries.size(); other++) {
-                if (other != withoutKeys) {
-                    addPair(result, seenPairs, entries, withoutKeys, other);
-                }
-            }
-        }
-        return result;
-    }
-
-    private static void addPair(List<CandidatePair> result, Set<Long> seenPairs, List<BibEntry> entries, int one, int two) {
-        int lower = Math.min(one, two);
-        int higher = Math.max(one, two);
-        if (seenPairs.add(((long) lower << 32) | higher)) {
-            result.add(new CandidatePair(entries.get(lower), entries.get(higher)));
-        }
+        // These pairs are streamed lazily: a keyless entry occurs in no block, so its pairs cannot
+        // collide with the block pairs, and materializing them (worst case quadratic when most
+        // entries are keyless) is not needed for de-duplication.
+        Stream<CandidatePair> keylessPairs = entriesWithoutKeys.stream()
+                .flatMap(withoutKeys -> IntStream.range(0, entries.size())
+                        .filter(other -> (other > withoutKeys) || ((other != withoutKeys) && !entriesWithoutKeys.contains(other)))
+                        .mapToObj(other -> new CandidatePair(entries.get(Math.min(withoutKeys, other)), entries.get(Math.max(withoutKeys, other)))));
+        return Stream.concat(blockPairs.stream(), keylessPairs);
     }
 
     private static Set<String> getBlockingKeys(BibEntry entry) {
@@ -164,14 +168,15 @@ public class DuplicateCandidateGenerator {
                 entry.getField(field).ifPresent(value -> {
                     if (field == StandardField.DOI) {
                         // DOI values may be given as plain DOI, URL, or contain LaTeX escapes - canonicalize them
-                        keys.add("doi:" + DOI.parse(value).map(DOI::asString).orElse(value).toLowerCase(Locale.ROOT));
+                        keys.add(EXACT_KEY_PREFIX + "doi:" + DOI.parse(value).map(DOI::asString).orElse(value).toLowerCase(Locale.ROOT));
                     } else {
-                        keys.add(field.getName() + ":" + value.trim());
+                        keys.add(EXACT_KEY_PREFIX + field.getName() + ":" + value.trim());
                     }
                 });
             }
         }
-        entry.getISBN().ifPresent(isbn -> keys.add("isbn:" + isbn.asString()));
+        // Lower-cased because ISBN equality ignores the case of the ISBN-10 check digit "X"
+        entry.getISBN().ifPresent(isbn -> keys.add(EXACT_KEY_PREFIX + "isbn:" + isbn.asString().toLowerCase(Locale.ROOT)));
         addWordKeys(keys, "title", entry.getFieldLatexFree(StandardField.TITLE), TITLE_KEY_WORDS);
         addNameKeys(keys, "author", entry.getFieldLatexFree(StandardField.AUTHOR));
         addNameKeys(keys, "editor", entry.getFieldLatexFree(StandardField.EDITOR));

--- a/jablib/src/main/java/org/jabref/logic/database/DuplicateCandidateGenerator.java
+++ b/jablib/src/main/java/org/jabref/logic/database/DuplicateCandidateGenerator.java
@@ -1,0 +1,199 @@
+package org.jabref.logic.database;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.jabref.model.entry.AuthorList;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.FieldProperty;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.identifier.DOI;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/// Generates the candidate pairs that are afterwards verified by [DuplicateCheck#isDuplicate].
+///
+/// Small libraries are searched exhaustively, i.e., every pair of entries is a candidate.
+/// For larger libraries, comparing all `n * (n - 1) / 2` pairs is too slow (see
+/// [issue 16579](https://github.com/JabRef/jabref/issues/16579)). There, a blocking stage
+/// (see [doi:10.1126/sciadv.abi8021](https://doi.org/10.1126/sciadv.abi8021)) assigns each entry a set
+/// of redundant blocking keys derived from its identifiers, title, and author/editor names.
+/// Only pairs sharing at least one key become candidates.
+///
+/// The keys are chosen to mirror the signals [DuplicateCheck] relies on, so that hardly any pair
+/// that would be classified as a duplicate is skipped:
+///
+///   - [DuplicateCheck] treats two field values as equal when
+///     [org.jabref.logic.util.strings.StringSimilarity#correlateByWords] exceeds `0.8`. That measure
+///     compares words position by position, so similar titles agree on their leading words unless the
+///     titles are very long. Keying on each of the leading title words (and analogously on the leading
+///     author/editor last names) therefore blocks such pairs together even when single words differ.
+///   - The entry type is never used for blocking, because different sources may use different types
+///     (e.g., `InCollection` vs. `InProceedings`) for the same publication.
+///   - Entries without any key (no identifier, title, author, or editor) are compared with all other
+///     entries.
+public class DuplicateCandidateGenerator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DuplicateCandidateGenerator.class);
+
+    /// Libraries with at most this many entries are searched exhaustively.
+    /// 1000 entries correspond to 499500 pairs, which [DuplicateCheck] handles quickly.
+    private static final int EXHAUSTIVE_SEARCH_LIMIT = 1000;
+
+    /// A title pair with more than 20 words is the only one that could evade all four keys
+    /// while still being considered similar by DuplicateCheck.
+    private static final int TITLE_KEY_WORDS = 4;
+
+    /// Analogous bound for last names: only pairs with more than 10 persons could evade both keys.
+    private static final int NAME_KEY_WORDS = 2;
+
+    private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+    private static final Pattern NOT_LETTER_OR_DIGIT = Pattern.compile("[^\\p{L}\\p{N}]");
+
+    private DuplicateCandidateGenerator() {
+    }
+
+    /// A pair of entries that potentially are duplicates of each other.
+    /// The order of `first` and `second` follows the order of the entries in the searched list.
+    public record CandidatePair(BibEntry first, BibEntry second) {
+    }
+
+    /// Determines the pairs of entries that need to be checked by [DuplicateCheck#isDuplicate].
+    ///
+    /// @param entries the entries to search, typically a snapshot of a library
+    /// @return all pairs that potentially are duplicates
+    public static List<CandidatePair> getCandidatePairs(List<BibEntry> entries) {
+        return getCandidatePairs(entries, EXHAUSTIVE_SEARCH_LIMIT);
+    }
+
+    /// Visible for tests to force the blocking stage with small entry lists.
+    static List<CandidatePair> getCandidatePairs(List<BibEntry> entries, int exhaustiveSearchLimit) {
+        if (entries.size() <= exhaustiveSearchLimit) {
+            return getAllPairs(entries);
+        }
+        List<CandidatePair> pairs = getBlockedPairs(entries);
+        LOGGER.debug("Blocking reduced {} entries to {} candidate pairs (exhaustive search would check {} pairs)",
+                entries.size(), pairs.size(), ((long) entries.size() * (entries.size() - 1)) / 2);
+        return pairs;
+    }
+
+    private static List<CandidatePair> getAllPairs(List<BibEntry> entries) {
+        List<CandidatePair> result = new ArrayList<>();
+        for (int i = 0; i < (entries.size() - 1); i++) {
+            for (int j = i + 1; j < entries.size(); j++) {
+                result.add(new CandidatePair(entries.get(i), entries.get(j)));
+            }
+        }
+        return result;
+    }
+
+    private static List<CandidatePair> getBlockedPairs(List<BibEntry> entries) {
+        Map<String, List<Integer>> blocks = new HashMap<>();
+        List<Integer> entriesWithoutKeys = new ArrayList<>();
+        for (int i = 0; i < entries.size(); i++) {
+            Set<String> keys = getBlockingKeys(entries.get(i));
+            if (keys.isEmpty()) {
+                entriesWithoutKeys.add(i);
+            } else {
+                for (String key : keys) {
+                    blocks.computeIfAbsent(key, unused -> new ArrayList<>()).add(i);
+                }
+            }
+        }
+
+        // Safeguard against unusually large blocks: a key shared by a large part of the library
+        // (e.g., all titles starting with "The") carries no identifying information, but would emit
+        // quadratically many pairs. Entries in such a block still meet through their other keys.
+        int maximumBlockSize = Math.max(200, entries.size() / 10);
+
+        List<CandidatePair> result = new ArrayList<>();
+        Set<Long> seenPairs = new HashSet<>();
+        for (Map.Entry<String, List<Integer>> blockEntry : blocks.entrySet()) {
+            // Stop generating candidates when the duplicate search was cancelled
+            if (Thread.currentThread().isInterrupted()) {
+                return result;
+            }
+            List<Integer> block = blockEntry.getValue();
+            if (block.size() > maximumBlockSize) {
+                LOGGER.debug("Skipping block '{}' with {} entries", blockEntry.getKey(), block.size());
+                continue;
+            }
+            for (int first = 0; first < (block.size() - 1); first++) {
+                for (int second = first + 1; second < block.size(); second++) {
+                    addPair(result, seenPairs, entries, block.get(first), block.get(second));
+                }
+            }
+        }
+        // An entry without any blocking key can still be a duplicate (e.g., two entries only
+        // containing the same journal and year), so it is compared with every other entry.
+        for (int withoutKeys : entriesWithoutKeys) {
+            if (Thread.currentThread().isInterrupted()) {
+                return result;
+            }
+            for (int other = 0; other < entries.size(); other++) {
+                if (other != withoutKeys) {
+                    addPair(result, seenPairs, entries, withoutKeys, other);
+                }
+            }
+        }
+        return result;
+    }
+
+    private static void addPair(List<CandidatePair> result, Set<Long> seenPairs, List<BibEntry> entries, int one, int two) {
+        int lower = Math.min(one, two);
+        int higher = Math.max(one, two);
+        if (seenPairs.add(((long) lower << 32) | higher)) {
+            result.add(new CandidatePair(entries.get(lower), entries.get(higher)));
+        }
+    }
+
+    private static Set<String> getBlockingKeys(BibEntry entry) {
+        Set<String> keys = new HashSet<>();
+        for (Field field : entry.getFields()) {
+            if (field.getProperties().contains(FieldProperty.IDENTIFIER)) {
+                entry.getField(field).ifPresent(value -> {
+                    if (field == StandardField.DOI) {
+                        // DOI values may be given as plain DOI, URL, or contain LaTeX escapes - canonicalize them
+                        keys.add("doi:" + DOI.parse(value).map(DOI::asString).orElse(value).toLowerCase(Locale.ROOT));
+                    } else {
+                        keys.add(field.getName() + ":" + value.trim());
+                    }
+                });
+            }
+        }
+        entry.getISBN().ifPresent(isbn -> keys.add("isbn:" + isbn.asString()));
+        addWordKeys(keys, "title", entry.getFieldLatexFree(StandardField.TITLE), TITLE_KEY_WORDS);
+        addNameKeys(keys, "author", entry.getFieldLatexFree(StandardField.AUTHOR));
+        addNameKeys(keys, "editor", entry.getFieldLatexFree(StandardField.EDITOR));
+        return keys;
+    }
+
+    private static void addNameKeys(Set<String> keys, String keyPrefix, Optional<String> value) {
+        // Same normalization as DuplicateCheck#compareAuthorField, so that the keys align with its word positions
+        addWordKeys(keys, keyPrefix, value.map(names -> AuthorList.fixAuthorLastNameOnlyCommas(names, false).replace(" and ", " ")), NAME_KEY_WORDS);
+    }
+
+    /// Adds one key per leading word of `value`. The word position is part of the key, because
+    /// [org.jabref.logic.util.strings.StringSimilarity#correlateByWords] also compares words position by position.
+    private static void addWordKeys(Set<String> keys, String keyPrefix, Optional<String> value, int wordCount) {
+        if (value.isEmpty()) {
+            return;
+        }
+        String[] words = WHITESPACE.split(value.get().trim());
+        for (int position = 0; (position < wordCount) && (position < words.length); position++) {
+            String normalized = NOT_LETTER_OR_DIGIT.matcher(words[position].toLowerCase(Locale.ROOT)).replaceAll("");
+            if (!normalized.isEmpty()) {
+                keys.add(keyPrefix + position + ":" + normalized);
+            }
+        }
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/database/DuplicateCandidateGenerator.java
+++ b/jablib/src/main/java/org/jabref/logic/database/DuplicateCandidateGenerator.java
@@ -112,8 +112,9 @@ public class DuplicateCandidateGenerator {
 
         // Safeguard against unusually large blocks: a key shared by a large part of the library
         // (e.g., all titles starting with "The") carries no identifying information, but would emit
-        // quadratically many pairs. Entries in such a block still meet through their other keys.
-        int maximumBlockSize = Math.max(200, entries.size() / 10);
+        // quadratically many pairs. True duplicates share several aligned words, so the pair still
+        // meets through its other, more discriminative keys.
+        int maximumBlockSize = Math.max(100, entries.size() / 50);
 
         List<CandidatePair> result = new ArrayList<>();
         Set<Long> seenPairs = new HashSet<>();

--- a/jablib/src/main/java/org/jabref/logic/database/DuplicateCheck.java
+++ b/jablib/src/main/java/org/jabref/logic/database/DuplicateCheck.java
@@ -25,6 +25,7 @@ import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldProperty;
 import org.jabref.model.entry.field.OrFields;
 import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.identifier.DOI;
 import org.jabref.model.entry.identifier.ISBN;
 import org.jabref.model.entry.types.StandardEntryType;
 
@@ -81,7 +82,13 @@ public class DuplicateCheck {
                                         .map(content -> {
                                             String oneValue = one.getField(field).orElseThrow();
                                             if (field == StandardField.DOI) {
-                                                return oneValue.equalsIgnoreCase(content);
+                                                if (oneValue.equalsIgnoreCase(content)) {
+                                                    return true;
+                                                }
+                                                // DOI values may be given as plain DOI, URL, or contain LaTeX escapes
+                                                return DOI.parse(oneValue)
+                                                          .flatMap(first -> DOI.parse(content).map(second -> first.asString().equalsIgnoreCase(second.asString())))
+                                                          .orElse(false);
                                             }
                                             return oneValue.equals(content);
                                         })

--- a/jablib/src/test/java/org/jabref/logic/database/DuplicateCandidateGeneratorTest.java
+++ b/jablib/src/test/java/org/jabref/logic/database/DuplicateCandidateGeneratorTest.java
@@ -1,0 +1,200 @@
+package org.jabref.logic.database;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jabref.logic.database.DuplicateCandidateGenerator.CandidatePair;
+import org.jabref.model.database.BibDatabaseMode;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryTypesManager;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DuplicateCandidateGeneratorTest {
+
+    private static final int FORCE_BLOCKING = 0;
+
+    private static boolean containsPair(List<CandidatePair> pairs, BibEntry one, BibEntry two) {
+        return pairs.stream().anyMatch(pair ->
+                ((pair.first() == one) && (pair.second() == two)) || ((pair.first() == two) && (pair.second() == one)));
+    }
+
+    @Test
+    public void smallLibraryIsSearchedExhaustively() {
+        List<BibEntry> entries = List.of(
+                new BibEntry(StandardEntryType.Article).withField(StandardField.TITLE, "Alpha"),
+                new BibEntry(StandardEntryType.Article).withField(StandardField.TITLE, "Beta"),
+                new BibEntry(StandardEntryType.Article).withField(StandardField.TITLE, "Gamma"),
+                new BibEntry(StandardEntryType.Article));
+
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(entries);
+
+        assertEquals(6, pairs.size());
+    }
+
+    @Test
+    public void sameDoiInDifferentFormsIsBlockedTogether() {
+        BibEntry plainDoi = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.TITLE, "Some title")
+                .withField(StandardField.DOI, "10.1000/182");
+        BibEntry doiAsUrl = new BibEntry(StandardEntryType.Misc)
+                .withField(StandardField.TITLE, "Entirely different words here")
+                .withField(StandardField.DOI, "https://doi.org/10.1000/182");
+
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(plainDoi, doiAsUrl), FORCE_BLOCKING);
+
+        assertTrue(containsPair(pairs, plainDoi, doiAsUrl));
+    }
+
+    @Test
+    public void typoInFirstTitleWordIsBlockedViaLaterWords() {
+        BibEntry correct = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.TITLE, "Innovation and Intellectual Property Rights");
+        BibEntry withTypo = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.TITLE, "Inovation and Intellectual Property Rights");
+
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(correct, withTypo), FORCE_BLOCKING);
+
+        assertTrue(containsPair(pairs, correct, withTypo));
+    }
+
+    @Test
+    public void sameFirstAuthorIsBlockedTogetherDespiteDifferentTitles() {
+        BibEntry one = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Smith, John and Doe, Jane")
+                .withField(StandardField.TITLE, "One title");
+        BibEntry two = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "John Smith")
+                .withField(StandardField.TITLE, "Completely other words");
+
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(one, two), FORCE_BLOCKING);
+
+        assertTrue(containsPair(pairs, one, two));
+    }
+
+    @Test
+    public void unrelatedEntriesAreNotBlockedTogether() {
+        BibEntry one = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Smith, John")
+                .withField(StandardField.TITLE, "Innovation and Intellectual Property Rights")
+                .withField(StandardField.DOI, "10.1000/182");
+        BibEntry two = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Doe, Jane")
+                .withField(StandardField.TITLE, "A serious paper about something")
+                .withField(StandardField.DOI, "10.1000/183");
+
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(one, two), FORCE_BLOCKING);
+
+        assertFalse(containsPair(pairs, one, two));
+    }
+
+    @Test
+    public void entryWithoutAnyKeyIsComparedWithAllOtherEntries() {
+        BibEntry withoutKeys = new BibEntry(StandardEntryType.Misc)
+                .withField(StandardField.JOURNAL, "International Journal of Something")
+                .withField(StandardField.YEAR, "2017");
+        BibEntry regular = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Smith, John")
+                .withField(StandardField.TITLE, "Innovation and Intellectual Property Rights");
+
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(withoutKeys, regular), FORCE_BLOCKING);
+
+        assertTrue(containsPair(pairs, withoutKeys, regular));
+    }
+
+    @Test
+    public void pairsAreNotReportedTwiceWhenSharingSeveralKeys() {
+        BibEntry one = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Smith, John")
+                .withField(StandardField.TITLE, "Innovation and Intellectual Property Rights");
+        BibEntry two = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Smith, J.")
+                .withField(StandardField.TITLE, "Innovation and Intellectual Property Rights");
+
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(one, two), FORCE_BLOCKING);
+
+        assertEquals(1, pairs.size());
+    }
+
+    /// Reports the candidate reduction for typical metadata shapes (guardrail from
+    /// [issue 16579](https://github.com/JabRef/jabref/issues/16579)): the number of candidate pairs
+    /// must stay far below the exhaustive `n * (n - 1) / 2`, including a common-field worst case
+    /// where all entries share the same journal and year.
+    @Test
+    public void blockingStaysFarBelowExhaustivePairCount() {
+        int entryCount = 2000;
+        long exhaustivePairs = ((long) entryCount * (entryCount - 1)) / 2;
+        List<BibEntry> complete = new ArrayList<>();
+        List<BibEntry> sparse = new ArrayList<>();
+        List<BibEntry> commonFields = new ArrayList<>();
+        for (int i = 0; i < entryCount; i++) {
+            complete.add(new BibEntry(StandardEntryType.Article)
+                    .withField(StandardField.AUTHOR, "Author" + i + ", First")
+                    .withField(StandardField.TITLE, "Distinct" + i + " title" + i + " about" + i + " topic" + i)
+                    .withField(StandardField.DOI, "10.1000/" + i)
+                    .withField(StandardField.YEAR, "2020"));
+            sparse.add(new BibEntry(StandardEntryType.Misc)
+                    .withField(StandardField.TITLE, "Sparse" + i));
+            // Worst case: all entries share the journal, the year, and the leading title word
+            commonFields.add(new BibEntry(StandardEntryType.Article)
+                    .withField(StandardField.AUTHOR, "Writer" + i + ", W.")
+                    .withField(StandardField.TITLE, "The unique" + i + " observations" + i)
+                    .withField(StandardField.JOURNAL, "Journal of Common Fields")
+                    .withField(StandardField.YEAR, "1999"));
+        }
+
+        assertTrue(DuplicateCandidateGenerator.getCandidatePairs(complete, FORCE_BLOCKING).size() < (exhaustivePairs / 100));
+        assertTrue(DuplicateCandidateGenerator.getCandidatePairs(sparse, FORCE_BLOCKING).size() < (exhaustivePairs / 100));
+        assertTrue(DuplicateCandidateGenerator.getCandidatePairs(commonFields, FORCE_BLOCKING).size() < (exhaustivePairs / 100));
+    }
+
+    /// Blocking must not lose pairs that [DuplicateCheck] classifies as duplicates:
+    /// every duplicate pair found by the exhaustive search must also be a blocking candidate.
+    @Test
+    public void blockingRetainsAllDuplicatePairsFoundExhaustively() {
+        List<BibEntry> entries = List.of(
+                new BibEntry(StandardEntryType.Article)
+                        .withField(StandardField.AUTHOR, "Single Author")
+                        .withField(StandardField.TITLE, "A serious paper about something")
+                        .withField(StandardField.YEAR, "2017"),
+                new BibEntry(StandardEntryType.Article)
+                        .withField(StandardField.AUTHOR, "Single Author")
+                        .withField(StandardField.TITLE, "A serious paper about something")
+                        .withField(StandardField.YEAR, "2017")
+                        .withField(StandardField.JOURNAL, "Journal of Serious Papers"),
+                new BibEntry(StandardEntryType.InCollection)
+                        .withField(StandardField.TITLE, "Innovation and Intellectual Property Rights")
+                        .withField(StandardField.AUTHOR, "Ove Grandstrand")
+                        .withField(StandardField.YEAR, "2004"),
+                new BibEntry(StandardEntryType.InProceedings)
+                        .withField(StandardField.TITLE, "Innovation and Intellectual Property Rights")
+                        .withField(StandardField.AUTHOR, "Grandstrand, Ove")
+                        .withField(StandardField.DOI, "10.1000/999"),
+                new BibEntry(StandardEntryType.Misc)
+                        .withField(StandardField.DOI, "https://doi.org/10.1000/999"),
+                new BibEntry(StandardEntryType.Article)
+                        .withField(StandardField.AUTHOR, "Completely Different")
+                        .withField(StandardField.TITLE, "Holiday Ideas for the Whole Family")
+                        .withField(StandardField.YEAR, "1992"));
+
+        DuplicateCheck duplicateCheck = new DuplicateCheck(new BibEntryTypesManager());
+        List<CandidatePair> blockedPairs = DuplicateCandidateGenerator.getCandidatePairs(entries, FORCE_BLOCKING);
+
+        for (int i = 0; i < (entries.size() - 1); i++) {
+            for (int j = i + 1; j < entries.size(); j++) {
+                BibEntry first = entries.get(i);
+                BibEntry second = entries.get(j);
+                if (duplicateCheck.isDuplicate(first, second, BibDatabaseMode.BIBTEX)) {
+                    assertTrue(containsPair(blockedPairs, first, second),
+                            "Blocking lost the duplicate pair %d/%d".formatted(i, j));
+                }
+            }
+        }
+    }
+}

--- a/jablib/src/test/java/org/jabref/logic/database/DuplicateCandidateGeneratorTest.java
+++ b/jablib/src/test/java/org/jabref/logic/database/DuplicateCandidateGeneratorTest.java
@@ -33,7 +33,7 @@ public class DuplicateCandidateGeneratorTest {
                 new BibEntry(StandardEntryType.Article).withField(StandardField.TITLE, "Gamma"),
                 new BibEntry(StandardEntryType.Article));
 
-        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(entries);
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(entries).toList();
 
         assertEquals(6, pairs.size());
     }
@@ -47,7 +47,7 @@ public class DuplicateCandidateGeneratorTest {
                 .withField(StandardField.TITLE, "Entirely different words here")
                 .withField(StandardField.DOI, "https://doi.org/10.1000/182");
 
-        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(plainDoi, doiAsUrl), FORCE_BLOCKING);
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(plainDoi, doiAsUrl), FORCE_BLOCKING).toList();
 
         assertTrue(containsPair(pairs, plainDoi, doiAsUrl));
     }
@@ -59,7 +59,7 @@ public class DuplicateCandidateGeneratorTest {
         BibEntry withTypo = new BibEntry(StandardEntryType.Article)
                 .withField(StandardField.TITLE, "Inovation and Intellectual Property Rights");
 
-        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(correct, withTypo), FORCE_BLOCKING);
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(correct, withTypo), FORCE_BLOCKING).toList();
 
         assertTrue(containsPair(pairs, correct, withTypo));
     }
@@ -73,7 +73,7 @@ public class DuplicateCandidateGeneratorTest {
                 .withField(StandardField.AUTHOR, "John Smith")
                 .withField(StandardField.TITLE, "Completely other words");
 
-        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(one, two), FORCE_BLOCKING);
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(one, two), FORCE_BLOCKING).toList();
 
         assertTrue(containsPair(pairs, one, two));
     }
@@ -89,7 +89,7 @@ public class DuplicateCandidateGeneratorTest {
                 .withField(StandardField.TITLE, "A serious paper about something")
                 .withField(StandardField.DOI, "10.1000/183");
 
-        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(one, two), FORCE_BLOCKING);
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(one, two), FORCE_BLOCKING).toList();
 
         assertFalse(containsPair(pairs, one, two));
     }
@@ -103,7 +103,7 @@ public class DuplicateCandidateGeneratorTest {
                 .withField(StandardField.AUTHOR, "Smith, John")
                 .withField(StandardField.TITLE, "Innovation and Intellectual Property Rights");
 
-        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(withoutKeys, regular), FORCE_BLOCKING);
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(withoutKeys, regular), FORCE_BLOCKING).toList();
 
         assertTrue(containsPair(pairs, withoutKeys, regular));
     }
@@ -117,9 +117,36 @@ public class DuplicateCandidateGeneratorTest {
                 .withField(StandardField.AUTHOR, "Smith, J.")
                 .withField(StandardField.TITLE, "Innovation and Intellectual Property Rights");
 
-        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(one, two), FORCE_BLOCKING);
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(one, two), FORCE_BLOCKING).toList();
 
         assertEquals(1, pairs.size());
+    }
+
+    @Test
+    public void sameIsbnWithDifferentCheckDigitCaseIsBlockedTogether() {
+        BibEntry upperCase = new BibEntry(StandardEntryType.Misc)
+                .withField(StandardField.ISBN, "0-8044-2957-X");
+        BibEntry lowerCase = new BibEntry(StandardEntryType.Misc)
+                .withField(StandardField.ISBN, "0-8044-2957-x");
+
+        List<CandidatePair> pairs = DuplicateCandidateGenerator.getCandidatePairs(List.of(upperCase, lowerCase), FORCE_BLOCKING).toList();
+
+        assertTrue(containsPair(pairs, upperCase, lowerCase));
+    }
+
+    /// A shared identifier alone makes a pair a duplicate, so identifier blocks must survive the
+    /// large-block safeguard.
+    @Test
+    public void oversizedIdentifierBlockIsNotDropped() {
+        List<BibEntry> entries = new ArrayList<>();
+        for (int i = 0; i < 150; i++) {
+            entries.add(new BibEntry(StandardEntryType.Misc)
+                    .withField(StandardField.DOI, "10.1000/shared"));
+        }
+
+        long pairCount = DuplicateCandidateGenerator.getCandidatePairs(entries, FORCE_BLOCKING).count();
+
+        assertEquals((150L * 149) / 2, pairCount);
     }
 
     /// Reports the candidate reduction for typical metadata shapes (guardrail from
@@ -128,6 +155,7 @@ public class DuplicateCandidateGeneratorTest {
     /// where all entries share the same journal and year.
     @Test
     public void blockingStaysFarBelowExhaustivePairCount() {
+        // [utest->req~logic.duplicates.candidate-blocking~1]
         int entryCount = 2000;
         long exhaustivePairs = ((long) entryCount * (entryCount - 1)) / 2;
         List<BibEntry> complete = new ArrayList<>();
@@ -149,15 +177,16 @@ public class DuplicateCandidateGeneratorTest {
                     .withField(StandardField.YEAR, "1999"));
         }
 
-        assertTrue(DuplicateCandidateGenerator.getCandidatePairs(complete, FORCE_BLOCKING).size() < (exhaustivePairs / 100));
-        assertTrue(DuplicateCandidateGenerator.getCandidatePairs(sparse, FORCE_BLOCKING).size() < (exhaustivePairs / 100));
-        assertTrue(DuplicateCandidateGenerator.getCandidatePairs(commonFields, FORCE_BLOCKING).size() < (exhaustivePairs / 100));
+        assertTrue(DuplicateCandidateGenerator.getCandidatePairs(complete, FORCE_BLOCKING).count() < (exhaustivePairs / 100));
+        assertTrue(DuplicateCandidateGenerator.getCandidatePairs(sparse, FORCE_BLOCKING).count() < (exhaustivePairs / 100));
+        assertTrue(DuplicateCandidateGenerator.getCandidatePairs(commonFields, FORCE_BLOCKING).count() < (exhaustivePairs / 100));
     }
 
     /// Blocking must not lose pairs that [DuplicateCheck] classifies as duplicates:
     /// every duplicate pair found by the exhaustive search must also be a blocking candidate.
     @Test
     public void blockingRetainsAllDuplicatePairsFoundExhaustively() {
+        // [utest->req~logic.duplicates.candidate-blocking~1]
         List<BibEntry> entries = List.of(
                 new BibEntry(StandardEntryType.Article)
                         .withField(StandardField.AUTHOR, "Single Author")
@@ -184,7 +213,7 @@ public class DuplicateCandidateGeneratorTest {
                         .withField(StandardField.YEAR, "1992"));
 
         DuplicateCheck duplicateCheck = new DuplicateCheck(new BibEntryTypesManager());
-        List<CandidatePair> blockedPairs = DuplicateCandidateGenerator.getCandidatePairs(entries, FORCE_BLOCKING);
+        List<CandidatePair> blockedPairs = DuplicateCandidateGenerator.getCandidatePairs(entries, FORCE_BLOCKING).toList();
 
         for (int i = 0; i < (entries.size() - 1); i++) {
             for (int j = i + 1; j < entries.size(); j++) {

--- a/jablib/src/test/java/org/jabref/logic/database/DuplicateCheckTest.java
+++ b/jablib/src/test/java/org/jabref/logic/database/DuplicateCheckTest.java
@@ -378,6 +378,22 @@ public class DuplicateCheckTest {
     }
 
     @Test
+    void twoUnrelatedEntriesWithSameDoiAsPlainValueAndUrlAreDuplicates() {
+        simpleArticle.setField(StandardField.DOI, "10.1016/j.is.2004.02.002");
+        unrelatedArticle.setField(StandardField.DOI, "https://doi.org/10.1016/j.is.2004.02.002");
+
+        assertTrue(duplicateChecker.isDuplicate(simpleArticle, unrelatedArticle, BibDatabaseMode.BIBTEX));
+    }
+
+    @Test
+    void twoUnrelatedEntriesWithDifferentDoisAsPlainValueAndUrlAreNoDuplicates() {
+        simpleArticle.setField(StandardField.DOI, "10.1016/j.is.2004.02.002");
+        unrelatedArticle.setField(StandardField.DOI, "https://doi.org/10.1016/j.is.2004.02.00X");
+
+        assertFalse(duplicateChecker.isDuplicate(simpleArticle, unrelatedArticle, BibDatabaseMode.BIBTEX));
+    }
+
+    @Test
     void twoUnrelatedEntriesWithEqualPmidAreDuplicates() {
         simpleArticle.setField(StandardField.PMID, "12345678");
         unrelatedArticle.setField(StandardField.PMID, "12345678");


### PR DESCRIPTION
### Summary

`DuplicateSearch` compared every pair of entries — `n(n-1)/2` calls to `DuplicateCheck` — which does not scale to large libraries. This PR introduces a deterministic blocking stage, following the direction recommended in the issue discussion ("deterministic multi-key blocking plus the existing JabRef verifier, with exact identifier indexing as the first tier"):

- **Small libraries (≤ 1000 entries)** are still searched exhaustively, so candidate recall there is unchanged.
- **Larger libraries** go through the new `DuplicateCandidateGenerator` in `jablib`: each entry gets redundant blocking keys, and only pairs sharing at least one key are verified by the existing `DuplicateCheck`.

The keys mirror the signals `DuplicateCheck` itself uses, to keep candidate recall high:

- canonical DOI (parsed via the existing `DOI` class, so plain/URL/LaTeX forms block together), the other `IDENTIFIER` fields (eprint, PMID, MR number), and normalized ISBN (case-insensitive, since the ISBN-10 check digit `X` may be lower-case);
- each of the first 4 title words, namespaced by word position — `StringSimilarity.correlateByWords` compares words position by position with >80 % required matches, so two titles it considers equal can only disagree on all four leading words if they have more than 20 words;
- each of the first 2 author and editor last names (same `AuthorList.fixAuthorLastNameOnlyCommas` normalization as `DuplicateCheck#compareAuthorField`), covering duplicates whose titles are empty;
- the entry type is deliberately **never** used to exclude a pair (`InCollection` vs `InProceedings` may be the same publication);
- entries with no keys at all (no identifier, title, author, editor) are compared against every other entry, streamed lazily so even a mostly-keyless library never materializes quadratically many pairs.

Guardrails from the issue discussion that are implemented:

- candidate generation lives in `jablib`; `DuplicateSearch` remains GUI orchestration; no new dependency, no ported R/Python code;
- keys are computed once per entry; pairs are de-duplicated before reaching the verifier;
- safeguard for unusually large blocks: a *fuzzy* key shared by more than `max(100, n/50)` entries (e.g., all titles starting with "The") is dropped with a debug log — such a key carries no identifying signal, and true duplicates still meet through their other, aligned keys (the cap was tightened after measurements, see below). Blocks of exact identifier keys are never dropped, because a shared identifier alone already decides the duplicate question;
- `n` and the resulting candidate-pair count `P` are logged;
- candidate generation observes thread interruption and returns a partially lazy stream, so verification starts immediately and a cancelled search stops generating candidates;
- the design is recorded as [ADR-0070](https://github.com/cyclomati/jabref/blob/fix-16579-duplicate-blocking/docs/decisions/0070-use-deterministic-blocking-for-duplicate-candidate-generation.md) with an OpenFastTrace requirement (`req~logic.duplicates.candidate-blocking~1` in `docs/requirements/duplicates.md`) traced from implementation and tests.

Also, in a separate commit, `DuplicateCheck#haveSameIdentifier` now canonicalizes DOI values via `DOI.parse` when the raw comparison fails, so `10.x/y` and `https://doi.org/10.x/y` are recognized as the same publication — the gap explicitly noted in the issue discussion ("the current duplicate check compares DOI field text case-insensitively without parsing it"). Without this, blocking correctly pairs such entries but the verifier rejects them.

And it hoists the per-pair `new DuplicateCheck(...)` allocation out of the search loop.

### Measurements (n, P, time)

End-to-end on a generated 3060-entry corpus with 30 planted duplicate pairs (10 same-title/abbreviated-author, 10 DOI plain-vs-URL with different types and titles, 10 with a typo in the first title word), parsed from a real `.bib` through `BibtexParser`:

| corpus | n | P (candidates) | exhaustive pairs | reduction | generation | checking | planted pairs found |
|---|---|---|---|---|---|---|---|
| realistic vocabulary | 3060 | 560 | 4,680,270 | 8357× | 347 ms | 98 ms | 30/30 |
| pathological (20-word title vocabulary) | 3060 | 45,375 | 4,680,270 | 103× | 395 ms | 4.4 s | 30/30 |

The pathological corpus is what motivated tightening the block cap from `max(200, n/10)` (which yielded P ≈ 700,000, only 6×) to `max(100, n/50)`. Exhaustive checking of the same corpus takes ~5 minutes.

**Trade-off:** blocking is not lossless in theory. For >1000-entry libraries, a duplicate pair could be missed only if all four leading title words *and* both leading last names simultaneously differ as non-identical-but-Levenshtein-similar variants, with no shared identifier. The test suite asserts that blocking retains every pair the exhaustive search classifies as duplicate on representative entries.

**Deliberately out of scope** (follow-ups per the issue discussion): the candidate-list/report UI, the "not duplicates" suppression mechanism, the two named search workflows (high-recall review vs. exhaustive), and the search/resolution separation of #15190. This PR keeps the current UI and semantics and only changes how candidate pairs are generated.

### Steps to test

1. Open a library with more than 1000 entries containing known duplicates (also with DOI given once as plain DOI and once as `https://doi.org/...` URL).
2. Run Quality → Find duplicates.
3. Verify the known duplicates are still found, and that the search completes noticeably faster than before on large libraries.
4. Cancel a running search and verify it stops promptly.
5. With ≤ 1000 entries, behavior is identical to before (exhaustive search).

New JUnit tests: `DuplicateCandidateGeneratorTest` (11 tests) covers: the exhaustive path, DOI canonicalization, typo-tolerant title blocking, author blocking, a negative case, keyless entries, pair de-duplication, a recall check (every duplicate pair found exhaustively is retained by blocking), a candidate-count check on 2000-entry corpora (complete metadata, sparse metadata, and a common-field worst case sharing journal, year, and leading title word) asserting `P` stays below 1 % of the exhaustive pair count, ISBN check-digit case insensitivity, and retention of oversized exact-identifier blocks. Two new `DuplicateCheckTest` cases cover DOI plain-vs-URL equality (positive and negative).

Manually tested in running JabRef on macOS with a generated 3060-entry library containing 30 planted duplicate pairs: Quality → Find duplicates completes near-instantly and reports all pairs (screenshot below shows a planted abbreviated-author pair); cancelling works.

![Duplicate resolver showing pair 1 of 40 on the 3060-entry test library](https://raw.githubusercontent.com/cyclomati/jabref/pr-16748-assets/duplicate-dialog-1-40.png)

### Related issues and pull requests

Closes #16579

### AI usage

Claude Code (model claude-fable-5) was used to assist with the design analysis, implementation, and tests. I reviewed the changes, manually tested them in the running app, and take ownership of them.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
