### PR TITLE
Instruct agents to watch and fix CI after opening a PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,6 +487,16 @@ PR body — **must** be built from `.github/PULL_REQUEST_TEMPLATE.md`:
 7. Write the body to a temp file and run `gh pr create --body-file <file>` — never `--body`, which bypasses the template.
 8. Only if the CHANGELOG.md entry used a `TODO` placeholder (meaning no issue has been confidently identified yet — an existing issue link always stays): immediately after the PR is created replace `TODO` with the real PR-number link (`[#NUM](https://github.com/JabRef/jabref/pull/NUM)`), then commit and push that change. If an issue is identified or created later, switch the link to the issue per the precedence rule above.
 
+### After opening or updating a PR
+
+Opening a PR is not the end of the task — green checks are. After `gh pr create` and after every later push:
+
+1. Watch the checks: `gh pr checks <number> --watch` (or poll `gh pr checks <number>`).
+2. For each failing check, read the failure before touching anything: `gh run view <run-id> --log-failed`, or fetch the annotations (`gh api repos/JabRef/jabref/check-runs/<job-id>/annotations`) — they usually name the file and line.
+3. Fix straightforward failures yourself and push the fix. Typical ones: formatting/OpenRewrite diffs, CHANGELOG placement, Markdown/MADR lint (e.g. an ADR number colliding with one that landed on `main` after branching — renumber to the next free ID), a test broken by the PR's own change.
+4. If the failure is unrelated to the PR (infrastructure flake, `main` already red), say so in a PR comment instead of blindly re-pushing; re-run the job if it looks transient.
+5. Repeat until all checks are green or every remaining failure is explained on the PR.
+
 ---
 
 ## Documentation


### PR DESCRIPTION
### Summary

🤖 Agents (and contributors) currently treat `gh pr create` as the end of the task, leaving easily fixable CI failures — formatting diffs, MADR ID collisions with `main`, self-broken tests — sitting on the PR for a human to notice. AGENTS.md now tells them to watch the checks after every push, fix PR-caused failures themselves, and explain unrelated ones.

Analogies: Like honey, a green check run is the sweet result of patient work after the flowers have already been visited. Like chocolate, a PR is only enjoyable once fully finished — half-tempered chocolate and half-passing CI both leave a bad aftertaste. Like the moon, CI results only appear after the push has set; you have to look up afterwards to see them.

`jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

1. Read the new "After opening or updating a PR" section in `AGENTS.md`.
2. Verify the `gh` commands work, e.g. `gh pr checks 16124` and `gh api repos/JabRef/jabref/check-runs/99379201149/annotations` (shows the MADR 0070 duplicate-ID failure this section would have caught).

### Related issues and pull requests

Documentation-only change; no issue. Motivated by PR #16124's MADR job failing on a `0070` ADR ID collision and staying red.

### AI usage

Claude Code (model claude-fable-5), AIL4 — section drafted by AI from a maintainer instruction, reviewed by the maintainer.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

#### 1. Code self-review

Nullability and control flow

- [/] No `== null` / `!= null` checks — JSpecify annotations used instead.
- [/] No `Objects.requireNonNull(...)`.
- [/] New classes annotated with `@NullMarked`.
- [/] `Optional` consumed with `ifPresent` / `map` / `orElseThrow`.
- [/] `StringUtil.isBlank(...)` used.

(not applicable — Markdown-only change, no Java code)

Exceptions

- [/] No `catch (Exception e)`.
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)`.
- [/] Logged exceptions passed as last logger argument.

(not applicable — no Java code)

Style and idioms

- [/] New `BibEntry` objects built with withers.
- [/] Modern Java used.
- [/] Regexes precompiled.
- [/] Background work uses `BackgroundTask`.
- [x] No commented-out code, no trivial comments, no AI-disclosure comments.
- [/] Markdown Javadoc uses Markdown syntax.

(one "not applicable" note: Java-idiom items don't apply to a Markdown change)

User-facing text

- [/] All user-facing text localized.
- [/] Sentence case; no trailing `!`; labels without `:`.
- [/] Variance via placeholders.

(not applicable — developer documentation)

Security

- [/] User-controlled data HTML-escaped.

(not applicable)

Tests

- [/] Behavior changes have tests.
- [/] Tests assert contents, plain JUnit.
- [/] Fetcher tests hit live endpoints.

(not applicable — no code)

#### 2. Verification commands

- [/] `./gradlew :jablib:check`
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`
- [/] `./gradlew modernizer`
- [/] `./gradlew --no-configuration-cache :rewriteDryRun`
- [/] `./gradlew javadoc`
- [x] `npx markdownlint-cli2` on the changed file — 0 issues
- [/] IntelliJ format container

(Gradle checks not applicable — no Java changed)

#### 3. Documentation

- [/] `CHANGELOG.md` entry — not user-visible.
- [x] Searched issues — no related issue found.
- [/] Requirement in `docs/requirements/` — process doc, not a feature.
- [x] Developer documentation updated (this change *is* the doc update).

#### 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked.
- [x] All HTML comments removed.
- [x] Created with `gh pr create --body-file`.
- [/] CHANGELOG `TODO` replacement — no CHANGELOG entry.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrNgGXXBfAiJmx9GuMpqVd
