### PR TITLE
Send accented search terms to arXiv unchanged

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -64,7 +64,6 @@ import org.xml.sax.SAXException;
 ///
 /// These are the post-processing steps applied to the original fetch from ArXiv's API:
 /// <ol>
-///
 /// - Use ArXiv-issued DOI to get more merge more data with original entry, overwriting some of those fields;
 /// - Use user-issued DOI (if it was provided) to merge even more data with the result of the previous step, overwriting some of those fields;
 /// - Modify keywords: remove repetitions and adapt some edge cases (commas in keyword transformed into forward slashes).
@@ -173,7 +172,7 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
     /// Get ArXiv-issued DOI from the entry's arXiv ID
     /// <br/><br/>
     /// ArXiv-issued DOIs are identifiers associated with every ArXiv entry. They are composed of a fixed
-    /// [#DOI_PREFIX] + the entry's ArXiv ID
+    /// {@link #DOI_PREFIX} + the entry's ArXiv ID
     ///
     /// @param arXivId An ArXiv ID
     /// @return ArXiv-issued DOI
@@ -183,7 +182,7 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
 
     /// Get ArXiv-issued DOI from the arXiv entry itself.
     /// <br/><br/>
-    /// ArXiv-issued DOIs are identifiers associated with every ArXiv entry. They are composed of a fixed [#DOI_PREFIX] + the entry's ArXiv ID
+    /// ArXiv-issued DOIs are identifiers associated with every ArXiv entry. They are composed of a fixed {@link #DOI_PREFIX} + the entry's ArXiv ID
     ///
     /// @param arXivBibEntry A Bibtex Entry, formatted as a ArXiv entry. Must contain an EPRINT field
     /// @return ArXiv-issued DOI, or Empty, if method could not retrieve it
@@ -201,7 +200,7 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
 
     /// Get ArXiv-issued DOI from ArXiv Identifier object
     /// <br/><br/>
-    /// ArXiv-issued DOIs are identifiers associated with every ArXiv entry. They are composed of a fixed [#DOI_PREFIX] + the entry's ArXiv ID
+    /// ArXiv-issued DOIs are identifiers associated with every ArXiv entry. They are composed of a fixed {@link #DOI_PREFIX} + the entry's ArXiv ID
     ///
     /// @param arXivId An ArXiv ID as internal object
     /// @return ArXiv-issued DOI
@@ -220,7 +219,7 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
     /// <a href="https://link.springer.com/">Springer Link</a>.
     ///
     /// @param arXivBibEntry An ArXiv Bibtex entry from where the DOI is extracted
-    /// @return User-issued DOI, if any field exists and if it's not an automatic one (see [#getAutomaticDoi(ArXivIdentifier)])
+    /// @return User-issued DOI, if any field exists and if it's not an automatic one (see {@link #getAutomaticDoi(ArXivIdentifier)})
     private static Optional<String> getManualDoi(BibEntry arXivBibEntry) {
         return arXivBibEntry.getField(StandardField.DOI).filter(ArXivFetcher::isManualDoi);
     }
@@ -599,9 +598,8 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
             } catch (URISyntaxException e) {
                 throw new FetcherException("Invalid URL", e);
             }
-            // The arXiv API has problems with accents, so we remove them (i.e. Fréchet -> Frechet)
             if (StringUtil.isNotBlank(searchQuery)) {
-                uriBuilder.addParameter("search_query", StringUtil.stripAccents(searchQuery));
+                uriBuilder.addParameter("search_query", searchQuery);
             }
             if (!ids.isEmpty()) {
                 uriBuilder.addParameter("id_list",


### PR DESCRIPTION
### Summary

`ArXivFetcher.callApi` stripped accents from the search query, with the comment *"The arXiv API has problems with accents, so we remove them (i.e. Fréchet -> Frechet)"*. That is no longer true, and the workaround now guarantees **zero** results for any accented search — arXiv matches only the accented form:

| what is sent | results from `export.arxiv.org` |
|---|---|
| `ti:"slice theorem for Fr%C3%A9chet"` (UTF-8) | **1** |
| `ti:"slice theorem for Frechet"` (what JabRef sent) | **0** |
| `Fr%E9chet` (Latin-1) | 0 |

`URIBuilder` already percent-encodes the parameter as UTF-8, so passing the query through unchanged is enough.

The other two `stripAccents` calls in this file are deliberately untouched: `buildBroadTitleQuery` skips accented terms when assembling the broad fallback query, and `normalizeForTitleMatching` normalises for comparison rather than for the request.

### Steps to test

`./gradlew :jablib:fetcherTest --tests "*ArXivFetcherTest*"`

`searchEntryByPartOfTitleWithAcuteAccent` currently fails on `main` with `expected: <[...]> but was: <[]>` — the search returns nothing at all. With this change it returns the correct paper.

**It does not yet make that test green, and I would rather say so than hide it.** After this fix the assertion fails on one remaining field, the citation key:

- expected `@article{Diez:2013fdp,`
- actual `@article{https://doi.org/10.48550/arxiv.1405.2249,`

That is a second, independent problem in `infuseWithInspireCitationKeyIfMissing`, not something this change introduces — before it, the search returned an empty list, so the key path was never exercised. INSPIRE still serves the expected key (`GET /api/arxiv/1405.2249?fields=texkeys` → `["Diez:2013fdp", "Diez:2014ppa"]`), and `INSPIREFetcherTest` passes 3/3, so the fetcher itself is healthy — the lookup from `ArXivFetcher` is what comes back empty, and its `FetcherClientException` branch logs at TRACE, so it fails silently.

Happy to chase that in this PR or a separate one, whichever you prefer. I did not want to bundle a guess at it with a fix I can actually demonstrate.

### Related issues and pull requests

Closes #16772

### AI usage

Claude Code (model `claude-opus-5`), used to run the fetcher test task, read the failure report, and check the arXiv and INSPIRE APIs directly. AIL3 — AI-assisted, human-directed and human-owned.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
