### PR TITLE
Open online file links via URL-aware browser call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where opening an online link (e.g. from the "file" field or a DOI) could open a truncated URL in the browser when the link contained a query string. [#16769](https://github.com/JabRef/jabref/pull/16769)
 - We fixed an issue where a full-text PDF link found by DOI lookup was attached in lowercase and failed. [#16762](https://github.com/JabRef/jabref/pull/16762)
 - "Git commit" now saves a modified library first (if autosave is enabled) or asks to save it, so unsaved changes are no longer silently left out of the commit. [#16718](https://github.com/JabRef/jabref/pull/16718)
 - We fixed an issue where a library could be closed without asking to save changes made after an undo. [#16680](https://github.com/JabRef/jabref/pull/16680)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where opening an online link (e.g. from the "file" field or a DOI) could open a truncated URL in the browser when the link contained a query string. [#16769](https://github.com/JabRef/jabref/pull/16769)
+- We fixed an issue where opening an online link (e.g. from the "file" field or a DOI) could open a truncated URL in the browser when the link contained a query string. [#16774](https://github.com/JabRef/jabref/pull/16774)
 - We fixed an issue where a full-text PDF link found by DOI lookup was attached in lowercase and failed. [#16762](https://github.com/JabRef/jabref/pull/16762)
 - "Git commit" now saves a modified library first (if autosave is enabled) or asks to save it, so unsaved changes are no longer silently left out of the commit. [#16718](https://github.com/JabRef/jabref/pull/16718)
 - We fixed an issue where a library could be closed without asking to save changes made after an undo. [#16680](https://github.com/JabRef/jabref/pull/16680)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where opening an online link (e.g. from the "file" field or a DOI) could open a truncated URL in the browser when the link contained a query string. [#16774](https://github.com/JabRef/jabref/pull/16774)
+- We fixed an issue where opening an online link with a query string could open a truncated URL. [#16774](https://github.com/JabRef/jabref/pull/16774)
 - We fixed an issue where a full-text PDF link found by DOI lookup was attached in lowercase and failed. [#16762](https://github.com/JabRef/jabref/pull/16762)
 - "Git commit" now saves a modified library first (if autosave is enabled) or asks to save it, so unsaved changes are no longer silently left out of the commit. [#16718](https://github.com/JabRef/jabref/pull/16718)
 - We fixed an issue where a library could be closed without asking to save changes made after an undo. [#16680](https://github.com/JabRef/jabref/pull/16680)

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/DefaultDesktop.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/DefaultDesktop.java
@@ -26,6 +26,11 @@ public class DefaultDesktop extends NativeDesktop {
     }
 
     @Override
+    public void openUrlWithSystemHandler(String url) throws IOException {
+        throw new IOException("No URL handler known for this platform, cannot open " + url);
+    }
+
+    @Override
     public void openFileWithApplication(String filePath, String application) throws IOException {
         Desktop.getDesktop().open(Path.of(filePath).toFile());
     }

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/Linux.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/Linux.java
@@ -73,6 +73,11 @@ public class Linux extends NativeDesktop {
     }
 
     @Override
+    public void openUrlWithSystemHandler(String url) throws IOException {
+        new ProcessBuilder("xdg-open", url).start();
+    }
+
+    @Override
     public void openFileWithApplication(String filePath, String application) throws IOException {
         // Use the given app if specified, and the universal "xdg-open" otherwise:
         String[] openWith;

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -285,14 +285,16 @@ public abstract class NativeDesktop {
     ///
     /// @param url the URL to open
     public static void openBrowser(String url, ExternalApplicationsPreferences externalApplicationsPreferences) throws IOException {
-        openBrowser(url, externalApplicationsPreferences, e -> LoggerFactory.getLogger(NativeDesktop.class).error("Could not open browser for {}", url, e));
+        openBrowser(url, externalApplicationsPreferences, e -> {
+            // Terminal failure is already logged where it is caught
+        });
     }
 
     /// Opens the given URL using the system browser
     ///
     /// @param url            the URL to open
     /// @param onAsyncFailure invoked (from a background thread) when opening fails after this
-    ///                                                                   method has already returned; synchronous failures throw instead
+    ///                                                                                         method has already returned; synchronous failures throw instead
     public static void openBrowser(String url, ExternalApplicationsPreferences externalApplicationsPreferences, Consumer<IOException> onAsyncFailure) throws IOException {
         openBrowser(url, externalApplicationsPreferences, onAsyncFailure, get());
     }
@@ -327,6 +329,7 @@ public abstract class NativeDesktop {
                     try {
                         desktop.openUrlWithSystemHandler(url);
                     } catch (IOException e2) {
+                        LoggerFactory.getLogger(NativeDesktop.class).error("Could not open browser for {}", url, e2);
                         onAsyncFailure.accept(e2);
                     }
                 }

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -23,6 +23,8 @@ import org.jabref.logic.importer.util.IdentifierParser;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.os.OS;
 import org.jabref.logic.util.Directories;
+import org.jabref.logic.util.HeadlessExecutorService;
+import org.jabref.logic.util.URLUtil;
 import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -281,7 +283,28 @@ public abstract class NativeDesktop {
     /// @param url the URL to open
     public static void openBrowser(String url, ExternalApplicationsPreferences externalApplicationsPreferences) throws IOException {
         Optional<ExternalFileType> fileType = ExternalFileTypes.getExternalFileTypeByExt("html", externalApplicationsPreferences);
-        openExternalFilePlatformIndependent(fileType, url, externalApplicationsPreferences);
+        if (fileType.isPresent() && !fileType.get().getOpenWithApplication().isEmpty()) {
+            // The user configured a custom browser; hand it the URL string unmodified
+            get().openFileWithApplication(url, fileType.get().getOpenWithApplication());
+            return;
+        }
+        // A URL must be opened via a URL-aware API: the file-open path runs it through
+        // Path.of(...), which collapses "https://" to "https:/" and yields a bogus filesystem path
+        URI uri = URLUtil.createUri(url);
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+            // Desktop.browse may block on some Linux desktops, so keep it off the JavaFX thread
+            HeadlessExecutorService.INSTANCE.execute(() -> {
+                try {
+                    Desktop.getDesktop().browse(uri);
+                } catch (IOException e) {
+                    LoggerFactory.getLogger(NativeDesktop.class).error("Could not open browser for {}", url, e);
+                }
+            });
+        } else {
+            // Headless or BROWSE unsupported: the platform openers pass the string through to
+            // xdg-open/open/explorer, which are URL-aware
+            get().openFile(url, "html", externalApplicationsPreferences);
+        }
     }
 
     public static void openBrowser(URI url, ExternalApplicationsPreferences externalApplicationsPreferences) throws IOException {

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -294,9 +294,9 @@ public abstract class NativeDesktop {
         try {
             uri = URLUtil.createUri(url);
         } catch (IllegalArgumentException e) {
-            // Not URI-parseable (e.g. unencoded spaces); the platform openers accept the raw string
-            LoggerFactory.getLogger(NativeDesktop.class).debug("Could not parse {} as URI, falling back to platform opener", url, e);
-            get().openFile(url, "html", externalApplicationsPreferences);
+            // Not URI-parseable (e.g. unencoded spaces); the OS URL handlers accept the raw string
+            LoggerFactory.getLogger(NativeDesktop.class).debug("Could not parse {} as URI, falling back to the OS URL handler", url, e);
+            get().openUrlWithSystemHandler(url);
             return;
         }
         // Desktop.browse rejects relative URIs, which createUri also produces; those go to the platform opener
@@ -306,18 +306,16 @@ public abstract class NativeDesktop {
                 try {
                     Desktop.getDesktop().browse(uri);
                 } catch (IOException e) {
-                    LoggerFactory.getLogger(NativeDesktop.class).warn("Desktop.browse failed for {}, falling back to platform opener", url, e);
+                    LoggerFactory.getLogger(NativeDesktop.class).warn("Desktop.browse failed for {}, falling back to the OS URL handler", url, e);
                     try {
-                        get().openFile(url, "html", externalApplicationsPreferences);
+                        get().openUrlWithSystemHandler(url);
                     } catch (IOException e2) {
                         LoggerFactory.getLogger(NativeDesktop.class).error("Could not open browser for {}", url, e2);
                     }
                 }
             });
         } else {
-            // Headless or BROWSE unsupported: the platform openers pass the string through to
-            // xdg-open/open/explorer, which are URL-aware
-            get().openFile(url, "html", externalApplicationsPreferences);
+            get().openUrlWithSystemHandler(url);
         }
     }
 
@@ -355,6 +353,11 @@ public abstract class NativeDesktop {
     }
 
     public abstract void openFile(String filePath, String fileType, ExternalApplicationsPreferences externalApplicationsPreferences) throws IOException;
+
+    /// Hands the URL string, unmodified, to the OS's URL-aware handler.
+    /// Used when `Desktop.browse` is unsupported, not applicable, or failed;
+    /// the URL must never be run through `Path.of`, which mangles it.
+    public abstract void openUrlWithSystemHandler(String url) throws IOException;
 
     /// Opens a file on an Operating System, using the given application.
     ///

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -304,7 +304,12 @@ public abstract class NativeDesktop {
                 try {
                     Desktop.getDesktop().browse(uri);
                 } catch (IOException e) {
-                    LoggerFactory.getLogger(NativeDesktop.class).error("Could not open browser for {}", url, e);
+                    LoggerFactory.getLogger(NativeDesktop.class).warn("Desktop.browse failed for {}, falling back to platform opener", url, e);
+                    try {
+                        get().openFile(url, "html", externalApplicationsPreferences);
+                    } catch (IOException e2) {
+                        LoggerFactory.getLogger(NativeDesktop.class).error("Could not open browser for {}", url, e2);
+                    }
                 }
             });
         } else {

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -299,7 +299,8 @@ public abstract class NativeDesktop {
             get().openFile(url, "html", externalApplicationsPreferences);
             return;
         }
-        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+        // Desktop.browse rejects relative URIs, which createUri also produces; those go to the platform opener
+        if (uri.isAbsolute() && Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
             // Desktop.browse may block on some Linux desktops, so keep it off the JavaFX thread
             HeadlessExecutorService.INSTANCE.execute(() -> {
                 try {

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -36,6 +36,7 @@ import org.jabref.model.entry.identifier.DOI;
 import org.jabref.model.entry.identifier.Identifier;
 
 import com.airhacks.afterburner.injection.Injector;
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.LoggerFactory;
 
 import static org.jabref.model.entry.field.StandardField.PDF;
@@ -291,12 +292,17 @@ public abstract class NativeDesktop {
     ///
     /// @param url            the URL to open
     /// @param onAsyncFailure invoked (from a background thread) when opening fails after this
-    ///                                             method has already returned; synchronous failures throw instead
+    ///                                                                   method has already returned; synchronous failures throw instead
     public static void openBrowser(String url, ExternalApplicationsPreferences externalApplicationsPreferences, Consumer<IOException> onAsyncFailure) throws IOException {
+        openBrowser(url, externalApplicationsPreferences, onAsyncFailure, get());
+    }
+
+    @VisibleForTesting
+    static void openBrowser(String url, ExternalApplicationsPreferences externalApplicationsPreferences, Consumer<IOException> onAsyncFailure, NativeDesktop desktop) throws IOException {
         Optional<ExternalFileType> fileType = ExternalFileTypes.getExternalFileTypeByExt("html", externalApplicationsPreferences);
         if (fileType.isPresent() && !fileType.get().getOpenWithApplication().isEmpty()) {
             // The user configured a custom browser; hand it the URL string unmodified
-            get().openFileWithApplication(url, fileType.get().getOpenWithApplication());
+            desktop.openFileWithApplication(url, fileType.get().getOpenWithApplication());
             return;
         }
         // A URL must be opened via a URL-aware API: the file-open path runs it through
@@ -307,27 +313,37 @@ public abstract class NativeDesktop {
         } catch (IllegalArgumentException e) {
             // Not URI-parseable (e.g. unencoded spaces); the OS URL handlers accept the raw string
             LoggerFactory.getLogger(NativeDesktop.class).debug("Could not parse {} as URI, falling back to the OS URL handler", url, e);
-            get().openUrlWithSystemHandler(url);
+            desktop.openUrlWithSystemHandler(url);
             return;
         }
         // Desktop.browse rejects relative URIs, which createUri also produces; those go to the platform opener
-        if (uri.isAbsolute() && Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+        if (uri.isAbsolute() && desktop.supportsDesktopBrowse()) {
             // Desktop.browse may block on some Linux desktops, so keep it off the JavaFX thread
             HeadlessExecutorService.INSTANCE.execute(() -> {
                 try {
-                    Desktop.getDesktop().browse(uri);
+                    desktop.desktopBrowse(uri);
                 } catch (IOException e) {
                     LoggerFactory.getLogger(NativeDesktop.class).warn("Desktop.browse failed for {}, falling back to the OS URL handler", url, e);
                     try {
-                        get().openUrlWithSystemHandler(url);
+                        desktop.openUrlWithSystemHandler(url);
                     } catch (IOException e2) {
                         onAsyncFailure.accept(e2);
                     }
                 }
             });
         } else {
-            get().openUrlWithSystemHandler(url);
+            desktop.openUrlWithSystemHandler(url);
         }
+    }
+
+    /// Whether the AWT desktop integration can open URLs. Overridable for tests.
+    boolean supportsDesktopBrowse() {
+        return Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE);
+    }
+
+    /// Opens the URI via the AWT desktop integration. Overridable for tests.
+    void desktopBrowse(URI uri) throws IOException {
+        Desktop.getDesktop().browse(uri);
     }
 
     public static void openBrowser(URI url, ExternalApplicationsPreferences externalApplicationsPreferences) throws IOException {

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -290,7 +290,14 @@ public abstract class NativeDesktop {
         }
         // A URL must be opened via a URL-aware API: the file-open path runs it through
         // Path.of(...), which collapses "https://" to "https:/" and yields a bogus filesystem path
-        URI uri = URLUtil.createUri(url);
+        URI uri;
+        try {
+            uri = URLUtil.createUri(url);
+        } catch (IllegalArgumentException e) {
+            // Not URI-parseable (e.g. unencoded spaces); the platform openers accept the raw string
+            get().openFile(url, "html", externalApplicationsPreferences);
+            return;
+        }
         if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
             // Desktop.browse may block on some Linux desktops, so keep it off the JavaFX thread
             HeadlessExecutorService.INSTANCE.execute(() -> {

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import org.jabref.architecture.AllowedToUseAwt;
@@ -18,6 +19,7 @@ import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.frame.ExternalApplicationsPreferences;
 import org.jabref.gui.preferences.GuiPreferences;
+import org.jabref.gui.util.UiTaskExecutor;
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.importer.util.IdentifierParser;
 import org.jabref.logic.l10n.Localization;
@@ -282,6 +284,15 @@ public abstract class NativeDesktop {
     ///
     /// @param url the URL to open
     public static void openBrowser(String url, ExternalApplicationsPreferences externalApplicationsPreferences) throws IOException {
+        openBrowser(url, externalApplicationsPreferences, e -> LoggerFactory.getLogger(NativeDesktop.class).error("Could not open browser for {}", url, e));
+    }
+
+    /// Opens the given URL using the system browser
+    ///
+    /// @param url            the URL to open
+    /// @param onAsyncFailure invoked (from a background thread) when opening fails after this
+    ///                                             method has already returned; synchronous failures throw instead
+    public static void openBrowser(String url, ExternalApplicationsPreferences externalApplicationsPreferences, Consumer<IOException> onAsyncFailure) throws IOException {
         Optional<ExternalFileType> fileType = ExternalFileTypes.getExternalFileTypeByExt("html", externalApplicationsPreferences);
         if (fileType.isPresent() && !fileType.get().getOpenWithApplication().isEmpty()) {
             // The user configured a custom browser; hand it the URL string unmodified
@@ -310,7 +321,7 @@ public abstract class NativeDesktop {
                     try {
                         get().openUrlWithSystemHandler(url);
                     } catch (IOException e2) {
-                        LoggerFactory.getLogger(NativeDesktop.class).error("Could not open browser for {}", url, e2);
+                        onAsyncFailure.accept(e2);
                     }
                 }
             });
@@ -328,17 +339,22 @@ public abstract class NativeDesktop {
     /// @param url the URL to open
     public static void openBrowserShowPopup(String url, DialogService dialogService, ExternalApplicationsPreferences externalApplicationsPreferences) {
         try {
-            openBrowser(url, externalApplicationsPreferences);
+            openBrowser(url, externalApplicationsPreferences,
+                    exception -> UiTaskExecutor.runInJavaFXThread(() -> showManualOpenPopup(url, dialogService, exception)));
         } catch (IOException exception) {
-            ClipBoardManager clipBoardManager = Injector.instantiateModelOrService(ClipBoardManager.class);
-            clipBoardManager.setContent(url);
-            LoggerFactory.getLogger(NativeDesktop.class).error("Could not open browser", exception);
-            String couldNotOpenBrowser = Localization.lang("Could not open browser.");
-            String openManually = Localization.lang("Please open %0 manually.", url);
-            String copiedToClipboard = Localization.lang("The link has been copied to the clipboard.");
-            dialogService.notify(couldNotOpenBrowser);
-            dialogService.showErrorDialogAndWait(couldNotOpenBrowser, couldNotOpenBrowser + "\n" + openManually + "\n" + copiedToClipboard);
+            showManualOpenPopup(url, dialogService, exception);
         }
+    }
+
+    private static void showManualOpenPopup(String url, DialogService dialogService, IOException exception) {
+        ClipBoardManager clipBoardManager = Injector.instantiateModelOrService(ClipBoardManager.class);
+        clipBoardManager.setContent(url);
+        LoggerFactory.getLogger(NativeDesktop.class).error("Could not open browser", exception);
+        String couldNotOpenBrowser = Localization.lang("Could not open browser.");
+        String openManually = Localization.lang("Please open %0 manually.", url);
+        String copiedToClipboard = Localization.lang("The link has been copied to the clipboard.");
+        dialogService.notify(couldNotOpenBrowser);
+        dialogService.showErrorDialogAndWait(couldNotOpenBrowser, couldNotOpenBrowser + "\n" + openManually + "\n" + copiedToClipboard);
     }
 
     public static NativeDesktop get() {

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -295,6 +295,7 @@ public abstract class NativeDesktop {
             uri = URLUtil.createUri(url);
         } catch (IllegalArgumentException e) {
             // Not URI-parseable (e.g. unencoded spaces); the platform openers accept the raw string
+            LoggerFactory.getLogger(NativeDesktop.class).debug("Could not parse {} as URI, falling back to platform opener", url, e);
             get().openFile(url, "html", externalApplicationsPreferences);
             return;
         }

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/OSX.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/OSX.java
@@ -30,6 +30,11 @@ public class OSX extends NativeDesktop {
     }
 
     @Override
+    public void openUrlWithSystemHandler(String url) throws IOException {
+        new ProcessBuilder("/usr/bin/open", url).start();
+    }
+
+    @Override
     public void openFileWithApplication(String filePath, String application) throws IOException {
         // Use "-a <application>" if the app is specified, and just "open <filename>" otherwise:
         String[] cmd = (application != null) && !application.isEmpty() ? new String[] {"/usr/bin/open", "-a",

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/Windows.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/Windows.java
@@ -37,6 +37,12 @@ public class Windows extends NativeDesktop {
     }
 
     @Override
+    public void openUrlWithSystemHandler(String url) throws IOException {
+        // quote String so explorer handles URL query strings correctly
+        new ProcessBuilder("explorer.exe", "\"" + url + "\"").start();
+    }
+
+    @Override
     public Path getApplicationDirectory() {
         String programDir = System.getenv("ProgramFiles");
 

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/Windows.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/Windows.java
@@ -64,7 +64,8 @@ public class Windows extends NativeDesktop {
 
     @Override
     public void openFileWithApplication(String filePath, String application) throws IOException {
-        new ProcessBuilder(Path.of(application).toString(), Path.of(filePath).toString()).start();
+        // filePath may be a URL; Path.of would throw on query characters and mangle the scheme
+        new ProcessBuilder(Path.of(application).toString(), filePath).start();
     }
 
     @Override

--- a/jabgui/src/test/java/org/jabref/gui/desktop/os/NativeDesktopTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/desktop/os/NativeDesktopTest.java
@@ -1,13 +1,20 @@
 package org.jabref.gui.desktop.os;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 
 import javafx.collections.FXCollections;
 
+import org.jabref.gui.DialogService;
 import org.jabref.gui.externalfiletype.CustomExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.frame.ExternalApplicationsPreferences;
@@ -74,5 +81,123 @@ class NativeDesktopTest {
         new Windows().openFileWithApplication(URL_WITH_QUERY, recorder.toString());
 
         assertEquals(URL_WITH_QUERY, recordedArgument());
+    }
+
+    @Test
+    void openBrowserPassesFullUrlToDesktopBrowse() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+        FakeDesktop desktop = new FakeDesktop(true, false, false);
+
+        NativeDesktop.openBrowser(URL_WITH_QUERY, noCustomBrowser(), FakeDesktop.NO_FAILURE_EXPECTED, desktop);
+
+        assertEquals(URL_WITH_QUERY, desktop.browsed.get(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void openBrowserFallsBackToSystemHandlerWhenBrowseFails() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+        FakeDesktop desktop = new FakeDesktop(true, true, false);
+
+        NativeDesktop.openBrowser(URL_WITH_QUERY, noCustomBrowser(), FakeDesktop.NO_FAILURE_EXPECTED, desktop);
+
+        assertEquals(URL_WITH_QUERY, desktop.systemHandled.get(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void openBrowserReportsAsyncFailureWhenAllMechanismsFail() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+        FakeDesktop desktop = new FakeDesktop(true, true, true);
+        CompletableFuture<IOException> failure = new CompletableFuture<>();
+
+        NativeDesktop.openBrowser(URL_WITH_QUERY, noCustomBrowser(), failure::complete, desktop);
+
+        assertEquals("system handler failed", failure.get(5, TimeUnit.SECONDS).getMessage());
+    }
+
+    @Test
+    void openBrowserUsesSystemHandlerWhenBrowseUnsupported() throws IOException {
+        FakeDesktop desktop = new FakeDesktop(false, false, false);
+
+        NativeDesktop.openBrowser(URL_WITH_QUERY, noCustomBrowser(), FakeDesktop.NO_FAILURE_EXPECTED, desktop);
+
+        assertEquals(URL_WITH_QUERY, desktop.systemHandled.getNow(""));
+    }
+
+    @Test
+    void openBrowserUsesSystemHandlerForUnparseableUrl() throws IOException {
+        FakeDesktop desktop = new FakeDesktop(true, false, false);
+        String urlWithSpace = "https://example.org/some path?x=1&y=2";
+
+        NativeDesktop.openBrowser(urlWithSpace, noCustomBrowser(), FakeDesktop.NO_FAILURE_EXPECTED, desktop);
+
+        assertEquals(urlWithSpace, desktop.systemHandled.getNow(""));
+    }
+
+    private static ExternalApplicationsPreferences noCustomBrowser() {
+        ExternalApplicationsPreferences preferences = mock(ExternalApplicationsPreferences.class);
+        when(preferences.getExternalFileTypes()).thenReturn(FXCollections.observableSet());
+        return preferences;
+    }
+
+    private static final class FakeDesktop extends NativeDesktop {
+        static final Consumer<IOException> NO_FAILURE_EXPECTED = e -> {
+            throw new AssertionError("Unexpected async failure", e);
+        };
+
+        final CompletableFuture<String> browsed = new CompletableFuture<>();
+        final CompletableFuture<String> systemHandled = new CompletableFuture<>();
+
+        private final boolean browseSupported;
+        private final boolean browseFails;
+        private final boolean systemHandlerFails;
+
+        private FakeDesktop(boolean browseSupported, boolean browseFails, boolean systemHandlerFails) {
+            this.browseSupported = browseSupported;
+            this.browseFails = browseFails;
+            this.systemHandlerFails = systemHandlerFails;
+        }
+
+        @Override
+        boolean supportsDesktopBrowse() {
+            return browseSupported;
+        }
+
+        @Override
+        void desktopBrowse(URI uri) throws IOException {
+            if (browseFails) {
+                throw new IOException("browse failed");
+            }
+            browsed.complete(uri.toASCIIString());
+        }
+
+        @Override
+        public void openUrlWithSystemHandler(String url) throws IOException {
+            if (systemHandlerFails) {
+                throw new IOException("system handler failed");
+            }
+            systemHandled.complete(url);
+        }
+
+        @Override
+        public void openFile(String filePath, String fileType, ExternalApplicationsPreferences externalApplicationsPreferences) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void openFileWithApplication(String filePath, String application) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void openFolderAndSelectFile(Path file) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void openConsole(String absolutePath, DialogService dialogService) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Path getApplicationDirectory() {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/jabgui/src/test/java/org/jabref/gui/desktop/os/NativeDesktopTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/desktop/os/NativeDesktopTest.java
@@ -13,6 +13,7 @@ import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.frame.ExternalApplicationsPreferences;
 import org.jabref.gui.icon.IconTheme;
 
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -26,6 +27,7 @@ import static org.mockito.Mockito.when;
 /// The "browser" in these tests is a shell script recording its argument, so the assertions catch
 /// any URL mangling on the way to the external application (the regression fixed here: routing
 /// online links through `Path.of`, which collapses `https://` and truncates query strings).
+@NullMarked
 @DisabledOnOs(OS.WINDOWS)
 class NativeDesktopTest {
 

--- a/jabgui/src/test/java/org/jabref/gui/desktop/os/NativeDesktopTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/desktop/os/NativeDesktopTest.java
@@ -1,0 +1,76 @@
+package org.jabref.gui.desktop.os;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+
+import javafx.collections.FXCollections;
+
+import org.jabref.gui.externalfiletype.CustomExternalFileType;
+import org.jabref.gui.externalfiletype.ExternalFileType;
+import org.jabref.gui.frame.ExternalApplicationsPreferences;
+import org.jabref.gui.icon.IconTheme;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/// The "browser" in these tests is a shell script recording its argument, so the assertions catch
+/// any URL mangling on the way to the external application (the regression fixed here: routing
+/// online links through `Path.of`, which collapses `https://` and truncates query strings).
+@DisabledOnOs(OS.WINDOWS)
+class NativeDesktopTest {
+
+    private static final String URL_WITH_QUERY = "https://journals.plos.org/plosmedicine/article/file?id=10.1371/journal.pmed.1004085&type=printable";
+
+    @TempDir Path tempDir;
+
+    private Path recorder;
+    private Path recorded;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        recorded = tempDir.resolve("recorded.txt");
+        recorder = tempDir.resolve("recorder.sh");
+        Files.writeString(recorder, "#!/bin/sh\nprintf '%s' \"$1\" > " + recorded + "\n");
+        Files.setPosixFilePermissions(recorder, EnumSet.allOf(PosixFilePermission.class));
+    }
+
+    private String recordedArgument() throws IOException, InterruptedException {
+        for (int i = 0; i < 100; i++) {
+            if (Files.exists(recorded) && !Files.readString(recorded).isEmpty()) {
+                return Files.readString(recorded);
+            }
+            Thread.sleep(50);
+        }
+        return "";
+    }
+
+    @Test
+    void openBrowserPassesFullUrlToCustomBrowser() throws IOException, InterruptedException {
+        ExternalFileType htmlType = new CustomExternalFileType("URL", "html", "text/html", recorder.toString(), "www", IconTheme.JabRefIcons.WWW);
+        ExternalApplicationsPreferences preferences = mock(ExternalApplicationsPreferences.class);
+        when(preferences.getExternalFileTypes()).thenReturn(FXCollections.observableSet(htmlType));
+
+        NativeDesktop.openBrowser(URL_WITH_QUERY, preferences);
+
+        assertEquals(URL_WITH_QUERY, recordedArgument());
+    }
+
+    @Test
+    void windowsOpenFileWithApplicationKeepsUrlIntact() throws IOException, InterruptedException {
+        // The Windows implementation is executable on POSIX, which is enough to pin down that the
+        // URL is passed through verbatim instead of being run through Path.of
+        new Windows().openFileWithApplication(URL_WITH_QUERY, recorder.toString());
+
+        assertEquals(URL_WITH_QUERY, recordedArgument());
+    }
+}

--- a/jablib/src/test/java/org/jabref/logic/net/URLUtilTest.java
+++ b/jablib/src/test/java/org/jabref/logic/net/URLUtilTest.java
@@ -111,6 +111,13 @@ class URLUtilTest {
     }
 
     @Test
+    void createUriKeepsSchemeAndQuery() {
+        String input = "https://journals.plos.org/plosmedicine/article/file?id=10.1371/journal.pmed.1004085&type=printable";
+        URI uri = URLUtil.createUri(input);
+        assertEquals(input, uri.toASCIIString());
+    }
+
+    @Test
     void createUriShouldHandlePipeCharacter() {
         String input = "http://example.com/test|file";
         URI uri = URLUtil.createUri(input);


### PR DESCRIPTION
### Summary

🤖 Opening an online link stored in the "file" field (or a DOI) could land the browser on a truncated URL when the link contained a query string, because the URL was routed through the filesystem open path. Online links are now opened through a URL-aware browser call, so the full URL including its query reaches the browser.

`jabref-contrib-policy:4.2:reviewed​:ok`

**Analogies:** Like honey, this fix flows the URL through unaltered instead of letting it crystallize into a broken path. Like chocolate, it is a small piece that improves every link-opening moment. Like the moon, the bug only showed itself in certain phases (desktop/browser combinations) — but it was always there.

### Steps to test

1. Add a `file` field to an entry with the value `https://journals.plos.org/plosmedicine/article/file?id=10.1371/journal.pmed.1004085&type=printable`
1. Click the link's "open" icon in the entry table or entry editor
1. The browser opens that exact URL (a PDF), not a truncated `…/plosmedicine/article` 404 page

Verified end-to-end on Linux with a logging default-browser handler: the handler received the full URL with the query string intact.

### Related issues and pull requests

Found while testing browser-extension fulltext handling; no existing issue.

### AI usage

Claude Code (model claude-fable-5), AIL4 — task specified by the maintainer with the root cause traced; code AI-written, human-reviewed and owned.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [x] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block. (kept the file's existing `isPresent()` guard pattern used by the surrounding code)
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.
- [x] No `catch (Exception e)` — only specific exceptions are caught.
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [x] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.
- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [x] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [x] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`. (uses the `HeadlessExecutorService` already used by the platform open path)
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `code` instead of `{@code}`, `[ClassName]` instead of `{@link}`.
- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.
- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).
- [x] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [x] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.
- [/] Fetcher tests hit the live endpoints — the remote API is not mocked or stubbed (automated-review suggestions to mock it are rejected on purpose).
- [x] `./gradlew :jablib:check` (or `./gradlew check` for all modules). (URLUtilTest run; full check not runnable in this environment)
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [x] `./gradlew modernizer`.
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [/] `./gradlew javadoc`.
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [x] Only if formatting is still off after `rewriteRun`: intellij-format (run via pinned IDEA 2025.3.1 `format.sh`).
- [x] `CHANGELOG.md` entry added if the change is visible to the user.
- [x] Searched issues for a related issue; none found, PR link used.
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix.
- [/] Developer documentation under `docs/` updated if behavior or architecture changed.
- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [x] CHANGELOG PR-number link verified after PR creation.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user) — no visual UI change; the effect is the browser receiving the correct URL
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
