### PR TITLE
Show autolink file suggestions in entry editor Main tab again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where files found in the file directory but not yet linked were no longer shown in the entry editor; they are now highlighted with an orange background. [#16737](https://github.com/JabRef/jabref/issues/16737)
 - We fixed an issue where a full-text PDF link found by DOI lookup was attached in lowercase and failed. [#16762](https://github.com/JabRef/jabref/pull/16762)
 - "Git commit" now saves a modified library first (if autosave is enabled) or asks to save it, so unsaved changes are no longer silently left out of the commit. [#16718](https://github.com/JabRef/jabref/pull/16718)
 - We fixed an issue where a library could be closed without asking to save changes made after an undo. [#16680](https://github.com/JabRef/jabref/pull/16680)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where found but not yet linked files were no longer suggested in the entry editor. [#16737](https://github.com/JabRef/jabref/issues/16737)
 - We fixed an issue where a full-text PDF link found by DOI lookup was attached in lowercase and failed. [#16762](https://github.com/JabRef/jabref/pull/16762)
 - "Git commit" now saves a modified library first (if autosave is enabled) or asks to save it, so unsaved changes are no longer silently left out of the commit. [#16718](https://github.com/JabRef/jabref/pull/16718)
 - We fixed an issue where a library could be closed without asking to save changes made after an undo. [#16680](https://github.com/JabRef/jabref/pull/16680)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where files found in the file directory but not yet linked were no longer shown in the entry editor; they are now highlighted with a gray background. [#16737](https://github.com/JabRef/jabref/issues/16737)
+- We fixed an issue where found but not yet linked files were no longer suggested in the entry editor. [#16737](https://github.com/JabRef/jabref/issues/16737)
 - We fixed an issue where a full-text PDF link found by DOI lookup was attached in lowercase and failed. [#16762](https://github.com/JabRef/jabref/pull/16762)
 - "Git commit" now saves a modified library first (if autosave is enabled) or asks to save it, so unsaved changes are no longer silently left out of the commit. [#16718](https://github.com/JabRef/jabref/pull/16718)
 - We fixed an issue where a library could be closed without asking to save changes made after an undo. [#16680](https://github.com/JabRef/jabref/pull/16680)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where files found in the file directory but not yet linked were no longer shown in the entry editor; they are now highlighted with an orange background. [#16737](https://github.com/JabRef/jabref/issues/16737)
+- We fixed an issue where files found in the file directory but not yet linked were no longer shown in the entry editor; they are now highlighted with a gray background. [#16737](https://github.com/JabRef/jabref/issues/16737)
 - We fixed an issue where a full-text PDF link found by DOI lookup was attached in lowercase and failed. [#16762](https://github.com/JabRef/jabref/pull/16762)
 - "Git commit" now saves a modified library first (if autosave is enabled) or asks to save it, so unsaved changes are no longer silently left out of the commit. [#16718](https://github.com/JabRef/jabref/pull/16718)
 - We fixed an issue where a library could be closed without asking to save changes made after an undo. [#16680](https://github.com/JabRef/jabref/pull/16680)

--- a/docs/requirements/entry-editor.md
+++ b/docs/requirements/entry-editor.md
@@ -75,6 +75,13 @@ A field's row shows a small gray "remove field" icon button pinned to its top-ri
 
 Needs: impl
 
+## Files found in the file directory are suggested even when no file is linked
+`req~entry-editor.main-tab.autolink-suggestions~1`
+
+When "Search and store files relative to library file location" finds files in the file directory that match the entry but are not linked in it, the file editor is shown in the files and links section even if the entry has no file field, listing those files as suggestions with an orange background and an accept button. This matches the file editor's behavior for entries that already have linked files.
+
+Needs: impl
+
 ## Custom tabs show a user-defined list of field patterns
 `req~entry-editor.custom-tabs~1`
 

--- a/docs/requirements/entry-editor.md
+++ b/docs/requirements/entry-editor.md
@@ -78,7 +78,7 @@ Needs: impl
 ## Files found in the file directory are suggested even when no file is linked
 `req~entry-editor.main-tab.autolink-suggestions~1`
 
-When "Automatically search and show unlinked files in the entry editor" is enabled and files in the file directory match the entry but are not linked in it, the file editor is shown in the files and links section even if the entry has no file field, listing those files as suggestions with an orange background and an accept button. This matches the file editor's behavior for entries that already have linked files.
+When "Automatically search and show unlinked files in the entry editor" is enabled and files in the file directory match the entry but are not linked in it, the file editor is shown in the files and links section even if the entry has no file field, listing those files as suggestions with a gray background and an accept button. This matches the file editor's behavior for entries that already have linked files.
 
 Needs: impl
 

--- a/docs/requirements/entry-editor.md
+++ b/docs/requirements/entry-editor.md
@@ -78,7 +78,7 @@ Needs: impl
 ## Files found in the file directory are suggested even when no file is linked
 `req~entry-editor.main-tab.autolink-suggestions~1`
 
-When "Search and store files relative to library file location" finds files in the file directory that match the entry but are not linked in it, the file editor is shown in the files and links section even if the entry has no file field, listing those files as suggestions with an orange background and an accept button. This matches the file editor's behavior for entries that already have linked files.
+When "Automatically search and show unlinked files in the entry editor" is enabled and files in the file directory match the entry but are not linked in it, the file editor is shown in the files and links section even if the entry has no file field, listing those files as suggestions with an orange background and an accept button. This matches the file editor's behavior for entries that already have linked files.
 
 Needs: impl
 

--- a/docs/requirements/entry-editor.md
+++ b/docs/requirements/entry-editor.md
@@ -80,7 +80,7 @@ Needs: impl
 
 When "Automatically search and show unlinked files in the entry editor" is enabled and files in the file directory match the entry but are not linked in it, the file editor is shown in the files and links section even if the entry has no file field, listing those files as suggestions with a gray background and an accept button. This matches the file editor's behavior for entries that already have linked files.
 
-Needs: impl
+Needs: impl, utest
 
 ## Custom tabs show a user-defined list of field patterns
 `req~entry-editor.custom-tabs~1`

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -235,8 +235,10 @@ public class AllFieldsTab extends FieldsEditorTab {
                 guiPreferences.getAutoLinkPreferences());
         BackgroundTask.wrap(() -> util.findAssociatedNotLinkedFiles(entry))
                       .onSuccess(foundFiles -> {
+                          // subscribedEntry is cleared on dispose() and replaced on entry switch,
+                          // so this also invalidates callbacks that outlive the tab.
                           if (!foundFiles.isEmpty()
-                                  && (getCurrentEntry() == entry)
+                                  && subscribedEntry.filter(current -> current == entry).isPresent()
                                   && !editors.containsKey(StandardField.FILE)) {
                               userAddedFields.add(StandardField.FILE);
                               rebuildPanel(databaseContext, entry);
@@ -283,6 +285,11 @@ public class AllFieldsTab extends FieldsEditorTab {
         boolean entryTypeChanged = InternalField.TYPE_HEADER == event.getField();
         if (entryTypeChanged || !target.equals(editors.keySet())) {
             rebuildPanel(activeDatabaseContext(), entry);
+        }
+        // A changed citation key can make files in the file directory match this entry,
+        // so the suggestions must be re-discovered without switching entries.
+        if (InternalField.KEY_FIELD == event.getField()) {
+            showFileFieldIfAutoLinkFindsFiles(entry);
         }
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -221,6 +221,7 @@ public class AllFieldsTab extends FieldsEditorTab {
     /// shows not-yet-linked files as auto-found suggestions (issue #16737). Probe for such
     /// files here and, on a hit, show the (empty) file editor; its own bind then re-runs
     /// the search and renders the suggestion rows.
+    // [impl->req~entry-editor.main-tab.autolink-suggestions~1]
     private void showFileFieldIfAutoLinkFindsFiles(BibEntry entry) {
         if (editors.containsKey(StandardField.FILE)
                 || !guiPreferences.getEntryEditorPreferences().autoLinkFilesEnabled()) {

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -244,6 +244,7 @@ public class AllFieldsTab extends FieldsEditorTab {
                           // so this also invalidates callbacks that outlive the tab. The citation
                           // key comparison drops results of probes started for a stale key.
                           if (!foundFiles.isEmpty()
+                                  && guiPreferences.getEntryEditorPreferences().autoLinkFilesEnabled()
                                   && subscribedEntry.filter(current -> current == entry).isPresent()
                                   && entry.getCitationKey().equals(keyAtProbeStart)
                                   && !editors.containsKey(StandardField.FILE)) {

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -251,7 +251,7 @@ public class AllFieldsTab extends FieldsEditorTab {
                               rebuildPanel(databaseContext, entry);
                           }
                       })
-                      .onFailure(exception -> LOGGER.warn("Could not search the file directories for files matching entry {}", entry.getCitationKey().orElse(""), exception))
+                      .onFailure(exception -> LOGGER.warn("Could not search the file directories for files matching entry {}", entry.getCitationKey().orElse(entry.getAuthorTitleYear()), exception))
                       .executeWith(Injector.instantiateModelOrService(TaskExecutor.class));
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -73,6 +73,8 @@ import com.airhacks.afterburner.injection.Injector;
 import com.google.common.eventbus.Subscribe;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /// The single scroll-list tab ("Main") showing *all* fields of an entry (issue #12711):
 /// the citation key, all required fields (even when unset), and every set field.
@@ -85,6 +87,8 @@ import org.jspecify.annotations.Nullable;
 /// field-name box at the bottom adds arbitrary fields.
 @NullMarked
 public class AllFieldsTab extends FieldsEditorTab {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AllFieldsTab.class);
 
     /// Preferred number of visible text rows for multiline editors in the scroll list
     /// (instead of the JavaFX TextArea default of 10).
@@ -233,17 +237,21 @@ public class AllFieldsTab extends FieldsEditorTab {
                 guiPreferences.getExternalApplicationsPreferences(),
                 guiPreferences.getFilePreferences(),
                 guiPreferences.getAutoLinkPreferences());
+        Optional<String> keyAtProbeStart = entry.getCitationKey();
         BackgroundTask.wrap(() -> util.findAssociatedNotLinkedFiles(entry))
                       .onSuccess(foundFiles -> {
                           // subscribedEntry is cleared on dispose() and replaced on entry switch,
-                          // so this also invalidates callbacks that outlive the tab.
+                          // so this also invalidates callbacks that outlive the tab. The citation
+                          // key comparison drops results of probes started for a stale key.
                           if (!foundFiles.isEmpty()
                                   && subscribedEntry.filter(current -> current == entry).isPresent()
+                                  && entry.getCitationKey().equals(keyAtProbeStart)
                                   && !editors.containsKey(StandardField.FILE)) {
                               userAddedFields.add(StandardField.FILE);
                               rebuildPanel(databaseContext, entry);
                           }
                       })
+                      .onFailure(exception -> LOGGER.warn("Could not search the file directories for files matching entry {}", entry.getCitationKey().orElse(""), exception))
                       .executeWith(Injector.instantiateModelOrService(TaskExecutor.class));
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -41,6 +41,7 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 
 import org.jabref.gui.StateManager;
+import org.jabref.gui.externalfiles.AutoSetFileLinksUtil;
 import org.jabref.gui.fieldeditors.FieldEditorFX;
 import org.jabref.gui.fieldeditors.LinkedFilesEditor;
 import org.jabref.gui.fieldeditors.TagsEditor;
@@ -53,6 +54,8 @@ import org.jabref.gui.util.FieldsUtil;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.undo.UndoManager;
+import org.jabref.logic.util.BackgroundTask;
+import org.jabref.logic.util.TaskExecutor;
 import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.BibDatabaseMode;
@@ -66,6 +69,7 @@ import org.jabref.model.entry.field.OrFields;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.field.UserSpecificCommentField;
 
+import com.airhacks.afterburner.injection.Injector;
 import com.google.common.eventbus.Subscribe;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -209,6 +213,35 @@ public class AllFieldsTab extends FieldsEditorTab {
             subscribedEntry = Optional.of(entry);
         }
         super.bindToEntry(entry);
+        showFileFieldIfAutoLinkFindsFiles(entry);
+    }
+
+    /// Only set fields get an editor, so an entry without a file field has no
+    /// [LinkedFilesEditor] — whose view model is what searches the file directories and
+    /// shows not-yet-linked files as auto-found suggestions (issue #16737). Probe for such
+    /// files here and, on a hit, show the (empty) file editor; its own bind then re-runs
+    /// the search and renders the suggestion rows.
+    private void showFileFieldIfAutoLinkFindsFiles(BibEntry entry) {
+        if (editors.containsKey(StandardField.FILE)
+                || !guiPreferences.getEntryEditorPreferences().autoLinkFilesEnabled()) {
+            return;
+        }
+        BibDatabaseContext databaseContext = activeDatabaseContext();
+        AutoSetFileLinksUtil util = new AutoSetFileLinksUtil(
+                databaseContext,
+                guiPreferences.getExternalApplicationsPreferences(),
+                guiPreferences.getFilePreferences(),
+                guiPreferences.getAutoLinkPreferences());
+        BackgroundTask.wrap(() -> util.findAssociatedNotLinkedFiles(entry))
+                      .onSuccess(foundFiles -> {
+                          if (!foundFiles.isEmpty()
+                                  && (getCurrentEntry() == entry)
+                                  && !editors.containsKey(StandardField.FILE)) {
+                              userAddedFields.add(StandardField.FILE);
+                              rebuildPanel(databaseContext, entry);
+                          }
+                      })
+                      .executeWith(Injector.instantiateModelOrService(TaskExecutor.class));
     }
 
     @Override

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -222,7 +222,8 @@ public class AllFieldsTab extends FieldsEditorTab {
 
     /// Only set fields get an editor, so an entry without a file field has no
     /// [LinkedFilesEditor] — whose view model is what searches the file directories and
-    /// shows not-yet-linked files as auto-found suggestions (issue #16737). Probe for such
+    /// shows not-yet-linked files as auto-found suggestions
+    /// (issue <https://github.com/JabRef/jabref/issues/16737>). Probe for such
     /// files here and, on a hit, show the (empty) file editor; its own bind then re-runs
     /// the search and renders the suggestion rows.
     // [impl->req~entry-editor.main-tab.autolink-suggestions~1]

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -158,6 +158,7 @@ public class LinkedFilesEditor extends VBox implements FieldEditorFX {
 
         new ViewModelListCellFactory<LinkedFileViewModel>()
                 .withStringTooltip(LinkedFileViewModel::getDescriptionAndLink)
+                .withPseudoClass(PseudoClass.getPseudoClass("auto-found"), LinkedFileViewModel::isAutomaticallyFoundProperty)
                 .withGraphic(this::createFileDisplay)
                 .withOnMouseClickedEvent(this::handleItemMouseClick)
                 .setOnDragDetected(this::handleOnDragDetected)
@@ -309,9 +310,6 @@ public class LinkedFilesEditor extends VBox implements FieldEditorFX {
 
         HBox container = new HBox(2);
         container.setPrefHeight(Double.NEGATIVE_INFINITY);
-        container.getStyleClass().add("file-row");
-        EasyBind.subscribe(linkedFile.isAutomaticallyFoundProperty(),
-                found -> container.pseudoClassStateChanged(PseudoClass.getPseudoClass("auto-found"), found));
         container.getChildren().addAll(acceptAutoLinkedFile, info, writeMetadataToPdf, parsePdfMetadata);
 
         return container;

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -309,6 +309,9 @@ public class LinkedFilesEditor extends VBox implements FieldEditorFX {
 
         HBox container = new HBox(2);
         container.setPrefHeight(Double.NEGATIVE_INFINITY);
+        container.getStyleClass().add("file-row");
+        EasyBind.subscribe(linkedFile.isAutomaticallyFoundProperty(),
+                found -> container.pseudoClassStateChanged(PseudoClass.getPseudoClass("auto-found"), found));
         container.getChildren().addAll(acceptAutoLinkedFile, info, writeMetadataToPdf, parsePdfMetadata);
 
         return container;

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -340,9 +340,10 @@
     -fx-fill: derive(-fx-text-base-color, 70%);
 }
 
-/* File found in the file directory but not (yet) linked in the entry */
+/* File found in the file directory but not (yet) linked in the entry.
+   Deliberately not -color-warning-subtle: orange signals "linked but not found". */
 .file-row:auto-found {
-    -fx-background-color: -color-warning-subtle;
+    -fx-background-color: -color-shadow-subtle;
     -fx-background-radius: 4px;
 }
 

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -341,9 +341,11 @@
 }
 
 /* File found in the file directory but not (yet) linked in the entry.
-   Deliberately not -color-warning-subtle: orange signals "linked but not found". */
+   Deliberately not -color-warning-subtle: orange signals "linked but not found".
+   -color-selection-inactive is a neutral gray that stays readable in dark themes,
+   where a translucent black fill would sink into the panel background. */
 .file-row:auto-found {
-    -fx-background-color: -color-shadow-subtle;
+    -fx-background-color: -color-selection-inactive;
     -fx-background-radius: 4px;
 }
 

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -349,6 +349,16 @@
     -fx-background-radius: 4px;
 }
 
+/* The suggestion background must not mask the list's interaction affordances
+   (same colors the themes use for cell hover and selection). */
+.linked-files-list .list-cell:auto-found:filled:hover {
+    -fx-background-color: -color-border-default;
+}
+
+.linked-files-list .list-cell:auto-found:filled:selected {
+    -fx-background-color: -color-selection;
+}
+
 /* Sidepane */
 
 .sidePaneComponent {

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -344,7 +344,7 @@
    Deliberately not -color-warning-subtle: orange signals "linked but not found".
    -color-selection-inactive is a neutral gray that stays readable in dark themes,
    where a translucent black fill would sink into the panel background. */
-.file-row:auto-found {
+.linked-files-list .list-cell:auto-found {
     -fx-background-color: -color-selection-inactive;
     -fx-background-radius: 4px;
 }

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -340,6 +340,12 @@
     -fx-fill: derive(-fx-text-base-color, 70%);
 }
 
+/* File found in the file directory but not (yet) linked in the entry */
+.file-row:auto-found {
+    -fx-background-color: -color-warning-subtle;
+    -fx-background-radius: 4px;
+}
+
 /* Sidepane */
 
 .sidePaneComponent {

--- a/jabgui/src/test/java/org/jabref/gui/entryeditor/AllFieldsTabTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/entryeditor/AllFieldsTabTest.java
@@ -1,0 +1,195 @@
+package org.jabref.gui.entryeditor;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.clipboard.ClipBoardManager;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.externalfiletype.ExternalFileTypes;
+import org.jabref.gui.frame.ExternalApplicationsPreferences;
+import org.jabref.gui.keyboard.KeyBindingRepository;
+import org.jabref.gui.preferences.GuiPreferences;
+import org.jabref.gui.preview.PreviewPanel;
+import org.jabref.gui.undo.RedoAction;
+import org.jabref.gui.undo.UndoAction;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
+import org.jabref.logic.undo.JabRefUndoManager;
+import org.jabref.logic.util.BackgroundTask;
+import org.jabref.logic.util.CurrentThreadTaskExecutor;
+import org.jabref.logic.util.OptionalObjectProperty;
+import org.jabref.logic.util.TaskExecutor;
+import org.jabref.logic.util.io.AutoLinkPreferences;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.database.BibDatabaseMode;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryTypesManager;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.metadata.MetaData;
+import org.jabref.model.util.DummyFileUpdateMonitor;
+import org.jabref.model.util.FileUpdateMonitor;
+
+import com.airhacks.afterburner.injection.Injector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// [utest->req~entry-editor.main-tab.autolink-suggestions~1]
+@ExtendWith(ApplicationExtension.class)
+class AllFieldsTabTest {
+
+    /// Runs probes synchronously, but can hold them back so a test can change entry state
+    /// between probe start and probe completion (the stale-result scenario).
+    private static class DeferringTaskExecutor extends CurrentThreadTaskExecutor {
+        private final List<BackgroundTask<?>> deferred = new ArrayList<>();
+        private boolean deferring;
+
+        @Override
+        public <V> Future<V> execute(BackgroundTask<V> task) {
+            if (deferring) {
+                deferred.add(task);
+                return CompletableFuture.completedFuture(null);
+            }
+            return super.execute(task);
+        }
+
+        void deferUpcomingTasks() {
+            deferring = true;
+        }
+
+        /// Later tasks (e.g. the probe restarted by the key change itself) stay deferred.
+        void runNextDeferredTask() {
+            super.execute(deferred.removeFirst());
+        }
+    }
+
+    private Path fileDirectory;
+    private GuiPreferences preferences;
+    private DeferringTaskExecutor taskExecutor;
+    private AllFieldsTab tab;
+
+    @BeforeEach
+    void setUp(@TempDir Path fileDirectory) {
+        this.fileDirectory = fileDirectory;
+
+        preferences = mock(GuiPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(preferences.getOwnerPreferences().getDefaultOwner()).thenReturn("owner");
+        when(preferences.getEntryEditorPreferences().autoLinkFilesEnabled()).thenReturn(true);
+        when(preferences.getCitationKeyPatternPreferences().getUnwantedCharacters()).thenReturn("");
+        ExternalApplicationsPreferences externalApplicationsPreferences = mock(ExternalApplicationsPreferences.class);
+        when(externalApplicationsPreferences.getExternalFileTypes())
+                .thenReturn(FXCollections.observableSet(new TreeSet<>(ExternalFileTypes.getDefaultExternalFileTypes())));
+        when(preferences.getExternalApplicationsPreferences()).thenReturn(externalApplicationsPreferences);
+        when(preferences.getAutoLinkPreferences()).thenReturn(
+                new AutoLinkPreferences(AutoLinkPreferences.CitationKeyDependency.START, "", false, ';'));
+
+        BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
+        when(databaseContext.getFileDirectories(any())).thenReturn(List.of(fileDirectory));
+        when(databaseContext.getMode()).thenReturn(BibDatabaseMode.BIBTEX);
+        when(databaseContext.getMetaData()).thenReturn(new MetaData());
+
+        StateManager stateManager = mock(StateManager.class);
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.of(databaseContext));
+        when(stateManager.activeTabProperty()).thenReturn(OptionalObjectProperty.empty());
+
+        taskExecutor = new DeferringTaskExecutor();
+        Injector.setModelOrService(TaskExecutor.class, taskExecutor);
+        Injector.setModelOrService(GuiPreferences.class, preferences);
+        Injector.setModelOrService(DialogService.class, mock(DialogService.class));
+        Injector.setModelOrService(StateManager.class, stateManager);
+        Injector.setModelOrService(ClipBoardManager.class, mock(ClipBoardManager.class));
+        Injector.setModelOrService(org.jabref.logic.undo.UndoManager.class, new JabRefUndoManager());
+        Injector.setModelOrService(KeyBindingRepository.class, new KeyBindingRepository());
+        Injector.setModelOrService(BibEntryTypesManager.class, new BibEntryTypesManager());
+        Injector.setModelOrService(JournalAbbreviationRepository.class, mock(JournalAbbreviationRepository.class));
+        Injector.setModelOrService(FileUpdateMonitor.class, new DummyFileUpdateMonitor());
+
+        tab = new AllFieldsTab(
+                new JabRefUndoManager(),
+                mock(UndoAction.class),
+                mock(RedoAction.class),
+                preferences,
+                new BibEntryTypesManager(),
+                mock(JournalAbbreviationRepository.class),
+                stateManager,
+                mock(PreviewPanel.class));
+    }
+
+    private void runOnFxThreadAndWait(Runnable action) throws InterruptedException {
+        CountDownLatch done = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            action.run();
+            done.countDown();
+        });
+        assertTrue(done.await(30, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void fileEditorAppearsWhenAutolinkFindsUnlinkedFile() throws IOException, InterruptedException {
+        Files.createFile(fileDirectory.resolve("CiteKey2021.pdf"));
+        BibEntry entry = new BibEntry(StandardEntryType.Misc).withCitationKey("CiteKey2021");
+
+        runOnFxThreadAndWait(() -> tab.bindToEntry(entry));
+
+        assertTrue(tab.editors.containsKey(StandardField.FILE));
+    }
+
+    @Test
+    void fileEditorStaysHiddenWithoutMatchingFile() throws InterruptedException {
+        BibEntry entry = new BibEntry(StandardEntryType.Misc).withCitationKey("CiteKey2021");
+
+        runOnFxThreadAndWait(() -> tab.bindToEntry(entry));
+
+        assertFalse(tab.editors.containsKey(StandardField.FILE));
+    }
+
+    @Test
+    void fileEditorStaysHiddenWhenAutolinkIsDisabled() throws IOException, InterruptedException {
+        when(preferences.getEntryEditorPreferences().autoLinkFilesEnabled()).thenReturn(false);
+        Files.createFile(fileDirectory.resolve("CiteKey2021.pdf"));
+        BibEntry entry = new BibEntry(StandardEntryType.Misc).withCitationKey("CiteKey2021");
+
+        runOnFxThreadAndWait(() -> tab.bindToEntry(entry));
+
+        assertFalse(tab.editors.containsKey(StandardField.FILE));
+    }
+
+    @Test
+    void staleProbeResultDoesNotAddFileEditor() throws IOException, InterruptedException {
+        Files.createFile(fileDirectory.resolve("CiteKey2021.pdf"));
+        BibEntry entry = new BibEntry(StandardEntryType.Misc).withCitationKey("OtherKey");
+
+        taskExecutor.deferUpcomingTasks();
+        runOnFxThreadAndWait(() -> tab.bindToEntry(entry));
+        // The probe for "OtherKey" is still pending; by the time it runs, the key has changed
+        // and its (now matching) result must be discarded.
+        runOnFxThreadAndWait(() -> {
+            entry.setCitationKey("CiteKey2021");
+            taskExecutor.runNextDeferredTask();
+        });
+
+        assertFalse(tab.editors.containsKey(StandardField.FILE));
+    }
+}

--- a/jabgui/src/test/java/org/jabref/gui/entryeditor/AllFieldsTabTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/entryeditor/AllFieldsTabTest.java
@@ -16,8 +16,8 @@ import javafx.application.Platform;
 import javafx.collections.FXCollections;
 
 import org.jabref.gui.DialogService;
-import org.jabref.gui.clipboard.ClipBoardManager;
 import org.jabref.gui.StateManager;
+import org.jabref.gui.clipboard.ClipBoardManager;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.frame.ExternalApplicationsPreferences;
 import org.jabref.gui.keyboard.KeyBindingRepository;


### PR DESCRIPTION
### Summary

🤖 The new entry editor's "Main" tab no longer showed files that were found in the file directory but not yet linked to the entry — the autolink suggestions from JabRef 5.x were simply missing for entries without a file field. The file editor now appears with those suggestions again, highlighted with a gray background.

Analogies: Like honey, this fix quietly sticks a found file to its entry; like chocolate, the gray highlight is a small treat that makes you notice it; and like the moon, the suggested file was always there — it just wasn't visible until now.

`jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

1. Put a PDF named like an entry's citation key (e.g. `Fuchs2021tdc.pdf`) into the library's file directory, without linking it in the entry.
2. Open the entry in the entry editor's "Main" tab.
3. The "Files and links" section expands and shows the file with a gray background and a link button.
4. Click the link button — the file is linked and the highlight disappears.

Light theme:

![Autolink suggestion, light theme](https://raw.githubusercontent.com/JabRef/jabref-koppor/assets-fix-autolink-highlight/autolink-gray-row-light.png)

Dark theme:

![Autolink suggestion, dark theme](https://raw.githubusercontent.com/JabRef/jabref-koppor/assets-fix-autolink-highlight/autolink-gray-row-dark.png)

### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/16737

### AI usage

Claude Code (model claude-fable-5), AIL4 — implementation and testing by AI, reviewed by the contributor.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [x] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [x] No `catch (Exception e)` — only specific exceptions are caught.
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [/] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [x] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [x] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `code` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [x] Behavior changes have tests: `AllFieldsTabTest` covers the suggestion flow (appear, hidden, disabled, stale result).
- [x] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.
- [/] Fetcher tests hit the live endpoints — the remote API is not mocked or stubbed (automated-review suggestions to mock it are rejected on purpose).

## 2. Verification commands

- [x] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [x] `./gradlew modernizer`.
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [x] `./gradlew javadoc`.
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.

## 3. Documentation

- [/] `CHANGELOG.md` entry added if the change is visible to the user — no entry: the regression only affects the unreleased Main tab (feature only in `## [Unreleased]`).
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match.
- [x] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix.
- [/] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder, it was replaced with the real PR-number link after PR creation.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (`AllFieldsTabTest`)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` (not applicable: fix to a feature that is itself unreleased)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
