### PR TITLE
Use PAT for marking labeled PRs ready for review

### DIFF
--- a/.github/workflows/on-pr-labeled-update-pr-status.yml
+++ b/.github/workflows/on-pr-labeled-update-pr-status.yml
@@ -59,4 +59,6 @@ jobs:
             echo "⊘ label ready-for-review not found"
           fi;
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The default GITHUB_TOKEN cannot call the markPullRequestReadyForReview mutation
+          # ("Resource not accessible by integration") - a PAT is required
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADAPT_REVIEW }}


### PR DESCRIPTION
### 🤖 Summary

Since #16715, marking a labeled draft PR ready for review fails, because the GraphQL mutation behind `gh pr ready` is not accessible to the workflow's default token. The workflow now uses the same PAT that the draft-conversion workflows already use, so the automatic ready-for-review marking works again.

`jabref-contrib-policy:4.2:reviewed​:ok`

**Analogies:** Like honey, this fix is small but binds the whole recipe together; like chocolate, it swaps one ingredient to make the result work; and like the moon, the token merely reflects an authority it does not hold itself.

### Steps to test

1. Label an open draft PR with `status: ready-for-review` and check that the "Adapt PR status" run marks it ready.

### Related issues and pull requests

Failing run: https://github.com/JabRef/jabref/actions/runs/33335609731/job/99321845996

### AI usage

Claude Code (model claude-fable-5), AIL4.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

- [/] No `== null` / `!= null` checks — JSpecify annotations used instead.
- [/] No `Objects.requireNonNull(...)`.
- [/] New classes annotated with `@NullMarked`.
- [/] `Optional` consumed correctly.
- [/] `StringUtil.isBlank(...)` used.
- [/] No `catch (Exception e)`.
- [/] No `throw new RuntimeException(...)`.
- [/] Logged exceptions passed as last logger argument.
- [/] New `BibEntry` objects built with withers.
- [/] Modern Java used.
- [/] Regexes precompiled.
- [/] Background work uses `BackgroundTask`.
- [x] No commented-out code, no trivial comments, no AI-disclosure comments.
- [/] Markdown Javadoc syntax.
- [/] User-facing text localized.
- [/] Sentence case.
- [/] Placeholders, not concatenation.
- [/] User-controlled data HTML-escaped.
- [/] Tests for `org.jabref.model` / `org.jabref.logic` changes.
- [/] Test style rules.
- [/] Fetcher tests hit live endpoints.
- [/] `./gradlew :jablib:check` — not applicable, workflow-only change (no Java touched).
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [/] `./gradlew modernizer`.
- [/] `./gradlew --no-configuration-cache :rewriteDryRun`.
- [/] `./gradlew javadoc`.
- [/] `npx markdownlint-cli2` — no Markdown changed.
- [/] IntelliJ format.
- [/] `CHANGELOG.md` entry — not user-visible (CI infrastructure only).
- [x] Searched issues for a related one; only the failing Actions run exists.
- [/] Requirement in `docs/requirements/`.
- [/] Developer documentation under `docs/`.
- [x] PR body built from template, every section filled.
- [x] All checklist items kept and marked.
- [x] All HTML comments removed.
- [x] PR created with `gh pr create --body-file`.
- [/] `CHANGELOG.md` TODO placeholder.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required) — workflow-only change, verified against the failing Actions run
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pyhMJymcanQmWZyThARve
