### PR TITLE
Replace leftover <ol> HTML tags in Markdown doc comments with numbered lists

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/git/GitStatusViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/git/GitStatusViewModel.java
@@ -24,12 +24,10 @@ import org.jabref.model.database.BibDatabaseContext;
 /// ViewModel that holds current Git sync status for the open .bib database.
 /// It maintains the state of the GitHandler bound to the current file path, including:
 ///
-/// <ul>
-///   <li>Whether the current file is inside a Git repository</li>
-///   <li>Whether the file is tracked by Git</li>
-///   <li>Whether there are unresolved merge conflicts</li>
-///   <li>The current sync status (e.g., `UP_TO_DATE`, `DIVERGED`, etc.)</li>
-/// </ul>
+/// - Whether the current file is inside a Git repository
+/// - Whether the file is tracked by Git
+/// - Whether there are unresolved merge conflicts
+/// - The current sync status (e.g., `UP_TO_DATE`, `DIVERGED`, etc.)
 public class GitStatusViewModel extends AbstractViewModel {
     private final StateManager stateManager;
     private final TaskExecutor taskExecutor;

--- a/jablib/src/main/java/org/jabref/logic/ai/chatting/migrations/ChatHistoryMigrationV1.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/chatting/migrations/ChatHistoryMigrationV1.java
@@ -330,12 +330,9 @@ public final class ChatHistoryMigrationV1 {
 
     /// Reads raw Java-serialized bytes from MVStore's binary page format without invoking
     /// Java deserialization. MVStore's ObjectDataType stores each serializable value as:
-    /// <ol>
-    ///
-    /// - 1 byte: type identifier — `19` (TYPE_SERIALIZED_OBJECT in H2 2.3.232)
-    /// - VarInt: byte length of the serialized payload
-    /// - N bytes: the raw Java-serialized payload
-    /// </ol>
+    /// 1. 1 byte: type identifier — `19` (TYPE_SERIALIZED_OBJECT in H2 2.3.232)
+    /// 2. VarInt: byte length of the serialized payload
+    /// 3. N bytes: the raw Java-serialized payload
     private static class RawBytesDataType extends BasicDataType<byte[]> {
 
         // TYPE_SERIALIZED_OBJECT = 19, verified from H2 2.3.232 bytecode.

--- a/jablib/src/main/java/org/jabref/logic/ai/util/LlmResponseCleaner.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/util/LlmResponseCleaner.java
@@ -6,16 +6,13 @@ import org.jspecify.annotations.Nullable;
 /// fenced code block (``` ... ```) if present, or simply trimming whitespace.
 ///
 /// Rules:
-/// <ol>
-///
-/// - If the response contains no ``` fences → return the string stripped of
+/// 1. If the response contains no ``` fences → return the string stripped of
 /// leading/trailing whitespace.
-/// - If one or more ``` fences exist → find the *last* complete block,
+/// 2. If one or more ``` fences exist → find the *last* complete block,
 /// strip the optional language label on the opening fence (e.g. ````json`,
 /// ````markdown`), and return the inner content trimmed.
-/// - If the last fence is unclosed (no matching closing `````) → treat
+/// 3. If the last fence is unclosed (no matching closing `````) → treat
 /// everything after the opening fence line as the content.
-/// </ol>
 public final class LlmResponseCleaner {
     private static final String FENCE = "```";
 

--- a/jablib/src/main/java/org/jabref/logic/ai/util/LlmResponseCleaner.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/util/LlmResponseCleaner.java
@@ -7,12 +7,12 @@ import org.jspecify.annotations.Nullable;
 ///
 /// Rules:
 /// 1. If the response contains no ``` fences → return the string stripped of
-/// leading/trailing whitespace.
+///    leading/trailing whitespace.
 /// 2. If one or more ``` fences exist → find the *last* complete block,
-/// strip the optional language label on the opening fence (e.g. ````json`,
-/// ````markdown`), and return the inner content trimmed.
+///    strip the optional language label on the opening fence (e.g. ````json`,
+///    ````markdown`), and return the inner content trimmed.
 /// 3. If the last fence is unclosed (no matching closing `````) → treat
-/// everything after the opening fence line as the content.
+///    everything after the opening fence line as the content.
 public final class LlmResponseCleaner {
     private static final String FENCE = "```";
 

--- a/jablib/src/main/java/org/jabref/logic/ai/util/LlmResponseCleaner.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/util/LlmResponseCleaner.java
@@ -3,15 +3,15 @@ package org.jabref.logic.ai.util;
 import org.jspecify.annotations.Nullable;
 
 /// Cleans raw LLM response strings by extracting content from the last
-/// fenced code block (``` ... ```) if present, or simply trimming whitespace.
+/// fenced code block (`` ``` ... ``` ``) if present, or simply trimming whitespace.
 ///
 /// Rules:
-/// 1. If the response contains no ``` fences → return the string stripped of
+/// 1. If the response contains no `` ``` `` fences → return the string stripped of
 ///    leading/trailing whitespace.
-/// 2. If one or more ``` fences exist → find the *last* complete block,
-///    strip the optional language label on the opening fence (e.g. ````json`,
-///    ````markdown`), and return the inner content trimmed.
-/// 3. If the last fence is unclosed (no matching closing `````) → treat
+/// 2. If one or more `` ``` `` fences exist → find the *last* complete block,
+///    strip the optional language label on the opening fence (e.g. `` ```json ``
+///    or `` ```markdown ``), and return the inner content trimmed.
+/// 3. If the last fence is unclosed (no matching closing `` ``` ``) → treat
 ///    everything after the opening fence line as the content.
 public final class LlmResponseCleaner {
     private static final String FENCE = "```";

--- a/jablib/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
+++ b/jablib/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
@@ -1213,23 +1213,18 @@ public class BracketedPattern {
     ///
     ///
     /// Each part is examined separately:
-    /// <ol>
-    ///
-    /// - We remove all tokens of a part which are one of the defined ignore words (the, press), which end with a dot
-    /// (ltd., co., ...) and which first character is lowercase (of, on, di, ...).
-    /// - We detect the types of the part: university, technology institute,
-    /// department, school, rest
-    ///
-    /// - University: `"Uni[NameOfTheUniversity]"`
-    /// - Department: If the institution value contains more than one comma separated part, the department will be an
-    /// abbreviation of all words beginning with the uppercase letter except of words:
-    /// `d[ei]p.*`, school, faculty
-    /// - School: same as department
-    /// - Rest: If there are less than 3 tokens in such part than the result
-    /// is a concatenation of those tokens. Otherwise, the result will be built
-    /// from the first letter in each token.
-    ///
-    /// </ol>
+    /// 1. We remove all tokens of a part which are one of the defined ignore words (the, press), which end with a dot
+    ///    (ltd., co., ...) and which first character is lowercase (of, on, di, ...).
+    /// 2. We detect the types of the part: university, technology institute,
+    ///    department, school, rest
+    ///     - University: `"Uni[NameOfTheUniversity]"`
+    ///     - Department: If the institution value contains more than one comma separated part, the department will be an
+    ///       abbreviation of all words beginning with the uppercase letter except of words:
+    ///       `d[ei]p.*`, school, faculty
+    ///     - School: same as department
+    ///     - Rest: If there are less than 3 tokens in such part than the result
+    ///       is a concatenation of those tokens. Otherwise, the result will be built
+    ///       from the first letter in each token.
     ///
     /// Parts are concatenated together in the following way:
     ///

--- a/jablib/src/main/java/org/jabref/logic/crawler/Crawler.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/Crawler.java
@@ -54,13 +54,10 @@ public class Crawler {
     /// This method also persists the results in the same folder the study definition file is stored in.
     ///
     /// The whole process works as follows:
-    /// <ol>
-    ///
-    /// - Then the search is executed
-    /// - The repository changes to the search branch
-    /// - Afterwards, the results are persisted on the search branch.
-    /// - Finally, the changes are merged into the work branch
-    /// </ol>
+    /// 1. Then the search is executed
+    /// 2. The repository changes to the search branch
+    /// 3. Afterwards, the results are persisted on the search branch.
+    /// 4. Finally, the changes are merged into the work branch
     ///
     /// @throws IOException Thrown if a problem occurred during the persistence of the result.
     public void performCrawl() throws IOException, GitAPIException, SaveException, JabRefException {

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -233,15 +233,12 @@ public class StudyRepository {
 
     /// Persists the result locally and remotely by following the steps:
     /// Precondition: Currently checking out work branch
-    /// <ol>
-    ///
-    /// - Update the work and search branch
-    /// - Persist the results on the search branch
-    /// - Manually patch the diff of the search branch onto the work branch (as the merging will not work in
+    /// 1. Update the work and search branch
+    /// 2. Persist the results on the search branch
+    /// 3. Manually patch the diff of the search branch onto the work branch (as the merging will not work in
     /// certain cases without a conflict as it is context sensitive. But for this use case we do not need it to be
     /// context sensitive. So we can just prepend the patch without checking the "context" lines.
-    /// - Update the remote tracking branches of the work and search branch
-    /// </ol>
+    /// 4. Update the remote tracking branches of the work and search branch
     public void persist(List<QueryResult> crawlResults) throws IOException, GitAPIException, SaveException, JabRefException {
         updateWorkAndSearchBranch();
 

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -236,8 +236,8 @@ public class StudyRepository {
     /// 1. Update the work and search branch
     /// 2. Persist the results on the search branch
     /// 3. Manually patch the diff of the search branch onto the work branch (as the merging will not work in
-    /// certain cases without a conflict as it is context sensitive. But for this use case we do not need it to be
-    /// context sensitive. So we can just prepend the patch without checking the "context" lines.
+    ///    certain cases without a conflict as it is context sensitive. But for this use case we do not need it to be
+    ///    context sensitive. So we can just prepend the patch without checking the "context" lines.
     /// 4. Update the remote tracking branches of the work and search branch
     public void persist(List<QueryResult> crawlResults) throws IOException, GitAPIException, SaveException, JabRefException {
         updateWorkAndSearchBranch();

--- a/jablib/src/main/java/org/jabref/logic/icore/ConferenceRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/icore/ConferenceRepository.java
@@ -152,12 +152,9 @@ public class ConferenceRepository {
     ///
     /// While searching, the function computes Levenshtein similarity and LCS similarity between the query and the current conference
     /// title (also normalized) and prioritizes them in the following order:
-    /// <ol>
-    ///
-    /// - Whenever LCS similarity returns `1.0`, i.e., a conference title is found entirely as a substring in the query.
-    /// - Whenever Levenshtein similarity exceeds the threshold defined by the `LEVENSHTEIN_THRESHOLD` constant.
-    /// - The combined weighted score of both LCS and Levenshtein similarities exceeds the `COMBINED_LCS_LEV_THRESHOLD`.
-    /// </ol>
+    /// 1. Whenever LCS similarity returns `1.0`, i.e., a conference title is found entirely as a substring in the query.
+    /// 2. Whenever Levenshtein similarity exceeds the threshold defined by the `LEVENSHTEIN_THRESHOLD` constant.
+    /// 3. The combined weighted score of both LCS and Levenshtein similarities exceeds the `COMBINED_LCS_LEV_THRESHOLD`.
     ///
     /// The combined score is calculated as follows:
     /// `(0.6 * Levenshtein similarity) + (0.4 * LCS similarity)`

--- a/jablib/src/main/java/org/jabref/logic/icore/ConferenceUtils.java
+++ b/jablib/src/main/java/org/jabref/logic/icore/ConferenceUtils.java
@@ -163,17 +163,14 @@ public final class ConferenceUtils {
     ///
     /// The normalization process performs the following steps:
     ///
-    /// <ol>
-    ///
-    /// - Removes all substrings enclosed in parentheses, e.g., `"proceedings (ICSE 2022)"` -> `"Proceedings"`.
-    /// - Removes all years of form `19XX` or `20xx` (e.g., `1999`, `2022`) and ordinals in
+    /// 1. Removes all substrings enclosed in parentheses, e.g., `"proceedings (ICSE 2022)"` -> `"Proceedings"`.
+    /// 2. Removes all years of form `19XX` or `20xx` (e.g., `1999`, `2022`) and ordinals in
     /// regular form (e.g., `1st`, `2nd`, `3rd`) as well as in LaTeX syntax (e.g.,
     /// `3\textsuperscript{rd`} or `17\textsuperscript{th`}).
-    /// - Splits the input into alphanumeric tokens, discarding stopwords found in the `TITLE_STOPWORDS` set
+    /// 3. Splits the input into alphanumeric tokens, discarding stopwords found in the `TITLE_STOPWORDS` set
     /// (which includes months, or other common stopwords like `proceedings`, `papers`, etc.)
-    /// - Concatenates the remaining tokens into a normalized string without delimiters.
-    /// - Removes leading false-start tokens like `"ofthe"`, `"of"`, or `"the"`.
-    /// </ol>
+    /// 4. Concatenates the remaining tokens into a normalized string without delimiters.
+    /// 5. Removes leading false-start tokens like `"ofthe"`, `"of"`, or `"the"`.
     ///
     /// Note that the input is expected to already be lowercased before calling this method.
     ///

--- a/jablib/src/main/java/org/jabref/logic/icore/ConferenceUtils.java
+++ b/jablib/src/main/java/org/jabref/logic/icore/ConferenceUtils.java
@@ -165,10 +165,10 @@ public final class ConferenceUtils {
     ///
     /// 1. Removes all substrings enclosed in parentheses, e.g., `"proceedings (ICSE 2022)"` -> `"Proceedings"`.
     /// 2. Removes all years of form `19XX` or `20xx` (e.g., `1999`, `2022`) and ordinals in
-    /// regular form (e.g., `1st`, `2nd`, `3rd`) as well as in LaTeX syntax (e.g.,
-    /// `3\textsuperscript{rd`} or `17\textsuperscript{th`}).
+    ///    regular form (e.g., `1st`, `2nd`, `3rd`) as well as in LaTeX syntax (e.g.,
+    ///    `3\textsuperscript{rd`} or `17\textsuperscript{th`}).
     /// 3. Splits the input into alphanumeric tokens, discarding stopwords found in the `TITLE_STOPWORDS` set
-    /// (which includes months, or other common stopwords like `proceedings`, `papers`, etc.)
+    ///    (which includes months, or other common stopwords like `proceedings`, `papers`, etc.)
     /// 4. Concatenates the remaining tokens into a normalized string without delimiters.
     /// 5. Removes leading false-start tokens like `"ofthe"`, `"of"`, or `"the"`.
     ///

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -63,12 +63,9 @@ import org.xml.sax.SAXException;
 /// Fetcher for ArXiv that merges fields from arXiv-issued DOIs (and user-issued ones when applicable) to get more information overall.
 ///
 /// These are the post-processing steps applied to the original fetch from ArXiv's API:
-/// <ol>
-///
-/// - Use ArXiv-issued DOI to get more merge more data with original entry, overwriting some of those fields;
-/// - Use user-issued DOI (if it was provided) to merge even more data with the result of the previous step, overwriting some of those fields;
-/// - Modify keywords: remove repetitions and adapt some edge cases (commas in keyword transformed into forward slashes).
-/// </ol>
+/// 1. Use ArXiv-issued DOI to get more merge more data with original entry, overwriting some of those fields;
+/// 2. Use user-issued DOI (if it was provided) to merge even more data with the result of the previous step, overwriting some of those fields;
+/// 3. Modify keywords: remove repetitions and adapt some edge cases (commas in keyword transformed into forward slashes).
 ///
 /// @see <a href="https://blog.arxiv.org/2022/02/17/new-arxiv-articles-are-now-automatically-assigned-dois/">arXiv.org blog </a> for more info about arXiv-issued DOIs
 /// @see <a href="https://arxiv.org/help/api/index">ArXiv API</a> for an overview of the API

--- a/jablib/src/main/java/org/jabref/logic/integrity/UTF8Checker.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/UTF8Checker.java
@@ -17,11 +17,8 @@ public class UTF8Checker implements EntryChecker {
     private final Charset charset;
 
     /// Creates a UTF8Checker that,
-    /// <ol>
-    ///
-    /// - decode a String into a bytes array
-    /// - attempts to decode the bytes array to a character array using the UTF-8 Charset
-    /// </ol>
+    /// 1. decode a String into a bytes array
+    /// 2. attempts to decode the bytes array to a character array using the UTF-8 Charset
     ///
     /// @param charset the charset used to decode BibEntry fields
     public UTF8Checker(Charset charset) {

--- a/jablib/src/main/java/org/jabref/model/entry/AuthorList.java
+++ b/jablib/src/main/java/org/jabref/model/entry/AuthorList.java
@@ -15,13 +15,13 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
-/// This is an immutable class representing information of either <CODE>author</CODE> or <CODE>editor</CODE> field in bibtex record.
+/// This is an immutable class representing information of either `author` or `editor` field in bibtex record.
 ///
 /// Constructor performs parsing of raw field text and stores preformatted data. Various accessor methods return author/editor field in different formats.
 ///
 /// Parsing algorithm is designed to satisfy two requirements: (a) when author's name is typed correctly, the result should coincide with the one of BiBTeX; (b) for erroneous names, output should be reasonable (but may differ from BiBTeX output). The following rules are used:
 /// 1. 'author field' is a sequence of tokens;
-///     - tokens are separated by sequences of whitespaces (<CODE>Character.isWhitespace(c)==true</CODE>),
+///     - tokens are separated by sequences of whitespaces (`Character.isWhitespace(c)==true`),
 ///       commas (,), dashes (-), and tildas (~);
 ///     - every comma separates tokens, while sequences of other separators are
 ///       equivalent to a single separator; for example: "a - b" consists of 2 tokens
@@ -35,7 +35,7 @@ import org.jspecify.annotations.Nullable;
 ///     - for the purposes of splitting of 'author name' into parts and
 ///       construction of abbreviation of first name, one needs definitions of first
 ///       letter of a token, case of a token, and abbreviation of a token:
-///         - 'first letter' of a token is the first letter character (<CODE>Character.isLetter(c)==true</CODE>)
+///         - 'first letter' of a token is the first letter character (`Character.isLetter(c)==true`)
 ///           that does not belong to a sequence of letters that immediately follows "\"
 ///           character, with one exception: if "\" is followed by "aa", "AA", "ae", "AE",
 ///           "l", "L", "o", "O", "oe", "OE", "i", or "j" followed by non-letter, the
@@ -45,7 +45,7 @@ import org.jspecify.annotations.Nullable;
 ///           "A", in "\aex\ijk\Oe\j" 'first letter' is "j"; if there is no letter
 ///           satisfying the above rule, 'first letter' is undefined;
 ///         - token is "lower-case" token if its first letter is defined and is
-///           lower-case (<CODE>Character.isLowerCase(c)==true</CODE>), and token is
+///           lower-case (`Character.isLowerCase(c)==true`), and token is
 ///           "upper-case" token otherwise;
 ///         - 'abbreviation' of a token is the shortest prefix of the token that (a)
 ///           contains 'first letter' and (b) is braces-balanced; if 'first letter' is
@@ -244,17 +244,17 @@ public class AuthorList implements Iterable<Author> {
         return authors.isEmpty();
     }
 
-    /// Returns the <CODE>Author</CODE> object for the i-th author.
+    /// Returns the `Author` object for the i-th author.
     ///
-    /// @param i Index of the author (from 0 to <CODE>size()-1</CODE>).
-    /// @return the <CODE>Author</CODE> object.
+    /// @param i Index of the author (from 0 to `size()-1`).
+    /// @return the `Author` object.
     public Author getAuthor(int i) {
         return authors.get(i);
     }
 
-    /// Returns the list of <CODE>Author</CODE> objects.
+    /// Returns the list of `Author` objects.
     ///
-    /// @return the <CODE>List&lt;Author></CODE> object.
+    /// @return the `List<Author>` object.
     public List<Author> getAuthors() {
         return authors;
     }

--- a/jablib/src/main/java/org/jabref/model/entry/AuthorList.java
+++ b/jablib/src/main/java/org/jabref/model/entry/AuthorList.java
@@ -20,102 +20,93 @@ import org.jspecify.annotations.Nullable;
 /// Constructor performs parsing of raw field text and stores preformatted data. Various accessor methods return author/editor field in different formats.
 ///
 /// Parsing algorithm is designed to satisfy two requirements: (a) when author's name is typed correctly, the result should coincide with the one of BiBTeX; (b) for erroneous names, output should be reasonable (but may differ from BiBTeX output). The following rules are used:
-/// <ol>
-///
-/// -  'author field' is a sequence of tokens;
-///
-/// -  tokens are separated by sequences of whitespaces (<CODE>Character.isWhitespace(c)==true</CODE>),
-/// commas (,), dashes (-), and tildas (~);
-/// -  every comma separates tokens, while sequences of other separators are
-/// equivalent to a single separator; for example: "a - b" consists of 2 tokens
-/// ("a" and "b"), while "a,-,b" consists of 3 tokens ("a", "", and "b")
-/// -  anything enclosed in braces belongs to a single token; for example:
-/// "abc x{a,b,-~ c}x" consists of 2 tokens, while "abc xa,b,-~ cx" consists of 4
-/// tokens ("abc", "xa","b", and "cx");
-/// -  a token followed immediately by a dash is "dash-terminated" token, and
-/// all other tokens are "space-terminated" tokens; for example: in "a-b- c - d"
-/// tokens "a" and "b" are dash-terminated and "c" and "d" are space-terminated;
-/// -  for the purposes of splitting of 'author name' into parts and
-/// construction of abbreviation of first name, one needs definitions of first
-/// letter of a token, case of a token, and abbreviation of a token:
-///
-/// -  'first letter' of a token is the first letter character (<CODE>Character.isLetter(c)==true</CODE>)
-/// that does not belong to a sequence of letters that immediately follows "\"
-/// character, with one exception: if "\" is followed by "aa", "AA", "ae", "AE",
-/// "l", "L", "o", "O", "oe", "OE", "i", or "j" followed by non-letter, the
-/// 'first letter' of a token is a letter that follows "\"; for example: in
-/// "a{x}b" 'first letter' is "a", in "{\"{U}}bel" 'first letter' is "U", in
-/// "{\noopsort{\"o}}xyz" 'first letter' is "o", in "{\AE}x" 'first letter' is
-/// "A", in "\aex\ijk\Oe\j" 'first letter' is "j"; if there is no letter
-/// satisfying the above rule, 'first letter' is undefined;
-/// -  token is "lower-case" token if its first letter is defined and is
-/// lower-case (<CODE>Character.isLowerCase(c)==true</CODE>), and token is
-/// "upper-case" token otherwise;
-/// -  'abbreviation' of a token is the shortest prefix of the token that (a)
-/// contains 'first letter' and (b) is braces-balanced; if 'first letter' is
-/// undefined, 'abbreviation' is the token itself; in the above examples,
-/// 'abbreviation's are "a", "{\"{U}}", "{\noopsort{\"o}}", "{\AE}",
-/// "\aex\ijk\Oe\j";
-///
-/// -  the behavior based on the above definitions will be erroneous only in
-/// one case: if the first-name-token is "{\noopsort{A}}john", we abbreviate it
-/// as "{\noopsort{A}}.", while BiBTeX produces "j."; fixing this problem,
-/// however, requires processing of the preabmle;
-///
-/// -  'author names' in 'author field' are subsequences of tokens separated by
-/// token "and" ("and" is case-insensitive); if 'author name' is an empty
-/// sequence of tokens, it is ignored; for examle, both "John Smith and Peter
-/// Black" and "and and John Smith and and Peter Black" consists of 2 'author
-/// name's "Johm Smith" and "Peter Black" (in erroneous situations, this is a bit
-/// different from BiBTeX behavior);
-/// -  'author name' consists of 'first-part', 'von-part', 'last-part', and
-/// 'junior-part', each of which is a sequence of tokens; how a sequence of
-/// tokens has to be split into these parts, depends the number of commas:
-///
-/// -  no commas, all tokens are upper-case: 'junior-part' and 'von-part' are
-/// empty, 'last-part' consist of the last token, 'first-part' consists of all
-/// other tokens ('first-part' is empty if 'author name' consists of a single
-/// token); for example, in "John James Smith", 'last-part'="Smith" and
-/// 'first-part'="John James";
-/// -  no commas, there exists lower-case token: 'junior-part' is empty,
-/// 'first-part' consists of all upper-case tokens before the first lower-case
-/// token, 'von-part' consists of lower-case tokens starting the first lower-case
-/// token and ending the lower-case token that is followed by upper-case token,
-/// 'last-part' consists of the rest of tokens; note that both 'first-part' and
-/// 'latst-part' may be empty and 'last-part' may contain lower-case tokens; for
-/// example: in "von der", 'first-part'='last-part'="", 'von-part'="von der"; in
-/// "Charles Louis Xavier Joseph de la Vall{\'e}e la Poussin",
-/// 'first-part'="Charles Louis Xavier Joseph", 'von-part'="de la",
-/// 'last-part'="Vall{\'e}e la Poussin";
-/// -  one comma: 'junior-part' is empty, 'first-part' consists of all tokens
-/// after comma, 'von-part' consists of the longest sequence of lower-case tokens
-/// in the very beginning, 'last-part' consists of all tokens after 'von-part'
-/// and before comma; note that any part can be empty; for example: in "de la
-/// Vall{\'e}e la Poussin, Charles Louis Xavier Joseph", 'first-part'="Charles
-/// Louis Xavier Joseph", 'von-part'="de la", 'last-part'="Vall{\'e}e la
-/// Poussin"; in "Joseph de la Vall{\'e}e la Poussin, Charles Louis Xavier",
-/// 'first-part'="Charles Louis Xavier", 'von-part'="", 'last-part'="Joseph de la
-/// Vall{\'e}e la Poussin";
-/// -  two or more commas (any comma after the second one is ignored; it merely
-/// separates tokens): 'junior-part' consists of all tokens between first and
-/// second commas, 'first-part' consists of all tokens after the second comma,
-/// tokens before the first comma are split into 'von-part' and 'last-part'
-/// similarly to the case of one comma; for example: in "de la Vall{\'e}e
-/// Poussin, Jr., Charles Louis Xavier Joseph", 'first-part'="Charles Louis
-/// Xavier Joseph", 'von-part'="de la", 'last-part'="Vall{\'e}e la Poussin", and
-/// 'junior-part'="Jr.";
-///
-/// -  when 'first-part', 'last-part', 'von-part', or 'junior-part' is
-/// reconstructed from tokens, tokens in a part are separated either by space or
-/// by dash, depending on whether the token before the separator was
-/// space-terminated or dash-terminated; for the last token in a part it does not
-/// matter whether it was dash- or space-terminated;
-/// -  when 'first-part' is abbreviated, each token is replaced by its
-/// abbreviation followed by a period; separators are the same as in the case of
-/// non-abbreviated name; for example: in "Heinrich-{\"{U}}bel Kurt von Minich",
-/// 'first-part'="Heinrich-{\"{U}}bel Kurt", and its abbreviation is "H.-{\"{U}}.
-/// K."
-/// </ol>
+/// 1. 'author field' is a sequence of tokens;
+///     - tokens are separated by sequences of whitespaces (<CODE>Character.isWhitespace(c)==true</CODE>),
+///       commas (,), dashes (-), and tildas (~);
+///     - every comma separates tokens, while sequences of other separators are
+///       equivalent to a single separator; for example: "a - b" consists of 2 tokens
+///       ("a" and "b"), while "a,-,b" consists of 3 tokens ("a", "", and "b")
+///     - anything enclosed in braces belongs to a single token; for example:
+///       "abc x{a,b,-~ c}x" consists of 2 tokens, while "abc xa,b,-~ cx" consists of 4
+///       tokens ("abc", "xa","b", and "cx");
+///     - a token followed immediately by a dash is "dash-terminated" token, and
+///       all other tokens are "space-terminated" tokens; for example: in "a-b- c - d"
+///       tokens "a" and "b" are dash-terminated and "c" and "d" are space-terminated;
+///     - for the purposes of splitting of 'author name' into parts and
+///       construction of abbreviation of first name, one needs definitions of first
+///       letter of a token, case of a token, and abbreviation of a token:
+///         - 'first letter' of a token is the first letter character (<CODE>Character.isLetter(c)==true</CODE>)
+///           that does not belong to a sequence of letters that immediately follows "\"
+///           character, with one exception: if "\" is followed by "aa", "AA", "ae", "AE",
+///           "l", "L", "o", "O", "oe", "OE", "i", or "j" followed by non-letter, the
+///           'first letter' of a token is a letter that follows "\"; for example: in
+///           "a{x}b" 'first letter' is "a", in "{\"{U}}bel" 'first letter' is "U", in
+///           "{\noopsort{\"o}}xyz" 'first letter' is "o", in "{\AE}x" 'first letter' is
+///           "A", in "\aex\ijk\Oe\j" 'first letter' is "j"; if there is no letter
+///           satisfying the above rule, 'first letter' is undefined;
+///         - token is "lower-case" token if its first letter is defined and is
+///           lower-case (<CODE>Character.isLowerCase(c)==true</CODE>), and token is
+///           "upper-case" token otherwise;
+///         - 'abbreviation' of a token is the shortest prefix of the token that (a)
+///           contains 'first letter' and (b) is braces-balanced; if 'first letter' is
+///           undefined, 'abbreviation' is the token itself; in the above examples,
+///           'abbreviation's are "a", "{\"{U}}", "{\noopsort{\"o}}", "{\AE}",
+///           "\aex\ijk\Oe\j";
+///     - the behavior based on the above definitions will be erroneous only in
+///       one case: if the first-name-token is "{\noopsort{A}}john", we abbreviate it
+///       as "{\noopsort{A}}.", while BiBTeX produces "j."; fixing this problem,
+///       however, requires processing of the preabmle;
+/// 2. 'author names' in 'author field' are subsequences of tokens separated by
+///    token "and" ("and" is case-insensitive); if 'author name' is an empty
+///    sequence of tokens, it is ignored; for examle, both "John Smith and Peter
+///    Black" and "and and John Smith and and Peter Black" consists of 2 'author
+///    name's "Johm Smith" and "Peter Black" (in erroneous situations, this is a bit
+///    different from BiBTeX behavior);
+/// 3. 'author name' consists of 'first-part', 'von-part', 'last-part', and
+///    'junior-part', each of which is a sequence of tokens; how a sequence of
+///    tokens has to be split into these parts, depends the number of commas:
+///     - no commas, all tokens are upper-case: 'junior-part' and 'von-part' are
+///       empty, 'last-part' consist of the last token, 'first-part' consists of all
+///       other tokens ('first-part' is empty if 'author name' consists of a single
+///       token); for example, in "John James Smith", 'last-part'="Smith" and
+///       'first-part'="John James";
+///     - no commas, there exists lower-case token: 'junior-part' is empty,
+///       'first-part' consists of all upper-case tokens before the first lower-case
+///       token, 'von-part' consists of lower-case tokens starting the first lower-case
+///       token and ending the lower-case token that is followed by upper-case token,
+///       'last-part' consists of the rest of tokens; note that both 'first-part' and
+///       'latst-part' may be empty and 'last-part' may contain lower-case tokens; for
+///       example: in "von der", 'first-part'='last-part'="", 'von-part'="von der"; in
+///       "Charles Louis Xavier Joseph de la Vall{\'e}e la Poussin",
+///       'first-part'="Charles Louis Xavier Joseph", 'von-part'="de la",
+///       'last-part'="Vall{\'e}e la Poussin";
+///     - one comma: 'junior-part' is empty, 'first-part' consists of all tokens
+///       after comma, 'von-part' consists of the longest sequence of lower-case tokens
+///       in the very beginning, 'last-part' consists of all tokens after 'von-part'
+///       and before comma; note that any part can be empty; for example: in "de la
+///       Vall{\'e}e la Poussin, Charles Louis Xavier Joseph", 'first-part'="Charles
+///       Louis Xavier Joseph", 'von-part'="de la", 'last-part'="Vall{\'e}e la
+///       Poussin"; in "Joseph de la Vall{\'e}e la Poussin, Charles Louis Xavier",
+///       'first-part'="Charles Louis Xavier", 'von-part'="", 'last-part'="Joseph de la
+///       Vall{\'e}e la Poussin";
+///     - two or more commas (any comma after the second one is ignored; it merely
+///       separates tokens): 'junior-part' consists of all tokens between first and
+///       second commas, 'first-part' consists of all tokens after the second comma,
+///       tokens before the first comma are split into 'von-part' and 'last-part'
+///       similarly to the case of one comma; for example: in "de la Vall{\'e}e
+///       Poussin, Jr., Charles Louis Xavier Joseph", 'first-part'="Charles Louis
+///       Xavier Joseph", 'von-part'="de la", 'last-part'="Vall{\'e}e la Poussin", and
+///       'junior-part'="Jr.";
+/// 4. when 'first-part', 'last-part', 'von-part', or 'junior-part' is
+///    reconstructed from tokens, tokens in a part are separated either by space or
+///    by dash, depending on whether the token before the separator was
+///    space-terminated or dash-terminated; for the last token in a part it does not
+///    matter whether it was dash- or space-terminated;
+/// 5. when 'first-part' is abbreviated, each token is replaced by its
+///    abbreviation followed by a period; separators are the same as in the case of
+///    non-abbreviated name; for example: in "Heinrich-{\"{U}}bel Kurt von Minich",
+///    'first-part'="Heinrich-{\"{U}}bel Kurt", and its abbreviation is "H.-{\"{U}}.
+///    K."
 @AllowedToUseLogic("because it needs access to AuthorList parser")
 public class AuthorList implements Iterable<Author> {
     private static final int AUTHOR_CACHE_SIZE = 50_000;

--- a/jablib/src/main/java/org/jabref/model/entry/AuthorList.java
+++ b/jablib/src/main/java/org/jabref/model/entry/AuthorList.java
@@ -24,25 +24,28 @@ import org.jspecify.annotations.Nullable;
 ///     - tokens are separated by sequences of whitespaces (`Character.isWhitespace(c)==true`),
 ///       commas (,), dashes (-), and tildas (~);
 ///     - every comma separates tokens, while sequences of other separators are
-///       equivalent to a single separator; for example: "a - b" consists of 2 tokens
-///       ("a" and "b"), while "a,-,b" consists of 3 tokens ("a", "", and "b")
+///       equivalent to a single separator; for example: `"a - b"` consists of
+///       2 tokens (`"a"` and `"b"`), while `"a,-,b"` consists of 3 tokens
+///       (`"a"`, `""`, and `"b"`)
 ///     - anything enclosed in braces belongs to a single token; for example:
-///       "abc x{a,b,-~ c}x" consists of 2 tokens, while "abc xa,b,-~ cx" consists of 4
-///       tokens ("abc", "xa","b", and "cx");
+///       `"abc x{a,b,-~ c}x"` consists of 2 tokens, while `"abc xa,b,-~ cx"`
+///       consists of 4 tokens (`"abc"`, `"xa"`, `"b"`, and `"cx"`);
 ///     - a token followed immediately by a dash is "dash-terminated" token, and
-///       all other tokens are "space-terminated" tokens; for example: in "a-b- c - d"
-///       tokens "a" and "b" are dash-terminated and "c" and "d" are space-terminated;
+///       all other tokens are "space-terminated" tokens; for example: in
+///       `"a-b- c - d"` tokens `"a"` and `"b"` are dash-terminated and `"c"`
+///       and `"d"` are space-terminated;
 ///     - for the purposes of splitting of 'author name' into parts and
 ///       construction of abbreviation of first name, one needs definitions of first
 ///       letter of a token, case of a token, and abbreviation of a token:
 ///         - 'first letter' of a token is the first letter character (`Character.isLetter(c)==true`)
-///           that does not belong to a sequence of letters that immediately follows "\"
-///           character, with one exception: if "\" is followed by "aa", "AA", "ae", "AE",
-///           "l", "L", "o", "O", "oe", "OE", "i", or "j" followed by non-letter, the
-///           'first letter' of a token is a letter that follows "\"; for example: in
-///           "a{x}b" 'first letter' is "a", in "{\"{U}}bel" 'first letter' is "U", in
-///           "{\noopsort{\"o}}xyz" 'first letter' is "o", in "{\AE}x" 'first letter' is
-///           "A", in "\aex\ijk\Oe\j" 'first letter' is "j"; if there is no letter
+///           that does not belong to a sequence of letters that immediately follows
+///           the `\` character, with one exception: if `\` is followed by `aa`,
+///           `AA`, `ae`, `AE`, `l`, `L`, `o`, `O`, `oe`, `OE`, `i`, or `j`
+///           followed by non-letter, the 'first letter' of a token is a letter
+///           that follows `\`; for example: in `"a{x}b"` 'first letter' is `"a"`,
+///           in `"{\"{U}}bel"` 'first letter' is `"U"`, in `"{\noopsort{\"o}}xyz"`
+///           'first letter' is `"o"`, in `"{\AE}x"` 'first letter' is `"A"`, in
+///           `"\aex\ijk\Oe\j"` 'first letter' is `"j"`; if there is no letter
 ///           satisfying the above rule, 'first letter' is undefined;
 ///         - token is "lower-case" token if its first letter is defined and is
 ///           lower-case (`Character.isLowerCase(c)==true`), and token is
@@ -50,17 +53,18 @@ import org.jspecify.annotations.Nullable;
 ///         - 'abbreviation' of a token is the shortest prefix of the token that (a)
 ///           contains 'first letter' and (b) is braces-balanced; if 'first letter' is
 ///           undefined, 'abbreviation' is the token itself; in the above examples,
-///           'abbreviation's are "a", "{\"{U}}", "{\noopsort{\"o}}", "{\AE}",
-///           "\aex\ijk\Oe\j";
+///           'abbreviation's are `"a"`, `"{\"{U}}"`, `"{\noopsort{\"o}}"`,
+///           `"{\AE}"`, `"\aex\ijk\Oe\j"`;
 ///     - the behavior based on the above definitions will be erroneous only in
-///       one case: if the first-name-token is "{\noopsort{A}}john", we abbreviate it
-///       as "{\noopsort{A}}.", while BiBTeX produces "j."; fixing this problem,
-///       however, requires processing of the preabmle;
+///       one case: if the first-name-token is `"{\noopsort{A}}john"`, we
+///       abbreviate it as `"{\noopsort{A}}."`, while BiBTeX produces `"j."`;
+///       fixing this problem, however, requires processing of the preabmle;
 /// 2. 'author names' in 'author field' are subsequences of tokens separated by
-///    token "and" ("and" is case-insensitive); if 'author name' is an empty
-///    sequence of tokens, it is ignored; for examle, both "John Smith and Peter
-///    Black" and "and and John Smith and and Peter Black" consists of 2 'author
-///    name's "Johm Smith" and "Peter Black" (in erroneous situations, this is a bit
+///    token `and` (`and` is case-insensitive); if 'author name' is an empty
+///    sequence of tokens, it is ignored; for examle, both
+///    `"John Smith and Peter Black"` and
+///    `"and and John Smith and and Peter Black"` consists of 2 'author name's
+///    `"Johm Smith"` and `"Peter Black"` (in erroneous situations, this is a bit
 ///    different from BiBTeX behavior);
 /// 3. 'author name' consists of 'first-part', 'von-part', 'last-part', and
 ///    'junior-part', each of which is a sequence of tokens; how a sequence of
@@ -68,35 +72,37 @@ import org.jspecify.annotations.Nullable;
 ///     - no commas, all tokens are upper-case: 'junior-part' and 'von-part' are
 ///       empty, 'last-part' consist of the last token, 'first-part' consists of all
 ///       other tokens ('first-part' is empty if 'author name' consists of a single
-///       token); for example, in "John James Smith", 'last-part'="Smith" and
-///       'first-part'="John James";
+///       token); for example, in `"John James Smith"`, `'last-part'="Smith"` and
+///       `'first-part'="John James"`;
 ///     - no commas, there exists lower-case token: 'junior-part' is empty,
 ///       'first-part' consists of all upper-case tokens before the first lower-case
 ///       token, 'von-part' consists of lower-case tokens starting the first lower-case
 ///       token and ending the lower-case token that is followed by upper-case token,
 ///       'last-part' consists of the rest of tokens; note that both 'first-part' and
 ///       'latst-part' may be empty and 'last-part' may contain lower-case tokens; for
-///       example: in "von der", 'first-part'='last-part'="", 'von-part'="von der"; in
-///       "Charles Louis Xavier Joseph de la Vall{\'e}e la Poussin",
-///       'first-part'="Charles Louis Xavier Joseph", 'von-part'="de la",
-///       'last-part'="Vall{\'e}e la Poussin";
+///       example: in `"von der"`, `'first-part'='last-part'=""`,
+///       `'von-part'="von der"`; in
+///       `"Charles Louis Xavier Joseph de la Vall{\'e}e la Poussin"`,
+///       `'first-part'="Charles Louis Xavier Joseph"`, `'von-part'="de la"`,
+///       `'last-part'="Vall{\'e}e la Poussin"`;
 ///     - one comma: 'junior-part' is empty, 'first-part' consists of all tokens
 ///       after comma, 'von-part' consists of the longest sequence of lower-case tokens
 ///       in the very beginning, 'last-part' consists of all tokens after 'von-part'
-///       and before comma; note that any part can be empty; for example: in "de la
-///       Vall{\'e}e la Poussin, Charles Louis Xavier Joseph", 'first-part'="Charles
-///       Louis Xavier Joseph", 'von-part'="de la", 'last-part'="Vall{\'e}e la
-///       Poussin"; in "Joseph de la Vall{\'e}e la Poussin, Charles Louis Xavier",
-///       'first-part'="Charles Louis Xavier", 'von-part'="", 'last-part'="Joseph de la
-///       Vall{\'e}e la Poussin";
+///       and before comma; note that any part can be empty; for example: in
+///       `"de la Vall{\'e}e la Poussin, Charles Louis Xavier Joseph"`,
+///       `'first-part'="Charles Louis Xavier Joseph"`, `'von-part'="de la"`,
+///       `'last-part'="Vall{\'e}e la Poussin"`; in
+///       `"Joseph de la Vall{\'e}e la Poussin, Charles Louis Xavier"`,
+///       `'first-part'="Charles Louis Xavier"`, `'von-part'=""`,
+///       `'last-part'="Joseph de la Vall{\'e}e la Poussin"`;
 ///     - two or more commas (any comma after the second one is ignored; it merely
 ///       separates tokens): 'junior-part' consists of all tokens between first and
 ///       second commas, 'first-part' consists of all tokens after the second comma,
 ///       tokens before the first comma are split into 'von-part' and 'last-part'
-///       similarly to the case of one comma; for example: in "de la Vall{\'e}e
-///       Poussin, Jr., Charles Louis Xavier Joseph", 'first-part'="Charles Louis
-///       Xavier Joseph", 'von-part'="de la", 'last-part'="Vall{\'e}e la Poussin", and
-///       'junior-part'="Jr.";
+///       similarly to the case of one comma; for example: in
+///       `"de la Vall{\'e}e Poussin, Jr., Charles Louis Xavier Joseph"`,
+///       `'first-part'="Charles Louis Xavier Joseph"`, `'von-part'="de la"`,
+///       `'last-part'="Vall{\'e}e la Poussin"`, and `'junior-part'="Jr."`;
 /// 4. when 'first-part', 'last-part', 'von-part', or 'junior-part' is
 ///    reconstructed from tokens, tokens in a part are separated either by space or
 ///    by dash, depending on whether the token before the separator was
@@ -104,9 +110,9 @@ import org.jspecify.annotations.Nullable;
 ///    matter whether it was dash- or space-terminated;
 /// 5. when 'first-part' is abbreviated, each token is replaced by its
 ///    abbreviation followed by a period; separators are the same as in the case of
-///    non-abbreviated name; for example: in "Heinrich-{\"{U}}bel Kurt von Minich",
-///    'first-part'="Heinrich-{\"{U}}bel Kurt", and its abbreviation is "H.-{\"{U}}.
-///    K."
+///    non-abbreviated name; for example: in `"Heinrich-{\"{U}}bel Kurt von Minich"`,
+///    `'first-part'="Heinrich-{\"{U}}bel Kurt"`, and its abbreviation is
+///    `"H.-{\"{U}}. K."`
 @AllowedToUseLogic("because it needs access to AuthorList parser")
 public class AuthorList implements Iterable<Author> {
     private static final int AUTHOR_CACHE_SIZE = 50_000;

--- a/jablib/src/test/java/org/jabref/logic/importer/fileformat/MedlineImporterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fileformat/MedlineImporterTest.java
@@ -16,14 +16,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /// Articles in the medline format can be downloaded from http://www.ncbi.nlm.nih.gov/pubmed/.
-/// <ol>
-///
-/// - Search for a term and make sure you have selected the **PubMed** database.
-/// - Select the results you want to export by checking their checkboxes.
-/// - Press on the **'Send to'** drop down menu on top of the search results.
-/// - Select **'File'** as Destination and **'XML'** as Format.
-/// - Press **'Create File'** to download your search results in a medline xml file.
-/// </ol>
+/// 1. Search for a term and make sure you have selected the **PubMed** database.
+/// 2. Select the results you want to export by checking their checkboxes.
+/// 3. Press on the **'Send to'** drop down menu on top of the search results.
+/// 4. Select **'File'** as Destination and **'XML'** as Format.
+/// 5. Press **'Create File'** to download your search results in a medline xml file.
 class MedlineImporterTest {
 
     private static final String AALTO_INPUT_FACTORY = "com.fasterxml.aalto.stax.InputFactoryImpl";


### PR DESCRIPTION
### Summary

🤖 A previous Markdown-Javadoc cleanup left `<ol>`/`</ol>` (and one `<ul>`/`<li>`) HTML tags around already-converted `-` bullet items in `///` doc comments, so those lists rendered broken. The leftover tags are removed and ordered lists now use Markdown `1.`, `2.`, … numbering; the originally nested lists in `AuthorList` and `BracketedPattern` got their nesting back.

`jabref-contrib-policy:4.2:reviewed​:ok`

**Analogies:** Like honey, numbered Markdown lists flow smoothly where stray HTML tags stick to everything. Like chocolate, the doc comments are now uniformly smooth with no foil left in the bar. Like the moon, the original list structure was always there — it just needed the obscuring tags to pass.

### Steps to test

1. `./gradlew :jablib:javadoc` and open the generated `AuthorList.html` — the parsing rules render as a numbered list with nested bullets.
2. `grep -rn '///.*<ol>' jablib jabgui` finds nothing.

### Related issues and pull requests

Follow-up to https://github.com/JabRef/jabref/pull/16765

### AI usage

Claude Code (model claude-fable-5), AIL4 — task specified by the maintainer, change generated and verified by the AI, reviewed by the contributor.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

#### 1. Code self-review

##### Nullability and control flow

- [/] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [/] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [/] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

(Not applicable: comment-only change, no code touched.)

##### Exceptions

- [/] No `catch (Exception e)` — only specific exceptions are caught.
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [/] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

(Not applicable: comment-only change.)

##### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [/] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

##### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

##### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

##### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [/] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.
- [/] Fetcher tests hit the live endpoints — the remote API is not mocked or stubbed (automated-review suggestions to mock it are rejected on purpose).

#### 2. Verification commands

- [x] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [x] `./gradlew modernizer`.
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [x] `./gradlew javadoc`.
- [/] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [x] Only if formatting is still off after `rewriteRun`: intellij-format container run — touched files verified byte-identical under IU-2026.2.1.

#### 3. Documentation

- [/] `CHANGELOG.md` entry added if the change is visible to the user.
- [x] Searched issues for a related issue; none — follow-up to PR github.com/JabRef/jabref/pull/16765.
- [/] Requirement added to `docs/requirements/<area>.md` (internal doc-comment cleanup).
- [/] Developer documentation under `docs/` updated if behavior or architecture changed.

#### 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] `TODO` placeholder replacement (no CHANGELOG entry).

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
