### PR TITLE
Merge the PR's base branch instead of main in the conflict automation

### DIFF
--- a/.github/actions/merge-upstream-branch/action.yml
+++ b/.github/actions/merge-upstream-branch/action.yml
@@ -1,10 +1,14 @@
-name: "Merge upstream main"
-description: "Merges upstream/main into the current branch, resolving CHANGELOG.md conflicts semantically, and pushes the merge commit. The changelog merge driver is run from source via jbang, so driver fixes apply without waiting for a maven-flow/merge release."
+name: "Merge upstream branch"
+description: "Merges a branch of JabRef/jabref (the PR's base branch, main by default) into the current branch, resolving CHANGELOG.md conflicts semantically, and pushes the merge commit. The changelog merge driver is run from source via jbang, so driver fixes apply without waiting for a maven-flow/merge release."
 
 inputs:
   target-branch:
     description: "Branch to push the merge commit to"
     required: true
+  base-branch:
+    description: "Branch of JabRef/jabref to merge - the PR's base branch, which is another PR's head branch for stacked PRs"
+    required: false
+    default: "main"
   driver-revision:
     description: "Commit of maven-flow/changelog-merge-driver to run (immutable pin; bump explicitly to pick up driver fixes)"
     required: false
@@ -30,13 +34,17 @@ runs:
         path: ~/.jbang
         key: jbang-changelog-merge-driver-${{ inputs.driver-revision }}
 
-    - name: Merge upstream/main
+    - name: Merge upstream/${{ inputs.base-branch }}
       shell: bash
       env:
         TARGET_BRANCH: ${{ inputs.target-branch }}
+        BASE_BRANCH: ${{ inputs.base-branch }}
         DRIVER_REVISION: ${{ inputs.driver-revision }}
       run: |
         set -ex
+        # The PR head may live in a fork; the base branch always comes from JabRef/jabref
+        git remote add upstream "https://github.com/JabRef/jabref.git" || true
+        git fetch upstream "$BASE_BRANCH"
         jbang trust add https://github.com/maven-flow/changelog-merge-driver/
         # Pinned to an immutable commit - never the repo's mutable HEAD/alias - since the
         # driver runs with a push-capable token in this job.
@@ -45,5 +53,5 @@ runs:
         echo "CHANGELOG.md merge=changelog" >> "$(git rev-parse --git-dir)/info/attributes"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git config user.name "github-actions[bot]"
-        git merge --no-ff --no-edit upstream/main
+        git merge --no-ff --no-edit "upstream/$BASE_BRANCH"
         git push origin "HEAD:refs/heads/$TARGET_BRANCH"

--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -155,12 +155,12 @@
     Your pull request conflicts with the target branch.
 
 
-    Please [merge `upstream/main`](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork#syncing-a-fork-branch-from-the-command-line) with your code.
+    Please [merge the target branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork#syncing-a-fork-branch-from-the-command-line) (`upstream/main` unless the pull request is stacked on another one) with your code.
     For a step-by-step guide to resolve merge conflicts, see <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line>.
 
 
     We strongly recommend using the command line for this process.
-    Using `git merge upstream/main` causes fewer issues with `CHANGELOG.md` and git submodules than most IDE-based tools.
+    Using `git merge upstream/<target branch>` causes fewer issues with `CHANGELOG.md` and git submodules than most IDE-based tools.
 - jobName: 'Source branch is other than "main"'
   workflowName: 'Check PR Modifications'
   message: >

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       pr:
-        description: 'PR number to merge main into'
+        description: 'PR number whose base branch (main, or the next lower PR of a stack) is merged into it'
         required: true
         type: number
 
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Resolve the PR head repo and branch for BOTH triggers. On pull_request the PR may
-      # come from a fork, so we must check out the head repo, not github.repository (the base) -
-      # otherwise the head branch does not exist in the checked-out repo and checkout fails.
+      # Resolve the PR head repo, head branch, and base branch for BOTH triggers. On pull_request
+      # the PR may come from a fork, so we must check out the head repo, not github.repository
+      # (the base) - otherwise the head branch does not exist in the checked-out repo and checkout fails.
       - name: Resolve PR head repo and branch
         id: resolve
         env:
@@ -38,14 +38,16 @@ jobs:
           PR_NUMBER: ${{ inputs.pr }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
           if [ "$EVENT" = "workflow_dispatch" ]; then
-            gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName,headRepositoryOwner,headRepository \
-              --jq '"branch=\(.headRefName)\nrepo=\(.headRepositoryOwner.login)/\(.headRepository.name)"' >> "$GITHUB_OUTPUT"
+            gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName,headRepositoryOwner,headRepository,baseRefName \
+              --jq '"branch=\(.headRefName)\nrepo=\(.headRepositoryOwner.login)/\(.headRepository.name)\nbase=\(.baseRefName)"' >> "$GITHUB_OUTPUT"
           else
             echo "branch=$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
             echo "repo=$PR_HEAD_REPO" >> "$GITHUB_OUTPUT"
+            echo "base=$PR_BASE_REF" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout
@@ -57,18 +59,14 @@ jobs:
           ref: ${{ steps.resolve.outputs.branch }}
           token: ${{ secrets.GH_TOKEN_JABREF_MACHINE_PR_APPROVE || github.token }}
 
-      # The PR may live in a fork ("repository" above); always merge main of JabRef/jabref
-      - name: Fetch upstream main
-        run: |
-          set -ex
-          git remote add upstream "https://github.com/JabRef/jabref.git" || true
-          git fetch upstream main
-
       # Pushes the merge commit back to the PR branch (the reason this workflow exists).
       # "$/" resolves the action from this workflow's own commit, not from the workspace -
       # the workspace holds the PR head (possibly a fork), whose copy of the action must
       # never run with write credentials.
-      - name: Merge main
-        uses: $/.github/actions/merge-upstream-main
+      # The PR may live in a fork ("repository" above); the base branch is always taken from
+      # JabRef/jabref. For a stacked PR, the base is the next lower PR's head branch, not main.
+      - name: Merge ${{ steps.resolve.outputs.base }}
+        uses: $/.github/actions/merge-upstream-branch
         with:
           target-branch: ${{ steps.resolve.outputs.branch }}
+          base-branch: ${{ steps.resolve.outputs.base }}

--- a/.github/workflows/on-pr-opened-updated.yml
+++ b/.github/workflows/on-pr-opened-updated.yml
@@ -43,8 +43,8 @@ jobs:
         run: |
           set -ex
           # approved_automerge is read before the merge commit below is pushed: that push may dismiss the approval.
-          gh pr view "$PR_NUMBER" --json headRefName,headRepositoryOwner,headRepository,maintainerCanModify,reviewDecision,autoMergeRequest \
-            --jq '"head_ref=\(.headRefName)\nhead_repo=\(.headRepositoryOwner.login)/\(.headRepository.name)\nmaintainer_can_modify=\(.maintainerCanModify)\napproved_automerge=\(.reviewDecision == "APPROVED" and .autoMergeRequest != null)"' \
+          gh pr view "$PR_NUMBER" --json headRefName,headRepositoryOwner,headRepository,baseRefName,maintainerCanModify,reviewDecision,autoMergeRequest \
+            --jq '"head_ref=\(.headRefName)\nhead_repo=\(.headRepositoryOwner.login)/\(.headRepository.name)\nbase_ref=\(.baseRefName)\nmaintainer_can_modify=\(.maintainerCanModify)\napproved_automerge=\(.reviewDecision == "APPROVED" and .autoMergeRequest != null)"' \
             >> $GITHUB_OUTPUT
       - name: Check PR mergeability
         id: check_mergeable
@@ -95,7 +95,8 @@ jobs:
             echo "Removed stale conflict comment $id" >> $GITHUB_STEP_SUMMARY
           done
 
-      # In case of a conflict, try to resolve it automatically by merging main:
+      # In case of a conflict, try to resolve it automatically by merging the PR's base branch
+      # (main, or the next lower PR's head branch for a stacked PR):
       # the changelog merge driver resolves conflicts in CHANGELOG.md semantically and lets
       # "git merge" fail on any other conflict - then, nothing is pushed.
       # Thus, a merge commit is pushed if and only if CHANGELOG.md is the only conflicting file.
@@ -113,26 +114,19 @@ jobs:
           fetch-depth: 0
           show-progress: 'false'
           token: ${{ secrets.GH_TOKEN_JABREF_MACHINE_PR_APPROVE || github.token }}
-      - name: Fetch upstream main
-        id: fetch_upstream
-        if: steps.checkout_pr.outcome == 'success'
-        continue-on-error: true
-        run: |
-          set -ex
-          git remote add upstream "https://github.com/JabRef/jabref.git" || true
-          git fetch upstream main
       # Pushes the resolved merge back to the PR branch. This is the whole point:
       # the push triggers a fresh run that then reports no conflicts (no comment).
       # "$/" resolves the action from this workflow's own (trusted) commit, not from the
       # workspace - the workspace holds the untrusted PR head, whose copy of the action
       # must never run with write credentials.
-      - name: Merge main into PR branch
+      - name: Merge ${{ steps.pr_info.outputs.base_ref }} into PR branch
         id: automerge
-        if: steps.fetch_upstream.outcome == 'success'
+        if: steps.checkout_pr.outcome == 'success'
         continue-on-error: true
-        uses: $/.github/actions/merge-upstream-main
+        uses: $/.github/actions/merge-upstream-branch
         with:
           target-branch: ${{ steps.pr_info.outputs.head_ref }}
+          base-branch: ${{ steps.pr_info.outputs.base_ref }}
       # After the merge, HEAD is the merge commit that was pushed.
       - name: Record pushed merge commit
         id: merge_commit
@@ -145,6 +139,7 @@ jobs:
           AUTOMERGE_OUTCOME: ${{ steps.automerge.outcome }}
           APPROVED_AUTOMERGE: ${{ steps.pr_info.outputs.approved_automerge }}
           HEAD_REPO: ${{ steps.pr_info.outputs.head_repo }}
+          BASE_REF: ${{ steps.pr_info.outputs.base_ref }}
           MERGE_COMMIT: ${{ steps.merge_commit.outputs.sha }}
           PAT: ${{ secrets.GH_TOKEN_JABREF_MACHINE_PR_APPROVE }}
           EVENT: ${{ github.event_name }}
@@ -155,9 +150,9 @@ jobs:
           set -ex
 
           if [ "$AUTOMERGE_OUTCOME" = "success" ]; then
-            # CHANGELOG.md was the only conflicting file - main was merged and pushed.
+            # CHANGELOG.md was the only conflicting file - the base branch was merged and pushed.
             # No comment: the push triggers a new run, which then reports no conflicts.
-            echo "✅ Conflict in CHANGELOG.md only - resolved by merging main" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Conflict in CHANGELOG.md only - resolved by merging $BASE_REF" >> $GITHUB_STEP_SUMMARY
             if [ "$APPROVED_AUTOMERGE" = "true" ]; then
               # The pushed merge commit dismisses the approval and thereby stalls auto-merge.
               # The label triggers "On PR labeled", which approves again and re-enables auto-merge.
@@ -210,12 +205,12 @@ jobs:
             fi
 
             echo "Commenting on PR..."
-            # Quoted delimiter: the body contains backticks, which an unquoted
-            # heredoc would run as command substitution - swallowing the link text.
-            cat > body.txt <<'EOF'
+            # Backticks are escaped: the heredoc is unquoted to expand $BASE_REF, and an
+            # unquoted heredoc would otherwise run them as command substitution.
+            cat > body.txt <<EOF
           Your pull request conflicts with the target branch.
 
-          Please [merge `upstream/main`](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork#syncing-a-fork-branch-from-the-command-line) with your code. For a step-by-step guide to resolve merge conflicts, see <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line>.
+          Please [merge \`upstream/$BASE_REF\`](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork#syncing-a-fork-branch-from-the-command-line) with your code. For a step-by-step guide to resolve merge conflicts, see <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line>.
 
           <!-- ghprcomment
           On PR opened/updated


### PR DESCRIPTION
### Summary

🤖 The conflict automation and the "Merge main" workflow always merged `upstream/main` into a PR branch, so a PR stacked on another PR (base = that PR's head branch) got flooded with upstream commits its base did not have yet. Both now merge the PR's actual base branch, taken from JabRef/jabref; PRs based on `main` behave as before. Motivating example: #16800 (base `fix-sync`, the head branch of #11879) received two bot merges of `main` and then showed 14 foreign commits.

**Analogies:** Like honey, the merge now flows from the comb the bee actually sits on, not from the hive next door. Like chocolate, the layers of a stack stay distinct instead of melting into one. Like the moon, each PR keeps circling its own planet rather than the sun.

`jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

1. `Merge main` runs on this PR itself (it changes its own workflow file) and must be green: the renamed action fetches `upstream/main` and merges it into this `main`-based branch.
2. `On PR opened/updated` runs from `main` (`pull_request_target`), so the stacked case is only observable after merge: dispatch `Merge main` with the number of a stacked PR (e.g. #16800) and check that the step is named after its base branch and the pushed commit is "Merge remote-tracking branch 'upstream/<base>'".
3. Push a CHANGELOG-only conflict to a stacked PR after merge: the summary reads "resolved by merging <base>", not "main".

### Related issues and pull requests

Motivated by #16800 stacked on #11879. No issue exists for this.

### AI usage

Claude Code (model claude-fable-5-1), AIL4: the change and this description were AI-generated on human instructions and reviewed by the contributor.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [/] No Java code changed — not applicable for this group.
- [/] No `Objects.requireNonNull(...)`.
- [/] New classes annotated with `@NullMarked`.
- [/] `Optional` consumed with `ifPresent` / `map` / `orElseThrow`.
- [/] `StringUtil.isBlank(...)` used.

### Exceptions

- [/] No Java code changed — not applicable for this group.
- [/] No `throw new RuntimeException(...)`.
- [/] Logged exceptions passed as the last logger argument.

### Style and idioms

- [/] No Java code changed — not applicable for this group.
- [/] Modern Java used.
- [/] Regexes precompiled.
- [/] Background work uses `BackgroundTask`.
- [x] No commented-out code, no trivial comments, no AI-disclosure comments.
- [/] Markdown Javadoc uses Markdown syntax.

### User-facing text

- [/] No application text changed — not applicable for this group.
- [/] Sentence case.
- [/] Variance expressed with placeholders.

### Security

- [/] No HTML output.

### Tests

- [/] No `org.jabref.logic` / `org.jabref.model` change — not applicable for this group.
- [/] Tests assert object contents.
- [/] Fetcher tests hit live endpoints.

## 2. Verification commands

- [/] No Java/Markdown-docs change — the YAML files were parsed with PyYAML, the comment heredoc was executed with `BASE_REF=fix-sync` and yields the expected text; the `Merge main` run on this PR exercises the action.
- [/] `checkstyleMain checkstyleTest checkstyleJmh`.
- [/] `modernizer`.
- [/] `rewriteDryRun`.
- [/] `javadoc`.
- [/] markdownlint.
- [/] intellij-format.

## 3. Documentation

- [/] CI-only change, not visible to users — no CHANGELOG entry.
- [x] Searched jabref and jabref-koppor issues; no match.
- [/] No requirement — internal change.
- [x] No developer documentation describes the merge automation (`grep -rn "merge-main\|merge upstream" docs AGENTS.md` only finds the manual sync instructions, which stay valid).

## 4. Pull request

- [x] PR body built from the template, every section filled.
- [x] All checklist items marked.
- [x] All HTML comments removed.
- [x] Created with `gh pr create --body-file`.
- [/] No CHANGELOG placeholder.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
