### PR TITLE
Pin all external GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/check-formatting/action.yml
+++ b/.github/actions/check-formatting/action.yml
@@ -38,7 +38,7 @@ runs:
       run: git -C "${{ inputs.working-directory }}" diff HEAD | tee "${{ inputs.working-directory }}/format.patch"
     - name: Upload formatting patch
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.working-directory }}/format.patch

--- a/.github/actions/format-java/action.yml
+++ b/.github/actions/format-java/action.yml
@@ -4,7 +4,7 @@ description: Reformat Java sources using IntelliJ IDEA's code style
 runs:
   using: composite
   steps:
-    - uses: leventeBajczi/intellij-idea-format@idea-2026.2.1
+    - uses: leventeBajczi/intellij-idea-format@db20da18da1ea0264171c370e2ea1922c7b3d18a # idea-2026.2.1
       with:
         file-mask: "*.java"
         settings-file: ".idea/codeStyles/Project.xml"

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -107,7 +107,7 @@ runs:
     - name: Upload ${{ inputs.component }} packages to GitHub
       # background: true
       if: (inputs.uploadAsArtifact == 'true') && (inputs.archivePortable != 'NONE')
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: ${{ inputs.componentShort }} (${{ inputs.displayName }})
         path: |
@@ -136,7 +136,7 @@ runs:
     - name: Upload ShadowJar to GitHub
       # background: true
       if: (inputs.uploadAsArtifact == 'true') && (inputs.os == 'ubuntu-22.04')
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: ${{ inputs.componentShort }} (${{ inputs.displayName }}) (shadowJar)
         path: |

--- a/.github/actions/pr-gate/action.yml
+++ b/.github/actions/pr-gate/action.yml
@@ -89,7 +89,7 @@ runs:
       if: ${{ steps.perm.outputs.skip-check != 'true'
               && steps.eval.outputs.ci_running == 'true'
               && inputs.ci-running-message != '' }}
-      uses: thollander/actions-comment-pull-request@v3
+      uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74 # v3
       with:
         github-token: ${{ inputs.github-token }}
         message: ${{ inputs.ci-running-message }}
@@ -100,7 +100,7 @@ runs:
       if: ${{ steps.perm.outputs.skip-check != 'true'
               && steps.eval.outputs.changes_required == 'true'
               && inputs.changes-required-message != '' }}
-      uses: thollander/actions-comment-pull-request@v3
+      uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74 # v3
       with:
         github-token: ${{ inputs.github-token }}
         message: ${{ inputs.changes-required-message }}

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -15,13 +15,13 @@ runs:
   using: composite
   steps:
     - name: Setup JDK
-      uses: actions/setup-java@v6
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
       with:
         java-version: ${{ inputs.javaVersion }}
         distribution: ${{ inputs.distribution }}
         check-latest: true
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
       with:
         gradle-version: current
       env:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -20,7 +20,7 @@ jobs:
       USER:      ${{ github.event.pull_request.user.login }}
       TITLE:     ${{ github.event.pull_request.title }}
     steps:
-      - uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+      - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: jq
           version: 1.0

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -144,27 +144,27 @@ jobs:
       jdkVersionFlavour: ${{ steps.binary.outputs.jdkVersionFlavour }}
       javafxVersion: ${{ steps.binary.outputs.javafxVersion }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         if: github.event_name == 'pull_request'
         with:
           fetch-depth: 0
           show-progress: 'false'
       - id: changed-non-workflow-files
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files_ignore: |
             .github/workflows/**
             **/*.md
       - id: changed-binaries-workflow
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files: |
             .github/workflows/binaries.yml
       - id: changed-binaries-resource-markdown
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files: |
             jabgui/buildres/**/*.md
@@ -518,20 +518,20 @@ jobs:
         run: echo "Skipping pre-build because no build-relevant files changed."
       - name: Fetch all history for all tags and branches
         if: needs.conditions.outputs.should-build == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           show-progress: 'false'
       - name: Install GitVersion
         if: needs.conditions.outputs.should-build == 'true'
         id: pre-gitversion
-        uses: gittools/actions/gitversion/setup@v4.7.0
+        uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         with:
           versionSpec: "6.x"
       - name: Run GitVersion
         if: needs.conditions.outputs.should-build == 'true'
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v4.7.0
+        uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
       - name: Normalize branch name
         if: needs.conditions.outputs.should-build == 'true'
         id: normalize
@@ -584,7 +584,7 @@ jobs:
         run: echo "Skipping binary build because no build-relevant files changed."
       - name: Checkout
         if: needs.conditions.outputs.should-build == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           submodules: 'true'
@@ -601,7 +601,7 @@ jobs:
         id: pigz
         if: needs.conditions.outputs.should-build == 'true' && startsWith(matrix.os, 'ubuntu')
         background: true
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: pigz
           version: 1.0
@@ -635,7 +635,7 @@ jobs:
       # Setup JDK EA and JavaFX EA
       - name: Set up latest JDK EA from jdk.java.net
         if: ${{ needs.conditions.outputs.should-build == 'true' && needs.conditions.outputs.useEaJdk == 'true' }}
-        uses: oracle-actions/setup-java@v1
+        uses: oracle-actions/setup-java@ec7274acdd237c7fe61395ed2edda22d756b5afe # v1
         with:
           website: jdk.java.net
           release: EA
@@ -880,7 +880,7 @@ jobs:
 
       - name: Upload jabgui and jabls-cli to GitHub workflow artifacts store for notarization (macOS)
         if: ${{ needs.conditions.outputs.should-build == 'true' && (startsWith(matrix.os, 'macos')) && (needs.conditions.outputs.should-notarize == 'true') }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           # tbn = to-be-notarized
           name: JabRef-${{ matrix.os }}-tbn
@@ -903,7 +903,7 @@ jobs:
         run: echo "Skipping native binary build because it is not needed for this event."
       - name: Checkout
         if: needs.conditions.outputs.should-build == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           submodules: 'true'
@@ -924,7 +924,7 @@ jobs:
       # jdk+fx maps to the Full Liberica package, used here for the AWT/java.desktop path triggered by PDFBox.
       - name: Set up Liberica NIK (native-image with AWT support)
         if: needs.conditions.outputs.should-build == 'true'
-        uses: graalvm/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@0426e2e191540e8514dff98dc52a5f5146a2a276 # v1
         with:
           distribution: 'liberica'
           java-package: ${{ matrix.javaPackage }}
@@ -940,7 +940,7 @@ jobs:
 
       - name: Install clitest
         if: needs.conditions.outputs.should-build == 'true'
-        uses: ethanjli/cached-download-action@v0.1.4
+        uses: ethanjli/cached-download-action@f1d109e4eca8d988e012ed5565366717aba90d0f # v0.1.4
         with:
           # clitest v0.5.0 (https://github.com/aureliojargas/clitest/releases/tag/0.5.0)
           url: https://raw.githubusercontent.com/aureliojargas/clitest/8bdaae2f56e524f8824307d5c443e6353fe0dbd9/clitest
@@ -980,7 +980,7 @@ jobs:
 
       - name: Upload jabkit native to GitHub artifacts store
         if: ${{ needs.conditions.outputs.should-build == 'true' && (github.event.inputs.upload-as-artifact == 'true') && (!startsWith(matrix.os, 'macos') || needs.conditions.outputs.should-notarize != 'true') }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jabkit-native (${{ matrix.displayName }})
           path: jabkit/build/native-dist/*.*
@@ -988,7 +988,7 @@ jobs:
 
       - name: Upload jabkit native to GitHub workflow artifacts store for notarization (macOS)
         if: ${{ needs.conditions.outputs.should-build == 'true' && (startsWith(matrix.os, 'macos')) && (needs.conditions.outputs.should-notarize == 'true') }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           # tbn = to-be-notarized
           name: jabkit-native-${{ matrix.os }}-tbn
@@ -1020,7 +1020,7 @@ jobs:
     steps:
       - name: Comment PR
         if: ${{ needs.disk-space-check.outputs.available == 'true' }}
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74 # v3
         with:
           message: |
             The build of this PR is available at <${{ needs.build.outputs.url }}>.
@@ -1040,7 +1040,7 @@ jobs:
           printf 'PR Body:\n%s\n' "$PR_BODY"
       - name: Determine issue number
         id: get_issue_number
-        uses: koppor/ticket-check-action@add-output
+        uses: koppor/ticket-check-action@5c5d28364fe8d3c2822611e0556fcacdde473b49 # add-output
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ticketLink: 'https://github.com/JabRef/jabref/issues/%ticketNumber%'
@@ -1053,7 +1053,7 @@ jobs:
           outputOnly: true
       - name: Comment on issue (build available)
         if: ${{ (steps.get_issue_number.outputs.ticketNumber != '-1') && (needs.disk-space-check.outputs.available == 'true') }}
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74 # v3
         with:
           pr-number: ${{ steps.get_issue_number.outputs.ticketNumber }}
           message: >
@@ -1097,7 +1097,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Download from GitHub workflow artifacts store (macOS)
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: JabRef-${{ matrix.os }}-tbn
       - name: Notarize dmg
@@ -1124,7 +1124,7 @@ jobs:
           rsync -rt --chmod=Du=rwx,Dg=rx,Do=rx,Fu=rw,Fg=r,Fo=r --itemize-changes --stats -e 'ssh -p 9922 -i sshkey -o StrictHostKeyChecking=no' ${{ matrix.path }}/build/packages/${{ matrix.os }}/ jrrsync@build-upload.jabref.org:/var/www/builds.jabref.org/www/${{ needs.build.outputs.branchname }}/
       - name: Upload artifacts
         if: ${{ github.event.inputs.upload-as-artifact || 'false' == 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.displayName }}
           path: |
@@ -1137,7 +1137,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Download from GitHub workflow artifacts store (macOS)
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: jabkit-native-macos-15-tbn
           path: jabkit/build/native-dist
@@ -1155,7 +1155,7 @@ jobs:
           rsync -rt --chmod=Du=rwx,Dg=rx,Do=rx,Fu=rw,Fg=r,Fo=r --itemize-changes --stats --rsync-path="mkdir -p /var/www/builds.jabref.org/www/${{ needs.pre-build.outputs.branch }}/macOS-silicon/tools && rsync" -e 'ssh -p 9922 -i sshkey -o StrictHostKeyChecking=no' jabkit/build/native-dist/ jrrsync@build-upload.jabref.org:/var/www/builds.jabref.org/www/${{ needs.pre-build.outputs.branch }}/macOS-silicon/tools/
       - name: Upload artifacts
         if: ${{ github.event.inputs.upload-as-artifact == 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jabkit-native (macOS-silicon)
           path: jabkit/build/native-dist/jabkit-native_macos-silicon.zip
@@ -1171,7 +1171,7 @@ jobs:
     steps:
       - name: Create pr_number.txt
         run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr_number
           path: pr_number.txt

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -25,11 +25,11 @@ jobs:
     # Does not work on ubuntu-slim
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           show-progress: 'false'
       - name: Run linkspector
-        uses: umbrelladocs/action-linkspector@v1.5.5
+        uses: umbrelladocs/action-linkspector@568ec8d29fa92b31fd9ea5381e155c51e922af83 # v1.5.5
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,12 +33,12 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@fa2b2666b747000bf42767d1f332065b375e3c8f # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -14,16 +14,16 @@ jobs:
       packages: write
     steps:
       - name: Cancel workflow "binaries" run
-        uses: styfle/cancel-workflow-action@0.13.1
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
         with:
           ignore_sha: true
           workflow_id: 9160969135
       - name: Cancel workflow "binaries (ea)" run
-        uses: styfle/cancel-workflow-action@0.13.1
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
         with:
           ignore_sha: true
           workflow_id: 160969125
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: "Check for 'dev: binaries' label"
         id: check_label
         run: |
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Delete folder on builds.jabref.org
         if: steps.check_label.outputs.has_label_binaries == 'yes'
-        uses: appleboy/ssh-action@v1.2.5
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           script: rm -rf /var/www/builds.jabref.org/www/pull/${{ github.event.pull_request.number }} || true
           host: build-upload.jabref.org
@@ -56,7 +56,7 @@ jobs:
       - name: Remove Docker Tag
         if: steps.changed-docker-files.outputs.any_changed == 'true'
         # A separate action is needed to delete a tag - see https://github.com/orgs/community/discussions/26267
-        uses: rafalkk/remove-dockertag-action@v1
+        uses: rafalkk/remove-dockertag-action@581f14f26a4a127cbe4145f7584975483a58b4e8 # v1
         with:
           tag_name: pr-${{ github.event.pull_request.number }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delete-old-runs-manually.yml
+++ b/.github/workflows/delete-old-runs-manually.yml
@@ -49,7 +49,7 @@ jobs:
       contents: read
     steps:
       - name: Delete workflow runs
-        uses: Mattraks/delete-workflow-runs@v2
+        uses: Mattraks/delete-workflow-runs@0cf693bc9909e5e867ee8f27b813224ba862939c # v2
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/${{ matrix.component }}
@@ -48,30 +48,30 @@ jobs:
         if: >
           (github.event_name == 'push' && github.repository == 'JabRef/jabref') ||
           (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'JabRef/jabref')
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: koppor
           password: ${{ secrets.CR_PAT }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       - name: Fetch all history for all tags and branches
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           submodules: 'true'
           show-progress: 'false'
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v4.7.0
+        uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         with:
           versionSpec: "6.x"
       - name: Run GitVersion
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v4.7.0
+        uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           push: >
             ${{

--- a/.github/workflows/gource.yml
+++ b/.github/workflows/gource.yml
@@ -51,13 +51,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           show-progress: 'false'
 
       - name: Generate Gource video
-        uses: nbprojekt/gource-action@v1
+        uses: nbprojekt/gource-action@d2fdf85904db416b69445dae5551282528e052ae # v1
         with:
           gource_title: ${{ matrix.title }}
           logo_url: 'https://www.jabref.org/img/JabRef-icon-256.png'
@@ -73,14 +73,14 @@ jobs:
           mv ./gource/gource.mp4 ${{ matrix.file }}
 
       - name: Upload gource video
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Gource-${{ matrix.file }}
           path: ${{ matrix.file }}
           retention-days: 80
 
       - name: Upload to files.jabref.org
-        uses: Pendect/action-rsyncer@v2.0.0
+        uses: Pendect/action-rsyncer@8e05ffa5c93e5d9c9b167796b26044d2c616b2b9 # v2.0.0
         env:
           DEPLOY_KEY: ${{ secrets.buildJabRefPrivateKey }}
         with:

--- a/.github/workflows/issue-comment.yml
+++ b/.github/workflows/issue-comment.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Download PR number
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         continue-on-error: true
         with:
           name: pr_number
@@ -62,7 +62,7 @@ jobs:
         id: pr_data
         env:
           PR_NUMBER: ${{ steps.read-pr_number.outputs.pr_number }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const {owner, repo} = context.repo;
@@ -98,7 +98,7 @@ jobs:
 
       - name: Comment on issue (no build available)
         if: ${{ (steps.read-pr_number.outputs.pr_number != '') && (steps.get_issue_number.outputs.ticketNumber != '') }}
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74 # v3
         with:
           pr-number: ${{ steps.get_issue_number.outputs.ticketNumber }}
           message: >

--- a/.github/workflows/jabls-native-smoke-test.yml
+++ b/.github/workflows/jabls-native-smoke-test.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Checkout
         if: github.event_name != 'pull_request' || matrix.runOnPullRequest == true
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           submodules: 'true'
@@ -67,7 +67,7 @@ jobs:
 
       - name: Set up GraalVM
         if: github.event_name != 'pull_request' || matrix.runOnPullRequest == true
-        uses: graalvm/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@0426e2e191540e8514dff98dc52a5f5146a2a276 # v1
         with:
           distribution: 'graalvm'
           java-version: '25'
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload JabLS native binary
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.upload-as-artifact }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jabls-native-${{ matrix.os }}
           path: jabls-cli/build/native/nativeCompile/

--- a/.github/workflows/junie.yml
+++ b/.github/workflows/junie.yml
@@ -24,12 +24,12 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
 
       - name: Run Junie
         id: junie
-        uses: JetBrains/junie-github-action@v1.7.6
+        uses: JetBrains/junie-github-action@63e8e2dd7c6739640604c56591248c4e2d0d7e30 # v1.7.6
         with:
           junie_api_key: ${{ secrets.JUNIE_API_KEY }}

--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install TeX Live
-        uses: zauguin/install-texlive@v4
+        uses: zauguin/install-texlive@f5e7d0b117035fff797d4392ea94131747e03d60 # v4
         with:
           package_file: jablib/src/test/latex/Texlivefile
   check-latex:
@@ -85,10 +85,10 @@ jobs:
             bibengine: biber
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install TeX Live
-        uses: zauguin/install-texlive@v4
+        uses: zauguin/install-texlive@f5e7d0b117035fff797d4392ea94131747e03d60 # v4
         with:
           package_file: jablib/src/test/latex/Texlivefile
 
@@ -104,7 +104,7 @@ jobs:
         working-directory: ${{ matrix.directory }}
 
       - name: Upload build result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: PDF-${{ matrix.tex }}
           path: |

--- a/.github/workflows/link-issue.yml
+++ b/.github/workflows/link-issue.yml
@@ -37,7 +37,7 @@ jobs:
           printf 'PR Body:\n%s\n' "$PR_BODY"
       - name: Determine issue number
         id: get_issue_number
-        uses: koppor/ticket-check-action@add-output
+        uses: koppor/ticket-check-action@5c5d28364fe8d3c2822611e0556fcacdde473b49 # add-output
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ticketLink: 'https://github.com/JabRef/jabref/issues/%ticketNumber%'
@@ -90,7 +90,7 @@ jobs:
       issues: write
     steps:
       - name: Move issue to "In Progress" in "Good First Issues"
-        uses: m7kvqbe1/github-action-move-issues/@main
+        uses: m7kvqbe1/github-action-move-issues/@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/5"
@@ -101,7 +101,7 @@ jobs:
           issue-number: ${{ needs.determine_issue_number.outputs.issue_number }}
           skip-if-not-in-project: true
       - name: Move issue to "In Progress" in "Candidates for University Projects"
-        uses: m7kvqbe1/github-action-move-issues/@main
+        uses: m7kvqbe1/github-action-move-issues/@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/3"
@@ -122,10 +122,10 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           show-progress: 'false'
-      - uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+      - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: jq
           version: 1.0

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ steps.resolve.outputs.repo }}
           submodules: 'true'

--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Assign the user or unassign stale assignments
         id: assign
-        uses: takanome-dev/assign-issue-action@edge
+        uses: takanome-dev/assign-issue-action@fad4b83750f7df31e03c2a42e8f1880b0b4b3573 # edge
         with:
           github_token: '${{ secrets.GH_TOKEN_ASSIGN_ISSUE_ACTION  || github.token }}'
           maintainers: '@JabRef/developers,Siedlerchr,ThiloteE,calixtus,HoussemNasri,subhramit,InAnYan'
@@ -85,7 +85,7 @@ jobs:
             - Ask a maintainer to assign you again.
             </details>
       - name: Move issue corresponding column in "Candidates for University Projects"
-        uses: m7kvqbe1/github-action-move-issues@main
+        uses: m7kvqbe1/github-action-move-issues@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         if: ${{ steps.assign.outputs.assigned == 'yes' || steps.assign.outputs.unassigned == 'yes' }}
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
@@ -96,7 +96,7 @@ jobs:
           default-column: "Free to take"
           skip-if-not-in-project: true
       - name: Move issue corresponding column in "Good First Issues"
-        uses: m7kvqbe1/github-action-move-issues@main
+        uses: m7kvqbe1/github-action-move-issues@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         if: ${{ steps.assign.outputs.assigned == 'yes' || steps.assign.outputs.unassigned == 'yes' }}
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}

--- a/.github/workflows/on-issue-labeled.yml
+++ b/.github/workflows/on-issue-labeled.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
     steps:
       - name: Move Issue to "Assigned" Column in "Candidates for University Projects"
-        uses: m7kvqbe1/github-action-move-issues@main
+        uses: m7kvqbe1/github-action-move-issues@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/3"
@@ -25,7 +25,7 @@ jobs:
           default-column: "Free to take"
           skip-if-not-in-project: true
       - name: Move Issue to "Assigned" Column in "Good First Issues"
-        uses: m7kvqbe1/github-action-move-issues@main
+        uses: m7kvqbe1/github-action-move-issues@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/5"
@@ -41,7 +41,7 @@ jobs:
       issues: write
     steps:
       - name: GreetingFirstTimeCodeContribution
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           issue-number: ${{ github.event.issue.number || github.event.pull_request.number }}
           body: |
@@ -59,7 +59,7 @@ jobs:
 
             Happy coding! 🚀
       - name: Move Issue to "Assigned" Column in "Candidates for University Projects"
-        uses: m7kvqbe1/github-action-move-issues@main
+        uses: m7kvqbe1/github-action-move-issues@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/3"
@@ -69,7 +69,7 @@ jobs:
           default-column: "Free to take"
           skip-if-not-in-project: true
       - name: Move Issue to "Assigned" Column in "Good First Issues"
-        uses: m7kvqbe1/github-action-move-issues@main
+        uses: m7kvqbe1/github-action-move-issues@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/5"
@@ -78,7 +78,7 @@ jobs:
           ignored-columns: ""
           default-column: "Free to take"
           skip-if-not-in-project: true
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Remove label
         run: |
           gh issue edit ${{ github.event.issue.number }} --remove-label "FirstTimeCodeContribution"
@@ -89,7 +89,7 @@ jobs:
     if: "${{ github.event.label.name == 'good first issue' && github.repository_owner == 'JabRef' }}"
     runs-on: ubuntu-slim
     steps:
-      - uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+      - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: jq
           version: 1.0
@@ -103,7 +103,7 @@ jobs:
     if: github.event.label.name == 'needs-refinement' && github.repository_owner == 'JabRef'
     runs-on: ubuntu-slim
     steps:
-      - uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+      - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: jq
           version: 1.0
@@ -118,7 +118,7 @@ jobs:
     if: "${{ github.event.label.name == 'status: freeze' && github.repository_owner == 'JabRef' }}"
     runs-on: ubuntu-slim
     steps:
-      - uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+      - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: jq
           version: 1.0
@@ -137,7 +137,7 @@ jobs:
       contents: read
     steps:
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74 # v3
         with:
           message: >
             👋 Hey, looks like you’re eager to work on this issue—great! 🎉
@@ -146,7 +146,7 @@ jobs:
           comment-tag:
             wisdom
           mode: recreate
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Remove label
         run: |
           gh issue edit ${{ github.event.issue.number }} --remove-label "dev: wisdom"

--- a/.github/workflows/on-issue-unassigned.yml
+++ b/.github/workflows/on-issue-unassigned.yml
@@ -13,8 +13,8 @@ jobs:
       issues: write
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: jq
           version: 1.0
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Move Issue to "Free to take" Column in "Candidates for University Projects"
         if: steps.check_assignee.outputs.assigned == 'no'
-        uses: m7kvqbe1/github-action-move-issues@main
+        uses: m7kvqbe1/github-action-move-issues@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/3"
@@ -43,7 +43,7 @@ jobs:
           skip-if-not-in-project: true
       - name: Move Issue to "Free to take" Column in "Good First Issues"
         if: steps.check_assignee.outputs.assigned == 'no'
-        uses: m7kvqbe1/github-action-move-issues@main
+        uses: m7kvqbe1/github-action-move-issues@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/5"

--- a/.github/workflows/on-issue-unlabeled.yml
+++ b/.github/workflows/on-issue-unlabeled.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
     steps:
       - name: Move Issue to "Free to take" Column in "Candidates for University Projects"
-        uses: m7kvqbe1/github-action-move-issues@main
+        uses: m7kvqbe1/github-action-move-issues@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/3"
@@ -24,7 +24,7 @@ jobs:
           default-column: "Free to take"
           skip-if-not-in-project: true
       - name: Move Issue to "Free to take" Column in "Good First Issues"
-        uses: m7kvqbe1/github-action-move-issues@main
+        uses: m7kvqbe1/github-action-move-issues@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/5"
@@ -33,7 +33,7 @@ jobs:
           ignored-columns: ""
           default-column: "Free to take"
           skip-if-not-in-project: true
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Remove all assignees
         run: |
           ASSIGNEES=$(gh issue view ${{ github.event.issue.number }} --json assignees --template '{{range .assignees}}{{.login}} {{end}}')

--- a/.github/workflows/on-pr-awaiting-second-review-check.yml
+++ b/.github/workflows/on-pr-awaiting-second-review-check.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Check whether a second approval is required
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             if (context.eventName !== 'merge_group') {

--- a/.github/workflows/on-pr-changes-requested-check.yml
+++ b/.github/workflows/on-pr-changes-requested-check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Create pr_number.txt
         run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr_number
           path: pr_number.txt

--- a/.github/workflows/on-pr-changes-requested-move-labels.yml
+++ b/.github/workflows/on-pr-changes-requested-move-labels.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Download artifact from triggering run
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           run-id: ${{ github.event.workflow_run.id }}
           name: pr_number

--- a/.github/workflows/on-pr-closed.yml
+++ b/.github/workflows/on-pr-closed.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ inputs.pr_number }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const {owner, repo} = context.repo;
@@ -112,7 +112,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Remove assignee
         env:
           ISSUE_NUMBER: ${{ needs.determine_issue_number.outputs.issue_number }}
@@ -144,7 +144,7 @@ jobs:
 
           # "brute force" remove assignee - it might happen that the contributor was unassinged, but the PR closed later; therefore we need " || true" to ignore any error
           gh issue edit "$ISSUE_NUMBER" --remove-assignee "$PR_USER" || true
-      - uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+      - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: jq
           version: 1.0
@@ -177,7 +177,7 @@ jobs:
           gh issue edit "$ISSUE_NUMBER" --remove-label "📍 Assigned,🔔 reminder-sent,📌 Pinned,FirstTimeCodeContribution"
       - name: Move issue to "Free to take" in "Good First Issues"
         if: steps.check_assignee.outputs.assigned == 'no'
-        uses: m7kvqbe1/github-action-move-issues/@main
+        uses: m7kvqbe1/github-action-move-issues/@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/5"
@@ -189,7 +189,7 @@ jobs:
           skip-if-not-in-project: true
       - name: Move issue to "Free to take" in "Candidates for University Projects"
         if: steps.check_assignee.outputs.assigned == 'no'
-        uses: m7kvqbe1/github-action-move-issues/@main
+        uses: m7kvqbe1/github-action-move-issues/@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/3"
@@ -234,7 +234,7 @@ jobs:
       issues: write
     steps:
       - name: Comment on issue
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74 # v3
         with:
           pr-number: ${{ needs.determine_issue_number.outputs.issue_number }}
           message: |
@@ -252,7 +252,7 @@ jobs:
       issues: write
     steps:
       - name: Delete download comment
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74 # v3
         with:
           pr-number: ${{ needs.determine_issue_number.outputs.issue_number }}
           comment-tag: download-link

--- a/.github/workflows/on-pr-labeled-update-pr-status.yml
+++ b/.github/workflows/on-pr-labeled-update-pr-status.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Download artifact from triggering run
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           run-id: ${{ github.event.workflow_run.id }}
           name: pr_number
@@ -30,7 +30,7 @@ jobs:
           else
             echo "continue=false" >> "$GITHUB_OUTPUT"
           fi
-      - uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+      - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: jq
           version: 1.0

--- a/.github/workflows/on-pr-labeled.yml
+++ b/.github/workflows/on-pr-labeled.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Create pr_number.txt
         run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr_number
           path: pr_number.txt

--- a/.github/workflows/on-pr-opened-updated.yml
+++ b/.github/workflows/on-pr-opened-updated.yml
@@ -22,7 +22,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           show-progress: 'false'
       # A human push invalidates the bot's earlier approval; "automerge" must be granted again explicitly.
@@ -106,7 +106,7 @@ jobs:
         id: checkout_pr
         if: steps.check_mergeable.outputs.mergeable == 'CONFLICTING' && (steps.pr_info.outputs.head_repo == 'JabRef/jabref' || steps.pr_info.outputs.maintainer_can_modify == 'true')
         continue-on-error: true
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ steps.pr_info.outputs.head_repo }}
           ref: ${{ steps.pr_info.outputs.head_ref }}

--- a/.github/workflows/on-pr-opened.yml
+++ b/.github/workflows/on-pr-opened.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: plbstl/first-contribution@v4
+      - uses: plbstl/first-contribution@2c36bdb58684587f60549a69aaa3ec00b9d5f4fe # v4
         with:
           labels: first contrib
           pr-opened-msg: >

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,11 +29,11 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           show-progress: 'false'
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           ruby-version: '3.3' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -41,13 +41,13 @@ jobs:
           working-directory: docs/
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - name: Build with Jekyll
         run: |
           cd docs
           bundle exec jekyll build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: docs/_site/
 
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5

--- a/.github/workflows/pr-changelog.yml
+++ b/.github/workflows/pr-changelog.yml
@@ -19,7 +19,7 @@ jobs:
     if: (github.event.pull_request.user.login != 'dependabot[bot]') && (github.event.pull_request.user.login != 'renovate-bot')
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - name: Check PR body for changelog note
@@ -74,7 +74,7 @@ jobs:
     steps:
       - name: Create pr_number.txt
         run: echo "${{ github.event.number }}" > pr_number.txt
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr_number
           path: pr_number.txt

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Download PR number
         if: ${{ github.event_name == 'workflow_run' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         continue-on-error: true
         with:
           name: pr_number
@@ -114,12 +114,12 @@ jobs:
 
       - name: Checkout
         # required for gh tool and .github/ghprcomment.yml
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           show-progress: 'false'
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+      - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: jq
           version: 1.0
@@ -160,7 +160,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # No setup-gradle here: this job never runs Gradle, it only needs a JDK and JBang.
-      - uses: actions/setup-java@v6
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true') }}
         with:
           distribution: 'corretto'
@@ -172,7 +172,7 @@ jobs:
       - name: Cache JBang
         # Own key: ghprcomment pulls different dependencies than the other JBang jobs.
         if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true') }}
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.jbang
           key: ${{ steps.cache-key.outputs.cache_key }}

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -156,7 +156,7 @@ jobs:
     steps:
       - name: Create pr_number.txt
         run: echo "${{ github.event.number }}" > pr_number.txt
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr_number
           path: pr_number.txt

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -21,6 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/labeler@v7
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7
         with:
           sync-labels: true

--- a/.github/workflows/pr-modifications.yml
+++ b/.github/workflows/pr-modifications.yml
@@ -29,11 +29,11 @@ jobs:
       )
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           show-progress: 'false'
       - name: Merge Conflict finder
-        uses: olivernybroe/action-conflict-finder@v4.1
+        uses: olivernybroe/action-conflict-finder@1a949ebd954a9eaee58802229ea5f9c69fb93a50 # v4.1
 
   no-force-push:
     if: >
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - name: Check force push
@@ -80,7 +80,7 @@ jobs:
       # No checkout -> the action uses GitHub's API (which is more reliable for submodule changes due to our submodule settings)
       - name: Get all submodule changes
         id: changes
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files: |
             jablib/src/main/abbrv.jabref.org
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - if: github.head_ref == 'main'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.setFailed('Pull requests should come from a branch other than "main"\n\n👉 Please read [the CONTRIBUTING guide](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md#contributing) carefully again. 👈')
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: Create pr_number.txt
         run: echo "${{ github.event.number }}" > pr_number.txt
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr_number
           path: pr_number.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,12 +55,12 @@ jobs:
     outputs:
       changed: ${{ steps.changed.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - name: Detect changed jablib classes or workflow
         id: changed
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files: |
             jablib/src/main/java/**/*.java
@@ -85,18 +85,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch all history for all tags and branches
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           submodules: 'true'
           show-progress: 'false'
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v4.7.0
+        uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         with:
           versionSpec: "6.x"
       - name: Run GitVersion
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v4.7.0
+        uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
       - uses: ./.github/actions/setup-gradle
 
       # region Publish JabLib on Maven Central
@@ -109,7 +109,7 @@ jobs:
           fi
       - name: Decode secretKeyRingFile
         id: secring
-        uses: timheuer/base64-to-file@v2
+        uses: timheuer/base64-to-file@dfa5a5dd38803cb4f5c3a081eeb28e8362d43e9c # v2
         with:
           fileName: 'secring.gpg'
           encodedString: ${{ secrets.KOPPOR_SIGNING_SECRETKEYRINGFILE_BASE64 }}

--- a/.github/workflows/remove-ready-for-review.yml
+++ b/.github/workflows/remove-ready-for-review.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/pr-gate
         id: gate
         with:

--- a/.github/workflows/remove-reviewers.yml
+++ b/.github/workflows/remove-reviewers.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/pr-gate
         id: gate
         with:

--- a/.github/workflows/rerun-merge-conflict-check.yml
+++ b/.github/workflows/rerun-merge-conflict-check.yml
@@ -17,8 +17,8 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: jq
           version: 1.0

--- a/.github/workflows/run-openrewrite.yml
+++ b/.github/workflows/run-openrewrite.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'true'
           ref: ${{ inputs.branch || github.event.pull_request.head.ref }}

--- a/.github/workflows/sbom-pr.yml
+++ b/.github/workflows/sbom-pr.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - uses: ./.github/actions/setup-gradle
 
@@ -38,7 +38,7 @@ jobs:
           echo "" >> bom.json
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(sbom): update CycloneDX SBOM files"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,7 +30,7 @@ jobs:
       # days-before-close against the GitHub field `updated_at`, which is bumped by any
       # activity on the pull request - including activity that is not the contributor's.
       # PRs whose `updated_at` keeps moving therefore never reach the close threshold.
-      - uses: actions/stale@v11
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11
         id: stale
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -158,7 +158,7 @@ jobs:
 
           echo "closed_prs=${closed# }" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         if: ${{ steps.close.outputs.closed_prs != '' }}
       - name: Process closed PRs
         if: ${{ steps.close.outputs.closed_prs != '' }}

--- a/.github/workflows/tests-code-fetchers.yml
+++ b/.github/workflows/tests-code-fetchers.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'true'
           show-progress: 'false'

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Create pr_number.txt
         run: echo "${{ github.event.number }}" > pr_number.txt
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr_number
           path: pr_number.txt
@@ -50,27 +50,27 @@ jobs:
       run-gradle-ci-requirements: ${{ steps.determine.outputs.run-gradle-ci-requirements }}
       run-gradle-ci-full: ${{ steps.determine.outputs.run-gradle-ci-full }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         if: github.event_name == 'pull_request'
         with:
           fetch-depth: 0
           show-progress: 'false'
       - id: changed-non-workflow-non-markdown-files
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files_ignore: |
             .github/workflows/**
             **/*.md
       - id: changed-requirements-docs
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files: |
             docs/requirements/**/*.md
       - id: changed-tests-code-workflow
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files: |
             .github/workflows/tests-code.yml
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'true'
           show-progress: 'false'
@@ -127,7 +127,7 @@ jobs:
     # ubuntu-slim doesn't offer docker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/format-java
       # job should fail in case there are changes
       - uses: ./.github/actions/check-formatting
@@ -140,15 +140,15 @@ jobs:
     # too slow on ubuntu-slim
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           path: 'jabref'
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: 'rmuller/Convert2MarkdownJavadoc'
           path: 'Convert2MarkdownJavadoc'
       - name: Setup JDK
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         with:
           java-version: '24'
           distribution: 'corretto'
@@ -169,7 +169,7 @@ jobs:
     if: needs.changes.outputs.run-gradle-ci-full == 'true'
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'true'
           show-progress: 'false'
@@ -185,7 +185,7 @@ jobs:
     if: needs.changes.outputs.run-gradle-ci-full == 'true'
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'true'
           show-progress: 'false'
@@ -212,7 +212,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'true'
           show-progress: 'false'
@@ -228,12 +228,12 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'false'
           show-progress: 'false'
       - name: markdownlint-cli2-action
-        uses: DavidAnson/markdownlint-cli2-action@v24
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24
         with:
           globs: |
             *.md
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'false'
           show-progress: 'false'
@@ -258,7 +258,7 @@ jobs:
         # Combined cache action: restores at start and saves ~/.jbang on a
         # cache miss in the post-job step. A madrlint-specific key keeps this
         # cache separate from the other JBang-using jobs.
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.jbang
           key: ${{ steps.cache-key.outputs.cache_key }}
@@ -267,7 +267,7 @@ jobs:
       - name: Resolve //DEPS into the cached directory
         # JBang resolves script dependencies into ~/.m2, which is not cached here.
         run: echo "JBANG_REPO=$HOME/.jbang/repository" >> "$GITHUB_ENV"
-      - uses: actions/setup-java@v6
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         with:
           distribution: 'corretto'
           java-version: '25'
@@ -305,7 +305,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'false'
           show-progress: 'false'
@@ -316,7 +316,7 @@ jobs:
           echo "cache_key=jbang-heylogs-$(date +%Y-%m)" >> $GITHUB_OUTPUT
       - name: Cache JBang
         # Combined cache action: the restore-only variant never wrote the key.
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.jbang
           key: ${{ steps.cache-key.outputs.cache_key }}
@@ -348,14 +348,14 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'false'
           show-progress: 'false'
           fetch-depth: 0
       - name: Cache clparse jar
         id: cache-clparse
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: /tmp/clparse
           key: clparse-0.9.1
@@ -367,7 +367,7 @@ jobs:
           tar xzvf clparse-0.9.1-x86_64-unknown-linux-musl.tar.gz
       - name: Install clparse
         run: sudo mv /tmp/clparse /usr/local/bin/clparse
-      - uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+      - uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: jq
           version: 1.0
@@ -385,7 +385,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'true'
           show-progress: 'false'
@@ -405,7 +405,7 @@ jobs:
         run: echo "Skipping tests because no source-relevant files changed."
       - name: Checkout source
         if: needs.changes.outputs.run-gradle-ci-full == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'true'
           show-progress: 'false'
@@ -421,7 +421,7 @@ jobs:
         run: gradle :jabkit:runJabKitPortableSmokeTest
       - name: Prepare format failed test results
         if: needs.changes.outputs.run-gradle-ci-full == 'true' && failure()
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: xml-twig-tools xsltproc
           version: 1.0
@@ -450,7 +450,7 @@ jobs:
         run: echo "Skipping Windows tests because no source-relevant files changed."
       - name: Checkout source
         if: needs.changes.outputs.run-gradle-ci-full == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'true'
           show-progress: 'false'
@@ -469,14 +469,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           submodules: 'true'
           show-progress: 'false'
       - name: Detect changed windows-related classes
         id: changed-windows-related-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files: |
             jablib/src/main/java/org/jabref/logic/citationstyle/CSLStyleUtils.java
@@ -511,7 +511,7 @@ jobs:
       - name: Shutdown Ubuntu MySQL
         run: sudo service mysql stop # Shutdown the Default MySQL to save memory, "sudo" is necessary, please do not remove it
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'true'
           show-progress: 'false'
@@ -540,7 +540,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'false'
           show-progress: 'false'
@@ -551,7 +551,7 @@ jobs:
       - name: Cache JBang
         # Shared by the "JBang (main)" and "JBang (PR)" jobs - both build the same scripts,
         # so they resolve the same dependencies. A PR run restores the entry written on main.
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.jbang
           key: ${{ steps.cache-key.outputs.cache_key }}
@@ -570,7 +570,7 @@ jobs:
     if: github.ref != 'refs/heads/main' && needs.changes.outputs.run-gradle-ci-full == 'true'
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'true'
           show-progress: 'false'
@@ -581,7 +581,7 @@ jobs:
       - name: Cache JBang
         # Shared by the "JBang (main)" and "JBang (PR)" jobs - both build the same scripts,
         # so they resolve the same dependencies. A PR run restores the entry written on main.
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.jbang
           key: ${{ steps.cache-key.outputs.cache_key }}
@@ -611,12 +611,12 @@ jobs:
         project: [ jablib-examples/maven3/doi-to-bibtex ]
     steps:
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'false'
           show-progress: 'false'
       - name: Set up JDK
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         with:
           java-version: 25
           distribution: 'corretto'
@@ -657,7 +657,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: 'true'
           show-progress: 'false'
@@ -669,7 +669,7 @@ jobs:
           CI: "true"
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           DBMS: "postgresql"
-      - uses: codecov/codecov-action@v7
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         if: (github.ref == 'refs/heads/main') && (steps.checksecrets.outputs.secretspresent == 'YES')
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -685,7 +685,7 @@ jobs:
     name: "Validate requirement coverage"
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           show-progress: 'false'
       - uses: ./.github/actions/setup-gradle
@@ -699,10 +699,10 @@ jobs:
     name: "Validate Gradle Wrapper"
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           show-progress: 'false'
-      - uses: gradle/actions/wrapper-validation@v5
+      - uses: gradle/actions/wrapper-validation@0723195856401067f7a2779048b490ace7a47d7c # v5
 
   # Guards against a committer (e.g. a dependabot wrapper bump) baking CRLF into
   # the committed gradlew.bat blob. .gitattributes stores it as LF and smudges it
@@ -711,7 +711,7 @@ jobs:
     name: "Line endings (gradlew.bat)"
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           show-progress: 'false'
       - name: Ensure gradlew.bat blob has no CRLF

--- a/.github/workflows/unassign-issues.yml
+++ b/.github/workflows/unassign-issues.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Unassign stale assignments
         id: unassign
-        uses: takanome-dev/assign-issue-action@edge
+        uses: takanome-dev/assign-issue-action@fad4b83750f7df31e03c2a42e8f1880b0b4b3573 # edge
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           reminder_text: |
@@ -70,7 +70,7 @@ jobs:
         issue_number: ${{ fromJson(needs.unassign_issues.outputs.unassigned_issues) }}
     steps:
       - name: Move issue to "Free to take" in "Good First Issues"
-        uses: m7kvqbe1/github-action-move-issues/@main
+        uses: m7kvqbe1/github-action-move-issues/@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/5"
@@ -81,7 +81,7 @@ jobs:
           issue-number: ${{ matrix.issue_number }}
           skip-if-not-in-project: true
       - name: Move issue to "Free to take" in "Candidates for University Projects"
-        uses: m7kvqbe1/github-action-move-issues/@main
+        uses: m7kvqbe1/github-action-move-issues/@1e0e8ac3ab57afe93ddec45b2d48cbe2f1a6595b # main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/3"

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -14,13 +14,13 @@ jobs:
     # ubuntu-slim does not offer Java (required by the update action)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
       - name: Update Gradle Wrapper
         # See https://github.com/JabRef/jabref/pull/15034
         if: false
-        uses: gradle-update/update-gradle-wrapper-action@v2
+        uses: gradle-update/update-gradle-wrapper-action@512b1875f3b6270828abfe77b247d5895a2da1e5 # v2
         with:
           labels: dependencies
           repo-token: ${{ secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER }}

--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -19,7 +19,7 @@ jobs:
           cd build
           wget -q -m -r -nH --cut-dirs 2 --no-parent --show-progress --accept=tar.gz,dmg,pkg,deb,rpm,zip,msi https://builds.jabref.org/tags/
       - name: Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3
         with:
           draft: true
           files: build/**


### PR DESCRIPTION
### Summary

🤖 Every third-party GitHub Action used in our workflows and composite actions was referenced by a mutable tag or branch, so a moved tag could silently change what runs in CI. All 52 distinct references are now pinned to their current full commit SHA, with the tag or branch kept as a trailing comment so Dependabot keeps bumping them.

Analogies: like honey, a pinned SHA does not spoil when the jar is left open; like chocolate, it stays the same bar you bought; like the moon, it keeps the same face turned toward us.

`jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

1. Check that CI on this PR is green.
2. `grep -rn "uses:" .github | grep -v "@[0-9a-f]\{40\}"` shows only local (`./`, `$/`) references and one commented-out line.

### Related issues and pull requests

Closes TODO

### AI usage

Claude Code (model claude-fable-5-1), AIL4: SHA resolution and rewrite done by a script written by the AI, reviewed by me.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

Not applicable: no Java, text, or test changes — only `uses:` lines in workflow YAML.

### Nullability and control flow

- [/] No `== null` / `!= null` checks
- [/] No `Objects.requireNonNull(...)`
- [/] New classes annotated with `@NullMarked`
- [/] `Optional` consumed properly
- [/] `StringUtil.isBlank(...)` used

### Exceptions

- [/] No `catch (Exception e)`
- [/] No `throw new RuntimeException(...)`
- [/] Logged exceptions passed as last logger argument

### Style and idioms

- [/] New `BibEntry` objects built with withers
- [/] Modern Java used
- [/] Regexes precompiled
- [/] Background work uses `BackgroundTask`
- [/] No commented-out code, no trivial comments
- [/] Markdown Javadoc uses Markdown syntax

### User-facing text

- [/] All user-facing text localized
- [/] Sentence case
- [/] Variance expressed with placeholders

### Security

- [/] User-controlled data HTML-escaped

### Tests

- [/] Behavior changes have tests
- [/] Tests assert object contents
- [/] Fetcher tests hit live endpoints

## 2. Verification commands

Not applicable: no source changed; the PR's own CI run is the verification.

- [/] `./gradlew :jablib:check`
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`
- [/] `./gradlew modernizer`
- [/] `./gradlew --no-configuration-cache :rewriteDryRun`
- [/] `./gradlew javadoc`
- [/] `npx markdownlint-cli2`
- [/] intellij-format

## 3. Documentation

- [/] `CHANGELOG.md` entry (not user-visible)
- [x] Searched issues for a related issue
- [/] Requirement added to `docs/requirements/`
- [/] Developer documentation updated

## 4. Pull request

- [x] PR body built from template
- [x] All checklist items kept and marked
- [x] All HTML comments removed
- [x] PR created with `gh pr create --body-file`
- [/] `CHANGELOG.md` TODO placeholder

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
