### PR TITLE
Configure navigation tree hierarchy for AI requirements in devdocs

### DIFF
--- a/docs/requirements/ai.md
+++ b/docs/requirements/ai.md
@@ -1,6 +1,5 @@
 ---
 parent: Requirements
-has_children: true
 ---
 
 # AI

--- a/docs/requirements/ai.md
+++ b/docs/requirements/ai.md
@@ -1,5 +1,6 @@
 ---
 parent: Requirements
+has_children: true
 ---
 
 # AI

--- a/docs/requirements/ai/chatting.md
+++ b/docs/requirements/ai/chatting.md
@@ -1,5 +1,7 @@
 ---
-parent: ai
+parent: AI
+grand_parent: Requirements
+nav_order: 2
 ---
 
 # Chat with AI

--- a/docs/requirements/ai/chatting.md
+++ b/docs/requirements/ai/chatting.md
@@ -1,7 +1,6 @@
 ---
 parent: AI
 grand_parent: Requirements
-nav_order: 2
 ---
 
 # Chat with AI

--- a/docs/requirements/ai/citation-parsing.md
+++ b/docs/requirements/ai/citation-parsing.md
@@ -1,7 +1,6 @@
 ---
 parent: AI
 grand_parent: Requirements
-nav_order: 5
 ---
 
 # Citation parsing with LLMs

--- a/docs/requirements/ai/citation-parsing.md
+++ b/docs/requirements/ai/citation-parsing.md
@@ -1,5 +1,7 @@
 ---
-parent: ai
+parent: AI
+grand_parent: Requirements
+nav_order: 5
 ---
 
 # Citation parsing with LLMs

--- a/docs/requirements/ai/expert-settings.md
+++ b/docs/requirements/ai/expert-settings.md
@@ -1,5 +1,7 @@
 ---
-parent: ai
+parent: AI
+grand_parent: Requirements
+nav_order: 7
 ---
 
 # AI expert settings

--- a/docs/requirements/ai/expert-settings.md
+++ b/docs/requirements/ai/expert-settings.md
@@ -1,7 +1,6 @@
 ---
 parent: AI
 grand_parent: Requirements
-nav_order: 7
 ---
 
 # AI expert settings

--- a/docs/requirements/ai/future.md
+++ b/docs/requirements/ai/future.md
@@ -1,5 +1,7 @@
 ---
-parent: ai
+parent: AI
+grand_parent: Requirements
+nav_order: 9
 ---
 
 <!-- oft:off -->

--- a/docs/requirements/ai/future.md
+++ b/docs/requirements/ai/future.md
@@ -1,7 +1,6 @@
 ---
 parent: AI
 grand_parent: Requirements
-nav_order: 9
 ---
 
 <!-- oft:off -->

--- a/docs/requirements/ai/general.md
+++ b/docs/requirements/ai/general.md
@@ -1,5 +1,7 @@
 ---
-parent: ai
+parent: AI
+grand_parent: Requirements
+nav_order: 1
 ---
 
 # General requirements for AI features

--- a/docs/requirements/ai/general.md
+++ b/docs/requirements/ai/general.md
@@ -1,7 +1,6 @@
 ---
 parent: AI
 grand_parent: Requirements
-nav_order: 1
 ---
 
 # General requirements for AI features

--- a/docs/requirements/ai/ingestion.md
+++ b/docs/requirements/ai/ingestion.md
@@ -1,5 +1,7 @@
 ---
-parent: ai
+parent: AI
+grand_parent: Requirements
+nav_order: 6
 ---
 
 # Ingestion

--- a/docs/requirements/ai/ingestion.md
+++ b/docs/requirements/ai/ingestion.md
@@ -1,7 +1,6 @@
 ---
 parent: AI
 grand_parent: Requirements
-nav_order: 6
 ---
 
 # Ingestion

--- a/docs/requirements/ai/llms.md
+++ b/docs/requirements/ai/llms.md
@@ -1,5 +1,7 @@
 ---
-parent: ai
+parent: AI
+grand_parent: Requirements
+nav_order: 8
 ---
 
 # LLMs in AI features

--- a/docs/requirements/ai/llms.md
+++ b/docs/requirements/ai/llms.md
@@ -1,7 +1,6 @@
 ---
 parent: AI
 grand_parent: Requirements
-nav_order: 8
 ---
 
 # LLMs in AI features

--- a/docs/requirements/ai/response-engines.md
+++ b/docs/requirements/ai/response-engines.md
@@ -1,7 +1,6 @@
 ---
 parent: AI
 grand_parent: Requirements
-nav_order: 3
 ---
 
 # Different response engines for AI chat

--- a/docs/requirements/ai/response-engines.md
+++ b/docs/requirements/ai/response-engines.md
@@ -1,5 +1,7 @@
 ---
-parent: ai
+parent: AI
+grand_parent: Requirements
+nav_order: 3
 ---
 
 # Different response engines for AI chat

--- a/docs/requirements/ai/summarization.md
+++ b/docs/requirements/ai/summarization.md
@@ -1,7 +1,6 @@
 ---
 parent: AI
 grand_parent: Requirements
-nav_order: 4
 ---
 
 # Summarization with LLMs

--- a/docs/requirements/ai/summarization.md
+++ b/docs/requirements/ai/summarization.md
@@ -1,5 +1,7 @@
 ---
-parent: ai
+parent: AI
+grand_parent: Requirements
+nav_order: 4
 ---
 
 # Summarization with LLMs


### PR DESCRIPTION
### Summary

🤖 The AI requirements documentation on the developer documentation site was not expandable in the sidebar navigation tree because its child documents specified a lowercase `parent: ai` without `grand_parent: Requirements` (which also caused ambiguity with the other `AI` page in `code-howtos`). This update updates `parent: AI` and adds `grand_parent: Requirements` across the 9 AI requirement sub-pages so that the AI section is properly nested under Requirements with an expander arrow.

Analogies: like honey, this change sweetens the developer documentation by making deeply nested topics smooth to navigate; like chocolate, it neatly organizes the sections into digestible squares; and like the moon, the pages were always there in the dark, and now the navigation tree shines a light right on them.

`jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

1. Build the developer documentation with Jekyll or inspect the front matter in `docs/requirements/ai/*.md`.
2. Verify that all child pages define `parent: AI` and `grand_parent: Requirements`.
3. In the devdocs navigation tree under Requirements, verify that "AI" displays an expander chevron/arrow and expands to show the 9 sub-pages.
4. Run `npx markdownlint-cli2 "docs/**/*.md" "*.md"` and `npm run textlint` to verify no lint or spelling issues.

### Related issues and pull requests

Closes NA

### AI usage

Antigravity (model Gemini 3.8 Flash), AIL-3.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

# Code checklist

> [!IMPORTANT]
> **This is a mandatory final gate.** When the implementation is finished and before you open a PR, work through **every** box below and tick it. If a box cannot be ticked, fix the code first; mark a box `[/]` only if the point genuinely does not apply.
>
> `AGENTS.md` describes how to write code *while* developing — this file confirms the finished result. Do not skip the checklist and do not skip individual points.

## 1. Code self-review

Read your own diff once, top to bottom, and confirm each point.

### Nullability and control flow

- [/] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [/] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [/] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [/] No `catch (Exception e)` — only specific exceptions are caught.
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [/] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [/] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: ` `code` ` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [/] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.
- [/] Fetcher tests hit the live endpoints — the remote API is not mocked or stubbed (automated-review suggestions to mock it are rejected on purpose).

## 2. Verification commands

Run in this order — cheapest first. Each must pass.

- [/] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [/] `./gradlew modernizer`.
- [/] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [/] `./gradlew javadoc`.
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [x] `npm ci && npm run textlint` reports no misspellings (only if Markdown changed).
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.

## 3. Documentation

- [/] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines, sorted in next to existing entries about the same component/feature). Link the issue if one exists; link the PR only when no issue exists. Use `TODO` as the placeholder when neither is known yet — never a fake number. No entry for fixes to changes that were themselves introduced after the last release (feature only in `## [Unreleased]`) — update the existing unreleased entry instead if needed.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [x] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder (no issue confidently identified yet — an existing issue link always stays), it was replaced with the real PR-number link after PR creation, then committed and pushed. If an issue is identified or created later, the link is switched to the issue.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with Antigravity (model Gemini 3.8 Flash)