### PR TITLE
Move more openoffice setting to preference tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
+- We moved zotero-related settings from openoffice panel to openoffice/libreoffice preference tab. [#16352](https://github.com/JabRef/jabref/issues/16352)
 - We changed the default size of the "New Entry" dialog to improve visibility. [#11589](https://github.com/JabRef/jabref/issues/11589)
 - We changed the default macOS shortcuts for "Search document identifier online" and "Focus group list" to not insert special characters. [#16528](https://github.com/JabRef/jabref/issues/16528)
 - We changed the extension of backup files from `.bak` to `.bib`, so that they can be opened in JabRef. [#11454](https://github.com/JabRef/jabref/issues/11454)

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import javafx.beans.binding.Bindings;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.concurrent.Task;
 import javafx.geometry.Insets;
@@ -666,19 +665,6 @@ public class OpenOfficePanel {
         alwaysAddCitedOnPagesText.setOnAction(_ -> openOfficePreferences.setAlwaysAddCitedOnPages(alwaysAddCitedOnPagesText.isSelected()));
         alwaysAddCitedOnPagesText.disableProperty().bind(currentStyleProperty.map(style -> !(style instanceof JStyle)));
 
-        CheckMenuItem zoteroCompatibilityMode = new CheckMenuItem(Localization.lang("Zotero compatibility mode"));
-        zoteroCompatibilityMode.selectedProperty().set(openOfficePreferences.getZoteroCompatibilityMode());
-        zoteroCompatibilityMode.setOnAction(_ -> openOfficePreferences.setZoteroCompatibilityMode(zoteroCompatibilityMode.isSelected()));
-        zoteroCompatibilityMode.disableProperty().bind(currentStyleProperty.map(style -> !(style instanceof CitationStyle)));
-
-        CheckMenuItem inferCslStyleFromDocument = new CheckMenuItem(Localization.lang("Infer CSL style from document"));
-        inferCslStyleFromDocument.selectedProperty().set(openOfficePreferences.shouldInferCslStyleFromDocument());
-        inferCslStyleFromDocument.setOnAction(_ -> openOfficePreferences.setInferCslStyleFromDocument(inferCslStyleFromDocument.isSelected()));
-        inferCslStyleFromDocument.disableProperty().bind(Bindings.createBooleanBinding(
-                () -> !zoteroCompatibilityMode.isSelected() || !(currentStyleProperty.get() instanceof CitationStyle),
-                zoteroCompatibilityMode.selectedProperty(),
-                currentStyleProperty));
-
         CheckMenuItem onlyUseActiveTab = new CheckMenuItem(Localization.lang("Look up BibTeX entries in the currently selected library only"));
         onlyUseActiveTab.setSelected(!openOfficePreferences.getUseAllDatabases());
 
@@ -696,33 +682,22 @@ public class OpenOfficePanel {
                 alwaysAddCitedOnPagesText,
                 addSpaceBefore,
                 addSpaceAfter,
-                zoteroCompatibilityMode,
-                inferCslStyleFromDocument,
                 new SeparatorMenuItem(),
                 onlyUseActiveTab,
                 new SeparatorMenuItem(),
                 clearConnectionSettings);
 
         EasyBind.subscribe(currentStyleProperty, newValue -> {
-            updatePreferences(newValue, zoteroCompatibilityMode, inferCslStyleFromDocument);
-        });
-
-        EasyBind.subscribe(zoteroCompatibilityMode.selectedProperty(), isSelected -> {
-            if (!isSelected) {
-                inferCslStyleFromDocument.setSelected(false);
-                openOfficePreferences.setInferCslStyleFromDocument(false);
-            }
+            updatePreferences(newValue);
         });
 
         return contextMenu;
     }
 
-    private void updatePreferences(OOStyle currentStyle, CheckMenuItem zoteroCompatibilityMode, CheckMenuItem inferCslStyleFromDocument) {
-        boolean shouldSwitchOffZoteroMode = !(currentStyle instanceof CitationStyle);
-
-        if (shouldSwitchOffZoteroMode) {
-            zoteroCompatibilityMode.setSelected(false);
+    private void updatePreferences(OOStyle currentStyle) {
+        if (!(currentStyle instanceof CitationStyle)) {
             openOfficePreferences.setZoteroCompatibilityMode(false);
+            openOfficePreferences.setInferCslStyleFromDocument(false);
         }
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/preferences/openoffice/OpenOfficeTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/openoffice/OpenOfficeTab.java
@@ -46,6 +46,10 @@ public class OpenOfficeTab extends AbstractPreferenceTabView<OpenOfficeTabViewMo
         setContent(form()
                 .section(Localization.lang("Pandoc"), pandoc -> pandoc
                         .custom(buildPandocPathRow()))
+                .section(Localization.lang("Zotero"), zotero -> zotero
+                        .checkbox(Localization.lang("Zotero compatibility mode"), viewModel.zoteroCompatibilityModeProperty())
+                        .checkbox(Localization.lang("Infer CSL style from document"), viewModel.inferCslStyleFromDocumentProperty(), inference -> inference
+                                .disableWhen(viewModel.zoteroCompatibilityModeProperty().not())))
                 .build());
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/openoffice/OpenOfficeTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/openoffice/OpenOfficeTab.java
@@ -47,9 +47,11 @@ public class OpenOfficeTab extends AbstractPreferenceTabView<OpenOfficeTabViewMo
                 .section(Localization.lang("Pandoc"), pandoc -> pandoc
                         .custom(buildPandocPathRow()))
                 .section(Localization.lang("Zotero"), zotero -> zotero
-                        .checkbox(Localization.lang("Zotero compatibility mode"), viewModel.zoteroCompatibilityModeProperty())
+                        .checkbox(Localization.lang("Zotero compatibility mode"), viewModel.zoteroCompatibilityModeProperty(), mode -> mode
+                                .disableWhen(viewModel.zoteroCompatibilityModeDisabledProperty()))
                         .checkbox(Localization.lang("Infer CSL style from document"), viewModel.inferCslStyleFromDocumentProperty(), inference -> inference
-                                .disableWhen(viewModel.zoteroCompatibilityModeProperty().not())))
+                                .disableWhen(viewModel.zoteroCompatibilityModeDisabledProperty()
+                                        .or(viewModel.zoteroCompatibilityModeProperty().not()))))
                 .build());
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/openoffice/OpenOfficeTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/openoffice/OpenOfficeTab.java
@@ -51,7 +51,7 @@ public class OpenOfficeTab extends AbstractPreferenceTabView<OpenOfficeTabViewMo
                                 .disableWhen(viewModel.zoteroCompatibilityModeDisabledProperty()))
                         .checkbox(Localization.lang("Infer CSL style from document"), viewModel.inferCslStyleFromDocumentProperty(), inference -> inference
                                 .disableWhen(viewModel.zoteroCompatibilityModeDisabledProperty()
-                                        .or(viewModel.zoteroCompatibilityModeProperty().not()))))
+                                                      .or(viewModel.zoteroCompatibilityModeProperty().not()))))
                 .build());
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/openoffice/OpenOfficeTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/openoffice/OpenOfficeTabViewModel.java
@@ -3,6 +3,8 @@ package org.jabref.gui.preferences.openoffice;
 import java.nio.file.Path;
 import java.util.Optional;
 
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
@@ -12,6 +14,7 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.preferences.PreferenceTabViewModel;
 import org.jabref.gui.util.FileDialogConfiguration;
 import org.jabref.logic.FilePreferences;
+import org.jabref.logic.citationstyle.CitationStyle;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.openoffice.OpenOfficePreferences;
 import org.jabref.logic.openoffice.bst.PandocLatexConverter;
@@ -35,6 +38,7 @@ public class OpenOfficeTabViewModel implements PreferenceTabViewModel {
     private final FilePreferences filePreferences;
     private final OpenOfficePreferences openOfficePreferences;
     private final TaskExecutor taskExecutor;
+    private final BooleanBinding zoteroCompatibilityModeDisabled;
 
     public OpenOfficeTabViewModel(DialogService dialogService,
                                   FilePreferences filePreferences,
@@ -44,8 +48,17 @@ public class OpenOfficeTabViewModel implements PreferenceTabViewModel {
         this.filePreferences = filePreferences;
         this.openOfficePreferences = openOfficePreferences;
         this.taskExecutor = taskExecutor;
+        zoteroCompatibilityModeDisabled = Bindings.createBooleanBinding(
+                () -> !(openOfficePreferences.getCurrentStyle() instanceof CitationStyle),
+                openOfficePreferences.currentStyleProperty());
         zoteroCompatibilityMode.addListener((_, _, enabled) -> {
             if (!enabled) {
+                inferCslStyleFromDocument.set(false);
+            }
+        });
+        zoteroCompatibilityModeDisabled.addListener((_, _, disabled) -> {
+            if (disabled) {
+                zoteroCompatibilityMode.set(false);
                 inferCslStyleFromDocument.set(false);
             }
         });
@@ -54,16 +67,21 @@ public class OpenOfficeTabViewModel implements PreferenceTabViewModel {
     @Override
     public void setValues() {
         pandocPath.set(openOfficePreferences.getPandocPath());
-        zoteroCompatibilityMode.set(openOfficePreferences.getZoteroCompatibilityMode());
+        boolean compatibilityMode = openOfficePreferences.getZoteroCompatibilityMode()
+                && !zoteroCompatibilityModeDisabled.get();
+        zoteroCompatibilityMode.set(compatibilityMode);
         inferCslStyleFromDocument.set(openOfficePreferences.shouldInferCslStyleFromDocument()
-                && zoteroCompatibilityMode.get());
+                && compatibilityMode);
     }
 
     @Override
     public void storeSettings() {
         openOfficePreferences.setPandocPath(pandocPath.get());
-        openOfficePreferences.setZoteroCompatibilityMode(zoteroCompatibilityMode.get());
-        openOfficePreferences.setInferCslStyleFromDocument(inferCslStyleFromDocument.get());
+        boolean compatibilityMode = zoteroCompatibilityMode.get()
+                && !zoteroCompatibilityModeDisabled.get();
+        openOfficePreferences.setZoteroCompatibilityMode(compatibilityMode);
+        openOfficePreferences.setInferCslStyleFromDocument(inferCslStyleFromDocument.get()
+                && compatibilityMode);
     }
 
     public StringProperty pandocPathProperty() {
@@ -76,6 +94,10 @@ public class OpenOfficeTabViewModel implements PreferenceTabViewModel {
 
     public BooleanProperty inferCslStyleFromDocumentProperty() {
         return inferCslStyleFromDocument;
+    }
+
+    public BooleanBinding zoteroCompatibilityModeDisabledProperty() {
+        return zoteroCompatibilityModeDisabled;
     }
 
     public void browsePandocPath() {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/openoffice/OpenOfficeTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/openoffice/OpenOfficeTabViewModel.java
@@ -3,6 +3,8 @@ package org.jabref.gui.preferences.openoffice;
 import java.nio.file.Path;
 import java.util.Optional;
 
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
@@ -26,6 +28,8 @@ public class OpenOfficeTabViewModel implements PreferenceTabViewModel {
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenOfficeTabViewModel.class);
 
     private final StringProperty pandocPath = new SimpleStringProperty();
+    private final BooleanProperty zoteroCompatibilityMode = new SimpleBooleanProperty();
+    private final BooleanProperty inferCslStyleFromDocument = new SimpleBooleanProperty();
 
     private final DialogService dialogService;
     private final FilePreferences filePreferences;
@@ -40,20 +44,38 @@ public class OpenOfficeTabViewModel implements PreferenceTabViewModel {
         this.filePreferences = filePreferences;
         this.openOfficePreferences = openOfficePreferences;
         this.taskExecutor = taskExecutor;
+        zoteroCompatibilityMode.addListener((_, _, enabled) -> {
+            if (!enabled) {
+                inferCslStyleFromDocument.set(false);
+            }
+        });
     }
 
     @Override
     public void setValues() {
         pandocPath.set(openOfficePreferences.getPandocPath());
+        zoteroCompatibilityMode.set(openOfficePreferences.getZoteroCompatibilityMode());
+        inferCslStyleFromDocument.set(openOfficePreferences.shouldInferCslStyleFromDocument()
+                && zoteroCompatibilityMode.get());
     }
 
     @Override
     public void storeSettings() {
         openOfficePreferences.setPandocPath(pandocPath.get());
+        openOfficePreferences.setZoteroCompatibilityMode(zoteroCompatibilityMode.get());
+        openOfficePreferences.setInferCslStyleFromDocument(inferCslStyleFromDocument.get());
     }
 
     public StringProperty pandocPathProperty() {
         return pandocPath;
+    }
+
+    public BooleanProperty zoteroCompatibilityModeProperty() {
+        return zoteroCompatibilityMode;
+    }
+
+    public BooleanProperty inferCslStyleFromDocumentProperty() {
+        return inferCslStyleFromDocument;
     }
 
     public void browsePandocPath() {

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -1204,6 +1204,7 @@ Automatically\ add\ "Cited\ on\ pages..."\ at\ the\ end\ of\ bibliographic\ entr
 Automatically\ sync\ bibliography\ when\ inserting\ citations=Automatically sync bibliography when inserting citations
 Add\ space\ before\ citation=Add space before citation
 Add\ space\ after\ citation=Add space after citation
+Zotero=Zotero
 Infer\ CSL\ style\ from\ document=Infer CSL style from document
 Zotero\ compatibility\ mode=Zotero compatibility mode
 Reference\ mark\ format=Reference mark format


### PR DESCRIPTION
### Summary

Moved zotero related settings to openoffice preference tab
<img width="881" height="270" alt="image" src="https://github.com/user-attachments/assets/b5d658b2-5fdf-41e4-854f-8c5e0a938df4" />


### Steps to test

go to preference -> openoffice/libreoffice tab -> observe settings

### Related issues and pull requests

Follow up https://github.com/JabRef/jabref/pull/16471
Closes https://github.com/JabRef/jabref/issues/16352

### AI usage
codex 5.5 + 🧠

_____

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
