### PR TITLE
Resolve LaTeX aux file paths relative to the library file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed freezing while scrolling results in the Search for unlinked local files dialog. [#16696](https://github.com/JabRef/jabref/pull/16696)
 - We fixed an issue where "File > Git > Commit" refused to commit when the repository had no remote or the remote could not be reached. [#16720](https://github.com/JabRef/jabref/pull/16720)
 - We fixed the unreadable hit count on group badges that turn green because they contain selected entries. [#16700](https://github.com/JabRef/jabref/pull/16700)
+- We fixed cited-entry groups using LaTeX aux files to work with relative library paths. [#8344](https://github.com/JabRef/jabref/issues/8344)
 - We fixed an issue where resolving external library conflicts through the merge dialog could discard the merged result. [#16537](https://github.com/JabRef/jabref/issues/16537)
 - We fixed an issue where switching entries in the source tab could throw an exception or overwrite another entry. [#16534](https://github.com/JabRef/jabref/issues/16534)
 - We fixed an issue where a PDF imported as a new entry via the merge dialog lost its file link. [#16677](https://github.com/JabRef/jabref/pull/16677)

--- a/docs/requirements/ux.md
+++ b/docs/requirements/ux.md
@@ -76,6 +76,14 @@ When a user creates a new explicit group, JabRef should allow reusing the curren
 
 Needs: impl
 
+## Cited-entry groups resolve relative aux paths predictably
+`req~ux.groups.cited-entries.aux-path-resolution~1`
+
+When a group based on cited entries stores a relative aux path, JabRef must resolve it first against the configured LaTeX file directory and then against the library file directory.
+When converting an absolute aux path back to a stored path, JabRef must keep it absolute unless the relative path would still resolve to the same aux file.
+
+Needs: impl
+
 ## Saving keeps external change detection active
 `req~ux.external-library-changes.after-save~1`
 

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
@@ -535,7 +535,11 @@ public class GroupDialogViewModel {
                                                                  .orElse(FileUtil.getInitialDirectory(currentDatabase, preferences.getFilePreferences().getWorkingDirectory())).toString() : texGroupFilePathProperty.get()).build();
         dialogService.showFileOpenDialog(fileDialogConfiguration)
                      .ifPresent(file -> texGroupFilePathProperty.setValue(
-                             FileUtil.relativize(file.toAbsolutePath(), getFileDirectoriesAsPaths()).toString()
+                             TexGroup.toStoredPath(
+                                             file.toAbsolutePath(),
+                                             currentDatabase.getMetaData(),
+                                             preferences.getFilePreferences().getUserAndHost())
+                                     .toString()
                      ));
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
@@ -3,7 +3,6 @@ package org.jabref.gui.groups;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -56,7 +55,6 @@ import org.jabref.model.groups.RegexKeywordGroup;
 import org.jabref.model.groups.SearchGroup;
 import org.jabref.model.groups.TexGroup;
 import org.jabref.model.groups.WordKeywordGroup;
-import org.jabref.model.metadata.MetaData;
 import org.jabref.model.search.SearchFlags;
 import org.jabref.model.search.query.SearchQuery;
 import org.jabref.model.util.FileUpdateMonitor;
@@ -283,13 +281,12 @@ public class GroupDialogViewModel {
                 sameNameValidator);
     }
 
-    /// Gets the absolute path relative to the LatexFileDirectory, if given a relative path
+    /// Resolves a user supplied aux file path against the directories of the library.
     ///
     /// @param input the user input path
-    /// @return an absolute path if LatexFileDirectory exists; otherwise, returns input
+    /// @return an absolute path if the file was found; otherwise, the input as given
     private Path getAbsoluteTexGroupPath(String input) {
-        Optional<Path> latexFileDirectory = currentDatabase.getMetaData().getLatexFileDirectory(preferences.getFilePreferences().getUserAndHost());
-        return latexFileDirectory.map(path -> path.resolve(input)).orElse(Path.of(input));
+        return FileUtil.find(input, getFileDirectoriesAsPaths()).orElse(Path.of(input));
     }
 
     public void validationHandler(Event event) {
@@ -533,9 +530,9 @@ public class GroupDialogViewModel {
                 .addExtensionFilter(StandardFileType.AUX)
                 .withDefaultExtension(StandardFileType.AUX)
                 .withInitialDirectory(texGroupFilePathProperty.getValue().isBlank() ?
-                                      currentDatabase.getMetaData()
-                                                     .getLatexFileDirectory(preferences.getFilePreferences().getUserAndHost())
-                                                     .orElse(FileUtil.getInitialDirectory(currentDatabase, preferences.getFilePreferences().getWorkingDirectory())).toString() : texGroupFilePathProperty.get()).build();
+                                      getFileDirectoriesAsPaths().stream()
+                                                                 .findFirst()
+                                                                 .orElse(FileUtil.getInitialDirectory(currentDatabase, preferences.getFilePreferences().getWorkingDirectory())).toString() : texGroupFilePathProperty.get()).build();
         dialogService.showFileOpenDialog(fileDialogConfiguration)
                      .ifPresent(file -> texGroupFilePathProperty.setValue(
                              FileUtil.relativize(file.toAbsolutePath(), getFileDirectoriesAsPaths()).toString()
@@ -543,11 +540,7 @@ public class GroupDialogViewModel {
     }
 
     private List<Path> getFileDirectoriesAsPaths() {
-        List<Path> fileDirs = new ArrayList<>();
-        MetaData metaData = currentDatabase.getMetaData();
-        metaData.getLatexFileDirectory(preferences.getFilePreferences().getUserAndHost()).ifPresent(fileDirs::add);
-
-        return fileDirs;
+        return TexGroup.auxFileDirectories(currentDatabase.getMetaData(), preferences.getFilePreferences().getUserAndHost());
     }
 
     public ValidationStatus validationStatus() {

--- a/jabgui/src/test/java/org/jabref/gui/groups/GroupDialogViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/groups/GroupDialogViewModelTest.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 
 import javafx.collections.FXCollections;
 import javafx.scene.control.ButtonType;
@@ -30,16 +29,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class GroupDialogViewModelTest {
 
+    private static final String USER_AND_HOST = "MockedUser-mockedhost";
+
     private GroupDialogViewModel viewModel;
     private Path temporaryFolder;
     private BibDatabaseContext bibDatabaseContext;
-    private final MetaData metaData = mock(MetaData.class);
+    private MetaData metaData;
     private final StateManager stateManager = mock(StateManager.class);
     private final GroupsPreferences groupsPreferences = mock(GroupsPreferences.class);
     private final DialogService dialogService = mock(DialogService.class);
@@ -49,6 +49,7 @@ class GroupDialogViewModelTest {
     @BeforeEach
     void setUp(@TempDir Path temporaryFolder) {
         this.temporaryFolder = temporaryFolder;
+        this.metaData = new MetaData();
         bibDatabaseContext = new BibDatabaseContext();
 
         when(group.getName()).thenReturn("Group");
@@ -56,7 +57,7 @@ class GroupDialogViewModelTest {
         when(preferences.getBibEntryPreferences()).thenReturn(mock(BibEntryPreferences.class));
         when(preferences.getBibEntryPreferences().getKeywordSeparator()).thenReturn(',');
         when(preferences.getFilePreferences()).thenReturn(mock(FilePreferences.class));
-        when(preferences.getFilePreferences().getUserAndHost()).thenReturn("MockedUser-mockedhost");
+        when(preferences.getFilePreferences().getUserAndHost()).thenReturn(USER_AND_HOST);
         when(preferences.getGroupsPreferences()).thenReturn(groupsPreferences);
         when(groupsPreferences.getDefaultHierarchicalContext()).thenReturn(GroupHierarchyType.INDEPENDENT);
         when(stateManager.getSelectedEntries()).thenReturn(FXCollections.emptyObservableList());
@@ -71,7 +72,6 @@ class GroupDialogViewModelTest {
         Path anAuxFile = temporaryFolder.resolve("auxfile.aux").toAbsolutePath();
 
         Files.createFile(anAuxFile);
-        when(metaData.getLatexFileDirectory(any(String.class))).thenReturn(Optional.of(temporaryFolder));
 
         viewModel.texGroupFilePathProperty().setValue(anAuxFile.toString());
         assertTrue(viewModel.texGroupFilePathValidatonStatus().isValid());
@@ -88,9 +88,19 @@ class GroupDialogViewModelTest {
     void validateExistingRelativePath() throws IOException {
         Path anAuxFile = Path.of("auxfile.aux");
 
-        // The file needs to exist
         Files.createFile(temporaryFolder.resolve(anAuxFile));
-        when(metaData.getLatexFileDirectory(any(String.class))).thenReturn(Optional.of(temporaryFolder));
+        metaData.setLatexFileDirectory(USER_AND_HOST, temporaryFolder.toString());
+
+        viewModel.texGroupFilePathProperty().setValue(anAuxFile.toString());
+        assertTrue(viewModel.texGroupFilePathValidatonStatus().isValid());
+    }
+
+    @Test
+    void validateExistingRelativePathRelativeToLibrary() throws IOException {
+        Path anAuxFile = Path.of("auxfile.aux");
+
+        Files.createFile(temporaryFolder.resolve(anAuxFile));
+        bibDatabaseContext.setDatabasePath(temporaryFolder.resolve("library.bib"));
 
         viewModel.texGroupFilePathProperty().setValue(anAuxFile.toString());
         assertTrue(viewModel.texGroupFilePathValidatonStatus().isValid());

--- a/jabgui/src/test/java/org/jabref/gui/groups/GroupDialogViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/groups/GroupDialogViewModelTest.java
@@ -107,6 +107,19 @@ class GroupDialogViewModelTest {
     }
 
     @Test
+    void validateExistingRelativePathFallsBackToLibraryWhenLatexDirectoryMissesTheAuxFile() throws IOException {
+        Path anAuxFile = Path.of("auxfile.aux");
+        Path latexDirectory = Files.createDirectory(temporaryFolder.resolve("latex"));
+
+        Files.createFile(temporaryFolder.resolve(anAuxFile));
+        metaData.setLatexFileDirectory(USER_AND_HOST, latexDirectory.toString());
+        bibDatabaseContext.setDatabasePath(temporaryFolder.resolve("library.bib"));
+
+        viewModel.texGroupFilePathProperty().setValue(anAuxFile.toString());
+        assertTrue(viewModel.texGroupFilePathValidatonStatus().isValid());
+    }
+
+    @Test
     void hierarchicalContextFromGroup() {
         GroupHierarchyType groupHierarchyType = GroupHierarchyType.INCLUDING;
         when(group.getHierarchicalContext()).thenReturn(groupHierarchyType);

--- a/jabgui/src/test/java/org/jabref/gui/groups/GroupDialogViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/groups/GroupDialogViewModelTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import javafx.collections.FXCollections;
 import javafx.scene.control.ButtonType;
@@ -29,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -117,6 +119,22 @@ class GroupDialogViewModelTest {
 
         viewModel.texGroupFilePathProperty().setValue(anAuxFile.toString());
         assertTrue(viewModel.texGroupFilePathValidatonStatus().isValid());
+    }
+
+    @Test
+    void texGroupBrowseKeepsAbsolutePathWhenRelativePathWouldRetarget() throws IOException {
+        Path libraryDirectory = Files.createDirectory(temporaryFolder.resolve("library"));
+        Path latexDirectory = Files.createDirectory(temporaryFolder.resolve("latex"));
+        Path libraryAuxFile = Files.createFile(libraryDirectory.resolve("paper.aux"));
+        Files.createFile(latexDirectory.resolve("paper.aux"));
+
+        metaData.setLatexFileDirectory(USER_AND_HOST, latexDirectory.toString());
+        bibDatabaseContext.setDatabasePath(libraryDirectory.resolve("library.bib"));
+        when(dialogService.showFileOpenDialog(any())).thenReturn(Optional.of(libraryAuxFile));
+
+        viewModel.texGroupBrowse();
+
+        assertEquals(libraryAuxFile.toString(), viewModel.texGroupFilePathProperty().get());
     }
 
     @Test

--- a/jablib/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -154,17 +154,11 @@ public class GroupsParser {
         GroupHierarchyType context = GroupHierarchyType.getByNumberOrDefault(Integer.parseInt(token.nextToken()));
         try {
             Path path = Path.of(token.nextToken());
-            try {
-                TexGroup newGroup = TexGroup.create(name, context, path, new DefaultAuxParser(new BibDatabase()), fileMonitor, metaData, userAndHost);
-                addGroupDetails(token, newGroup);
-                return newGroup;
-            } catch (IOException ex) {
-                LOGGER.warn("Could not access file {}. The group {} will not reflect changes to the aux file.", path, name, ex);
-
-                TexGroup newGroup = TexGroup.create(name, context, path, new DefaultAuxParser(new BibDatabase()), metaData, userAndHost);
-                addGroupDetails(token, newGroup);
-                return newGroup;
-            }
+            // The aux file often cannot be resolved yet, because the location of the `.bib` file is
+            // not known during parsing. TexGroup registers the file monitor as soon as it can.
+            TexGroup newGroup = TexGroup.create(name, context, path, new DefaultAuxParser(new BibDatabase()), fileMonitor, metaData, userAndHost);
+            addGroupDetails(token, newGroup);
+            return newGroup;
         } catch (InvalidPathException | IOException ex) {
             throw new ParseException(ex);
         }

--- a/jablib/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/jablib/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -82,6 +82,7 @@ public class BibDatabaseContext {
         this.database = database;
         this.metaData = metaData;
         this.location = DatabaseLocation.LOCAL;
+        this.metaData.setLibraryPath(null);
     }
 
     public BibDatabaseContext(BibDatabase database, MetaData metaData, @Nullable Path path) {
@@ -90,7 +91,7 @@ public class BibDatabaseContext {
 
     public BibDatabaseContext(BibDatabase database, MetaData metaData, @Nullable Path path, DatabaseLocation location) {
         this(database, metaData);
-        this.path = path;
+        setDatabasePath(path);
 
         if (location == DatabaseLocation.LOCAL) {
             convertToLocalDatabase();
@@ -107,6 +108,8 @@ public class BibDatabaseContext {
 
     public void setDatabasePath(@Nullable Path file) {
         this.path = file;
+        // Groups can store paths relative to the library, so they must learn about the new location.
+        this.metaData.setLibraryPath(file);
     }
 
     /// Get the path where this database was last saved to or loaded from, if any.
@@ -117,7 +120,7 @@ public class BibDatabaseContext {
     }
 
     public void clearDatabasePath() {
-        this.path = null;
+        setDatabasePath(null);
     }
 
     public BibDatabase getDatabase() {
@@ -135,6 +138,7 @@ public class BibDatabaseContext {
 
     public void setMetaData(MetaData metaData) {
         this.metaData = metaData;
+        this.metaData.setLibraryPath(this.path);
     }
 
     public boolean isBiblatexMode() {

--- a/jablib/src/main/java/org/jabref/model/groups/TexGroup.java
+++ b/jablib/src/main/java/org/jabref/model/groups/TexGroup.java
@@ -1,11 +1,13 @@
 package org.jabref.model.groups;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.SequencedSet;
 import java.util.Set;
 
@@ -47,11 +49,13 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
     /// Lazily computed value, therefore, nullable.
     private @Nullable Set<String> keysUsedInAux;
 
-    /// Lazily computed value, therefore, nullable. Dropped when the library path changes.
+    /// Lazily computed value, therefore, nullable. Dropped when the library path changes or when a
+    /// watched aux file is created or updated.
     private @Nullable Path resolvedPath;
 
-    /// The path currently registered at the file monitor, or null if nothing is registered.
-    private @Nullable Path monitoredPath;
+    /// Relative aux paths can appear later in any configured directory. We therefore watch every
+    /// absolute candidate path so a newly created higher-priority aux file can take over.
+    private final SequencedSet<Path> monitoredPaths = new LinkedHashSet<>();
 
     /// Whether this group was created with a real file monitor.
     private boolean monitorWanted;
@@ -109,6 +113,7 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
     ///    It comes first, because paths written by earlier JabRef versions are relative to it.
     /// 2. The directory of the `.bib` file. This makes the path work on every computer that
     ///    syncs the library, without any per-host setting.
+    // [impl->req~ux.groups.cited-entries.aux-path-resolution~1]
     public static List<Path> auxFileDirectories(MetaData metaData, String userAndHost) {
         SequencedSet<Path> directories = new LinkedHashSet<>();
         metaData.getLatexFileDirectory(userAndHost).ifPresent(directories::add);
@@ -116,6 +121,37 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
                 .flatMap(path -> java.util.Optional.ofNullable(path.getParent()))
                 .ifPresent(directories::add);
         return new ArrayList<>(directories);
+    }
+
+    /// Converts an absolute aux path to a portable stored path when doing so keeps the same file
+    /// selected after applying the LaTeX-directory lookup order.
+    public static Path toStoredPath(Path auxFile, MetaData metaData, String userAndHost) {
+        return toStoredPath(auxFile, auxFileDirectories(metaData, userAndHost));
+    }
+
+    private static Path toStoredPath(Path auxFile, List<Path> directories) {
+        if (!auxFile.isAbsolute()) {
+            return auxFile;
+        }
+
+        Path relativePath = FileUtil.relativize(auxFile, directories);
+        if (relativePath.isAbsolute()) {
+            return relativePath;
+        }
+
+        return FileUtil.find(relativePath.toString(), directories)
+                       .filter(resolvedPath -> refersToSameFile(resolvedPath, auxFile))
+                       .map(_ -> relativePath)
+                       .orElse(auxFile);
+    }
+
+    private static boolean refersToSameFile(Path first, Path second) {
+        try {
+            return Files.isSameFile(first, second);
+        } catch (IOException exception) {
+            LOGGER.debug("Could not compare aux file targets {} and {}", first, second, exception);
+            return first.toAbsolutePath().normalize().equals(second.toAbsolutePath().normalize());
+        }
     }
 
     /// Rebinds this group to the metadata instance that currently owns its group tree.
@@ -131,7 +167,8 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
         pathDependenciesChanged();
     }
 
-    /// The absolute path of the aux file, if it can be found. Otherwise, the stored path.
+    /// The path currently used for parsing: the first matching aux file, or the highest-priority
+    /// absolute candidate while the file is still missing.
     public Path getFilePathResolved() {
         Path currentPath = resolvedPath;
         if (currentPath == null) {
@@ -140,10 +177,14 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
         return currentPath;
     }
 
-    /// The path to write to the `.bib` file. It is relative if the aux file is below one of the
-    /// directories returned by `auxFileDirectories(MetaData, String)`.
+    /// The path to write to the `.bib` file. It is kept relative if that still resolves to the
+    /// same aux file with the library's directory precedence.
     public Path getFilePath() {
-        return FileUtil.relativize(getFilePathResolved(), auxFileDirectories(metaData, user));
+        if (!storedPath.isAbsolute()) {
+            return storedPath;
+        }
+
+        return toStoredPath(getFilePathResolved(), metaData, user);
     }
 
     @Override
@@ -199,7 +240,7 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
 
     @Override
     public void fileUpdated() {
-        // Reset previous parse result
+        resolvedPath = null;
         keysUsedInAux = null;
         metaData.groupsBinding().invalidate();
     }
@@ -215,9 +256,9 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
     }
 
     private Path refreshResolvedPath() {
-        Path currentPath = FileUtil.find(storedPath.toString(), auxFileDirectories(metaData, user)).orElse(storedPath);
+        Path currentPath = resolveExistingPath().orElseGet(this::firstCandidatePath);
         resolvedPath = currentPath;
-        updateFileMonitor(currentPath);
+        updateFileMonitor(candidateMonitorPaths());
         return currentPath;
     }
 
@@ -225,39 +266,63 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
     private void pathDependenciesChanged() {
         resolvedPath = null;
         keysUsedInAux = null;
-        updateFileMonitor(null);
+        updateFileMonitor(List.of());
         if (monitorWanted) {
             refreshResolvedPath();
         }
         metaData.groupsBinding().invalidate();
     }
 
-    /// Moves the file monitor to the given path.
-    private void updateFileMonitor(@Nullable Path newPath) {
+    private Optional<Path> resolveExistingPath() {
+        return FileUtil.find(storedPath.toString(), auxFileDirectories(metaData, user));
+    }
+
+    private Path firstCandidatePath() {
+        return candidateMonitorPaths().stream().findFirst().orElse(storedPath);
+    }
+
+    private List<Path> candidateMonitorPaths() {
+        if (storedPath.isAbsolute()) {
+            return List.of(storedPath);
+        }
+
+        return auxFileDirectories(metaData, user).stream()
+                                                 .map(directory -> directory.resolve(storedPath))
+                                                 .filter(Path::isAbsolute)
+                                                 .distinct()
+                                                 .toList();
+    }
+
+    private void updateFileMonitor(List<Path> newPaths) {
         if (!monitorWanted) {
             return;
         }
 
-        if ((newPath != null) && !newPath.isAbsolute()) {
-            newPath = null;
+        SequencedSet<Path> targetPaths = new LinkedHashSet<>(newPaths);
+        if (monitoredPaths.equals(targetPaths)) {
+            return;
         }
 
-        if (Objects.equals(monitoredPath, newPath)) {
-            return;
+        List<Path> pathsToRemove = monitoredPaths.stream()
+                                                 .filter(path -> !targetPaths.contains(path))
+                                                 .toList();
+        for (Path path : pathsToRemove) {
+            fileMonitor.removeListener(path, this);
+            monitoredPaths.remove(path);
         }
-        if (monitoredPath != null) {
-            fileMonitor.removeListener(monitoredPath, this);
-            monitoredPath = null;
-        }
-        if (newPath == null) {
-            return;
-        }
-        try {
-            fileMonitor.addListenerForFile(newPath, this);
-            monitoredPath = newPath;
-        } catch (IOException ex) {
-            LOGGER.warn("Could not access file {}. The group {} will not reflect changes to the aux file.",
-                    newPath, name.getValue(), ex);
+
+        for (Path path : targetPaths) {
+            if (monitoredPaths.contains(path)) {
+                continue;
+            }
+
+            try {
+                fileMonitor.addListenerForFile(path, this);
+                monitoredPaths.add(path);
+            } catch (IOException exception) {
+                LOGGER.warn("Could not access file {}. The group {} will not reflect changes to the aux file.",
+                        path, name.getValue(), exception);
+            }
         }
     }
 }

--- a/jablib/src/main/java/org/jabref/model/groups/TexGroup.java
+++ b/jablib/src/main/java/org/jabref/model/groups/TexGroup.java
@@ -189,8 +189,13 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
 
     @Override
     public boolean contains(BibEntry entry) {
+        Path currentAuxPath = getFilePathResolved();
+        if (!Files.exists(currentAuxPath)) {
+            return false;
+        }
+
         if (keysUsedInAux == null) {
-            AuxParserResult auxResult = auxParser.parse(getFilePathResolved());
+            AuxParserResult auxResult = auxParser.parse(currentAuxPath);
             keysUsedInAux = auxResult.getUniqueKeys();
         }
 

--- a/jablib/src/main/java/org/jabref/model/groups/TexGroup.java
+++ b/jablib/src/main/java/org/jabref/model/groups/TexGroup.java
@@ -2,9 +2,15 @@ package org.jabref.model.groups;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.SequencedSet;
 import java.util.Set;
+
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.WeakChangeListener;
 
 import org.jabref.architecture.AllowedToUseLogic;
 import org.jabref.logic.auxparser.AuxParser;
@@ -18,18 +24,43 @@ import org.jabref.model.util.FileUpdateMonitor;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @AllowedToUseLogic("because it needs access to aux parser")
 @NullMarked
 public class TexGroup extends AbstractGroup implements FileUpdateListener {
 
-    private final Path filePath;
-    // Lazily computed value, therefore, nullable.
-    private @Nullable Set<String> keysUsedInAux;
+    private static final Logger LOGGER = LoggerFactory.getLogger(TexGroup.class);
+
+    /// The path exactly as stored in the `.bib` file. It can be relative or absolute.
+    ///
+    /// The path is not resolved in the constructor. When the library is parsed, the location of the
+    /// `.bib` file is not known yet, and it changes again on "Save as". Resolution is therefore done
+    /// on demand in `getFilePathResolved()` and is dropped when the library or LaTeX directory changes.
+    private final Path storedPath;
     private final FileUpdateMonitor fileMonitor;
     private final AuxParser auxParser;
-    private final MetaData metaData;
+    private MetaData metaData;
     private final String user;
+
+    /// Lazily computed value, therefore, nullable.
+    private @Nullable Set<String> keysUsedInAux;
+
+    /// Lazily computed value, therefore, nullable. Dropped when the library path changes.
+    private @Nullable Path resolvedPath;
+
+    /// The path currently registered at the file monitor, or null if nothing is registered.
+    private @Nullable Path monitoredPath;
+
+    /// Whether this group was created with a real file monitor.
+    private boolean monitorWanted;
+
+    /// Held strongly, because they are registered as weak listeners.
+    private final ChangeListener<@Nullable Path> libraryPathListener = (_, _, _) -> pathDependenciesChanged();
+    private final WeakChangeListener<@Nullable Path> weakLibraryPathListener = new WeakChangeListener<>(libraryPathListener);
+    private final ChangeListener<Number> latexFileDirectoryVersionListener = (_, _, _) -> pathDependenciesChanged();
+    private final WeakChangeListener<Number> weakLatexFileDirectoryVersionListener = new WeakChangeListener<>(latexFileDirectoryVersionListener);
 
     TexGroup(String name,
              GroupHierarchyType context,
@@ -39,11 +70,12 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
              MetaData metaData,
              String user) {
         super(name, context);
-        this.metaData = metaData;
-        this.user = user;
-        this.filePath = expandPath(filePath);
+        this.storedPath = filePath;
         this.auxParser = auxParser;
         this.fileMonitor = fileMonitor;
+        this.metaData = metaData;
+        this.user = user;
+        registerMetaDataListeners();
     }
 
     public static TexGroup create(String name,
@@ -54,7 +86,10 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
                                   MetaData metaData,
                                   String userAndHost) throws IOException {
         TexGroup group = new TexGroup(name, context, filePath, auxParser, fileMonitor, metaData, userAndHost);
-        fileMonitor.addListenerForFile(group.getFilePathResolved(), group);
+        group.monitorWanted = true;
+        // Arms the monitor if the file can already be resolved. If it cannot, the monitor is armed
+        // as soon as the library path or LaTeX directory becomes known.
+        group.refreshResolvedPath();
         return group;
     }
 
@@ -68,14 +103,53 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
         return new TexGroup(name, context, filePath, auxParser, new DummyFileUpdateMonitor(), metaData, userAndHost);
     }
 
+    /// The directories a relative aux file path is resolved against, in order of precedence.
+    ///
+    /// 1. The LaTeX file directory of the library, which is specific to user and host.
+    ///    It comes first, because paths written by earlier JabRef versions are relative to it.
+    /// 2. The directory of the `.bib` file. This makes the path work on every computer that
+    ///    syncs the library, without any per-host setting.
+    public static List<Path> auxFileDirectories(MetaData metaData, String userAndHost) {
+        SequencedSet<Path> directories = new LinkedHashSet<>();
+        metaData.getLatexFileDirectory(userAndHost).ifPresent(directories::add);
+        metaData.getLibraryPath()
+                .flatMap(path -> java.util.Optional.ofNullable(path.getParent()))
+                .ifPresent(directories::add);
+        return new ArrayList<>(directories);
+    }
+
+    /// Rebinds this group to the metadata instance that currently owns its group tree.
+    /// Only [MetaData] is expected to call this when groups are attached to a library.
+    public void setMetaData(MetaData metaData) {
+        if (this.metaData == metaData) {
+            return;
+        }
+
+        unregisterMetaDataListeners();
+        this.metaData = metaData;
+        registerMetaDataListeners();
+        pathDependenciesChanged();
+    }
+
+    /// The absolute path of the aux file, if it can be found. Otherwise, the stored path.
     public Path getFilePathResolved() {
-        return this.filePath;
+        Path currentPath = resolvedPath;
+        if (currentPath == null) {
+            currentPath = refreshResolvedPath();
+        }
+        return currentPath;
+    }
+
+    /// The path to write to the `.bib` file. It is relative if the aux file is below one of the
+    /// directories returned by `auxFileDirectories(MetaData, String)`.
+    public Path getFilePath() {
+        return FileUtil.relativize(getFilePathResolved(), auxFileDirectories(metaData, user));
     }
 
     @Override
     public boolean contains(BibEntry entry) {
         if (keysUsedInAux == null) {
-            AuxParserResult auxResult = auxParser.parse(filePath);
+            AuxParserResult auxResult = auxParser.parse(getFilePathResolved());
             keysUsedInAux = auxResult.getUniqueKeys();
         }
 
@@ -89,7 +163,7 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
 
     @Override
     public AbstractGroup deepCopy() {
-        return new TexGroup(name.getValue(), context, filePath, auxParser, fileMonitor, metaData, user);
+        return new TexGroup(name.getValue(), context, storedPath, auxParser, fileMonitor, metaData, user);
     }
 
     @Override
@@ -104,13 +178,14 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
             return false;
         }
         TexGroup group = (TexGroup) o;
-        return Objects.equals(filePath, group.filePath);
+        return Objects.equals(storedPath, group.storedPath);
     }
 
     @Override
     public String toString() {
         return "TexGroup{" +
-                "filePath=" + filePath +
+                "storedPath=" + storedPath +
+                ", resolvedPath=" + resolvedPath +
                 ", keysUsedInAux=" + keysUsedInAux +
                 ", auxParser=" + auxParser +
                 ", fileMonitor=" + fileMonitor +
@@ -119,11 +194,7 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), filePath);
-    }
-
-    public Path getFilePath() {
-        return relativize(filePath);
+        return Objects.hash(super.hashCode(), storedPath);
     }
 
     @Override
@@ -133,24 +204,60 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
         metaData.groupsBinding().invalidate();
     }
 
-    /// Relativizes the given path to the file directories.
-    /// The getLatexFileDirectory must be absolute to correctly relativize because we do not have a bibdatabasecontext
-    ///
-    /// @param path The path to relativize
-    /// @return A relative path or the original one if it could not be made relative
-    private Path relativize(Path path) {
-        List<Path> fileDirectories = getFileDirectoriesAsPaths();
-        return FileUtil.relativize(path, fileDirectories);
+    private void registerMetaDataListeners() {
+        metaData.libraryPathProperty().addListener(weakLibraryPathListener);
+        metaData.latexFileDirectoryVersionProperty().addListener(weakLatexFileDirectoryVersionListener);
     }
 
-    private Path expandPath(Path path) {
-        List<Path> fileDirectories = getFileDirectoriesAsPaths();
-        return FileUtil.find(path.toString(), fileDirectories).orElse(path);
+    private void unregisterMetaDataListeners() {
+        metaData.libraryPathProperty().removeListener(weakLibraryPathListener);
+        metaData.latexFileDirectoryVersionProperty().removeListener(weakLatexFileDirectoryVersionListener);
     }
 
-    private List<Path> getFileDirectoriesAsPaths() {
-        return metaData.getLatexFileDirectory(user)
-                       .map(List::of)
-                       .orElse(List.of());
+    private Path refreshResolvedPath() {
+        Path currentPath = FileUtil.find(storedPath.toString(), auxFileDirectories(metaData, user)).orElse(storedPath);
+        resolvedPath = currentPath;
+        updateFileMonitor(currentPath);
+        return currentPath;
+    }
+
+    /// Called when the `.bib` file is loaded or moved, or when the LaTeX directory changes.
+    private void pathDependenciesChanged() {
+        resolvedPath = null;
+        keysUsedInAux = null;
+        updateFileMonitor(null);
+        if (monitorWanted) {
+            refreshResolvedPath();
+        }
+        metaData.groupsBinding().invalidate();
+    }
+
+    /// Moves the file monitor to the given path.
+    private void updateFileMonitor(@Nullable Path newPath) {
+        if (!monitorWanted) {
+            return;
+        }
+
+        if ((newPath != null) && !newPath.isAbsolute()) {
+            newPath = null;
+        }
+
+        if (Objects.equals(monitoredPath, newPath)) {
+            return;
+        }
+        if (monitoredPath != null) {
+            fileMonitor.removeListener(monitoredPath, this);
+            monitoredPath = null;
+        }
+        if (newPath == null) {
+            return;
+        }
+        try {
+            fileMonitor.addListenerForFile(newPath, this);
+            monitoredPath = newPath;
+        } catch (IOException ex) {
+            LOGGER.warn("Could not access file {}. The group {} will not reflect changes to the aux file.",
+                    newPath, name.getValue(), ex);
+        }
     }
 }

--- a/jablib/src/main/java/org/jabref/model/groups/TexGroup.java
+++ b/jablib/src/main/java/org/jabref/model/groups/TexGroup.java
@@ -274,6 +274,16 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
     }
 
     private Optional<Path> resolveExistingPath() {
+        if (storedPath.isAbsolute()) {
+            if (Files.exists(storedPath)) {
+                return Optional.of(storedPath);
+            }
+
+            return absolutePathFallbackCandidates().stream()
+                                                   .filter(Files::exists)
+                                                   .findFirst();
+        }
+
         return FileUtil.find(storedPath.toString(), auxFileDirectories(metaData, user));
     }
 
@@ -283,14 +293,39 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
 
     private List<Path> candidateMonitorPaths() {
         if (storedPath.isAbsolute()) {
-            return List.of(storedPath);
+            return absolutePathFallbackCandidates();
         }
 
         return auxFileDirectories(metaData, user).stream()
                                                  .map(directory -> directory.resolve(storedPath))
-                                                 .filter(Path::isAbsolute)
+                                                 .filter(this::canWatch)
                                                  .distinct()
                                                  .toList();
+    }
+
+    /// Absolute aux paths from another computer are not portable. If the stored absolute path is
+    /// missing, retry the current LaTeX and library directories with the same file name so the
+    /// group can recover after sync or when a different mount point is used.
+    private List<Path> absolutePathFallbackCandidates() {
+        SequencedSet<Path> candidates = new LinkedHashSet<>();
+        if (canWatch(storedPath)) {
+            candidates.add(storedPath);
+        }
+
+        Optional.of(storedPath)
+                .filter(path -> !Files.exists(path))
+                .map(Path::getFileName)
+                .stream()
+                .flatMap(fileName -> auxFileDirectories(metaData, user).stream()
+                                                                       .map(directory -> directory.resolve(fileName)))
+                .filter(this::canWatch)
+                .forEach(candidates::add);
+
+        return new ArrayList<>(candidates);
+    }
+
+    private boolean canWatch(Path path) {
+        return Optional.ofNullable(path.getParent()).map(Files::exists).orElse(false);
     }
 
     private void updateFileMonitor(List<Path> newPaths) {

--- a/jablib/src/main/java/org/jabref/model/metadata/MetaData.java
+++ b/jablib/src/main/java/org/jabref/model/metadata/MetaData.java
@@ -10,7 +10,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedSet;
 
+import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
 
 import org.jabref.architecture.AllowedToUseLogic;
@@ -26,6 +28,7 @@ import org.jabref.model.database.event.ChangePropagation;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.types.EntryType;
 import org.jabref.model.groups.GroupTreeNode;
+import org.jabref.model.groups.TexGroup;
 import org.jabref.model.groups.event.GroupUpdatedEvent;
 import org.jabref.model.metadata.event.MetaDataChangedEvent;
 
@@ -70,6 +73,18 @@ public class MetaData {
     private final Map<String, String> latexFileDirectory = new HashMap<>(); // <User-Host, FilePath>
 
     private final ObjectProperty<GroupTreeNode> groupsRoot = new SimpleObjectProperty<>(null);
+
+    /// The location of the `.bib` file this metadata belongs to.
+    ///
+    /// It is mirrored from [org.jabref.model.database.BibDatabaseContext] and is never written to the
+    /// `.bib` file. It is observable, because it is unknown while the library is parsed and it changes
+    /// on "Save as". Groups that store a path relative to the library need to know about that change.
+    private final ObjectProperty<@Nullable Path> libraryPath = new SimpleObjectProperty<>(null);
+
+    /// Incremented whenever the LaTeX file directory changes.
+    /// Tex groups resolve paths against this directory and therefore need to refresh when it changes.
+    private final IntegerProperty latexFileDirectoryVersion = new SimpleIntegerProperty(0);
+
     private final OptionalBinding<GroupTreeNode> groupsRootBinding = new OptionalWrapper<>(groupsRoot);
     private final Map<String, Path> blgFilePathMap = new HashMap<>();
     private Optional<Version> groupSearchSyntaxVersion = Optional.empty();
@@ -118,6 +133,12 @@ public class MetaData {
 
     /// Sets a new group root node. **WARNING **: This invalidates everything returned by getGroups() so far!!!
     public void setGroups(@NonNull GroupTreeNode root) {
+        root.iterateOverTree()
+            .map(GroupTreeNode::getGroup)
+            .filter(TexGroup.class::isInstance)
+            .map(TexGroup.class::cast)
+            .forEach(group -> group.setMetaData(this));
+
         groupsRoot.setValue(root);
         root.subscribeToDescendantChanged(groupTreeNode -> groupsRootBinding.invalidate());
         root.subscribeToDescendantChanged(groupTreeNode -> eventBus.post(new GroupUpdatedEvent(this)));
@@ -322,17 +343,39 @@ public class MetaData {
         postChange();
     }
 
+    /// The location of the `.bib` file this metadata belongs to, if it was already saved or loaded.
+    public Optional<Path> getLibraryPath() {
+        return Optional.ofNullable(libraryPath.get());
+    }
+
+    /// Only [org.jabref.model.database.BibDatabaseContext] is expected to call this.
+    /// The value is not part of the metadata written to the `.bib` file, so it does not mark the
+    /// library as changed.
+    public void setLibraryPath(@Nullable Path path) {
+        libraryPath.set(path);
+    }
+
+    public ObjectProperty<@Nullable Path> libraryPathProperty() {
+        return libraryPath;
+    }
+
+    public IntegerProperty latexFileDirectoryVersionProperty() {
+        return latexFileDirectoryVersion;
+    }
+
     public Optional<Path> getLatexFileDirectory(String userHostString) {
         return Optional.ofNullable(latexFileDirectory.get(userHostString)).map(Path::of);
     }
 
     public void setLatexFileDirectory(@NonNull String userHostString, @NonNull String path) {
         latexFileDirectory.put(userHostString, path);
+        latexFileDirectoryVersion.set(latexFileDirectoryVersion.get() + 1);
         postChange();
     }
 
     public void clearLatexFileDirectory(String userHostString) {
         latexFileDirectory.remove(userHostString);
+        latexFileDirectoryVersion.set(latexFileDirectoryVersion.get() + 1);
         postChange();
     }
 

--- a/jablib/src/test/java/org/jabref/model/groups/TexGroupTest.java
+++ b/jablib/src/test/java/org/jabref/model/groups/TexGroupTest.java
@@ -98,6 +98,19 @@ class TexGroupTest {
         assertEquals(latexAuxFile, group.getFilePathResolved());
     }
 
+    @Test
+    void libraryPathIsUsedWhenLatexDirectoryDoesNotContainTheAuxFile(@TempDir Path tempDir) throws Exception {
+        Path libraryDirectory = Files.createDirectory(tempDir.resolve("library"));
+        Path latexDirectory = Files.createDirectory(tempDir.resolve("latex"));
+        Path libraryAuxFile = copyPaperAux(libraryDirectory);
+
+        metaData.setLibraryPath(libraryDirectory.resolve("library.bib"));
+        metaData.setLatexFileDirectory(USER_AND_HOST, latexDirectory.toString());
+        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, Path.of("paper.aux"), new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
+
+        assertEquals(libraryAuxFile, group.getFilePathResolved());
+    }
+
     /// "Save as" moves the library. The aux file then resolves to another directory.
     @Test
     void resolvedPathFollowsTheLibrary(@TempDir Path tempDir) throws Exception {

--- a/jablib/src/test/java/org/jabref/model/groups/TexGroupTest.java
+++ b/jablib/src/test/java/org/jabref/model/groups/TexGroupTest.java
@@ -2,6 +2,7 @@ package org.jabref.model.groups;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import org.jabref.architecture.AllowedToUseLogic;
 import org.jabref.logic.auxparser.DefaultAuxParser;
@@ -55,7 +56,8 @@ class TexGroupTest {
     @Test
     void getFilePathReturnsRelativePath() throws Exception {
         Path auxFile = paperAuxSource();
-        metaData.setLatexFileDirectory(USER_AND_HOST, auxFile.getParent().toString());
+        Path auxDirectory = Optional.ofNullable(auxFile.getParent()).orElseThrow();
+        metaData.setLatexFileDirectory(USER_AND_HOST, auxDirectory.toString());
         TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, auxFile, new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
 
         assertEquals("paper.aux", group.getFilePath().toString());
@@ -111,6 +113,20 @@ class TexGroupTest {
         assertEquals(libraryAuxFile, group.getFilePathResolved());
     }
 
+    @Test
+    void getFilePathKeepsAbsolutePathWhenRelativePathWouldRetarget(@TempDir Path tempDir) throws Exception {
+        Path libraryDirectory = Files.createDirectory(tempDir.resolve("library"));
+        Path latexDirectory = Files.createDirectory(tempDir.resolve("latex"));
+        Path libraryAuxFile = copyPaperAux(libraryDirectory);
+        copyPaperAux(latexDirectory);
+
+        metaData.setLibraryPath(libraryDirectory.resolve("library.bib"));
+        metaData.setLatexFileDirectory(USER_AND_HOST, latexDirectory.toString());
+        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, libraryAuxFile, new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
+
+        assertEquals(libraryAuxFile, group.getFilePath());
+    }
+
     /// "Save as" moves the library. The aux file then resolves to another directory.
     @Test
     void resolvedPathFollowsTheLibrary(@TempDir Path tempDir) throws Exception {
@@ -147,8 +163,8 @@ class TexGroupTest {
     }
 
     @Test
-    void fileMonitorIsArmedWhenLibraryPathBecomesKnown(@TempDir Path tempDir) throws Exception {
-        Path auxFile = copyPaperAux(tempDir);
+    void fileMonitorIsArmedForMissingAuxWhenLibraryPathBecomesKnown(@TempDir Path tempDir) throws Exception {
+        Path auxFile = tempDir.resolve("paper.aux");
         FileUpdateMonitor fileMonitor = mock(FileUpdateMonitor.class);
 
         TexGroup group = TexGroup.create("paper", GroupHierarchyType.INDEPENDENT, Path.of("paper.aux"), new DefaultAuxParser(new BibDatabase()), fileMonitor, metaData, USER_AND_HOST);
@@ -157,6 +173,20 @@ class TexGroupTest {
         metaData.setLibraryPath(tempDir.resolve("library.bib"));
 
         verify(fileMonitor).addListenerForFile(auxFile, group);
+    }
+
+    @Test
+    void fileMonitorWatchesAllCandidatePathsForRelativeAuxFile(@TempDir Path tempDir) throws Exception {
+        Path libraryDirectory = Files.createDirectory(tempDir.resolve("library"));
+        Path latexDirectory = Files.createDirectory(tempDir.resolve("latex"));
+        FileUpdateMonitor fileMonitor = mock(FileUpdateMonitor.class);
+
+        metaData.setLibraryPath(libraryDirectory.resolve("library.bib"));
+        metaData.setLatexFileDirectory(USER_AND_HOST, latexDirectory.toString());
+        TexGroup group = TexGroup.create("paper", GroupHierarchyType.INDEPENDENT, Path.of("paper.aux"), new DefaultAuxParser(new BibDatabase()), fileMonitor, metaData, USER_AND_HOST);
+
+        verify(fileMonitor).addListenerForFile(latexDirectory.resolve("paper.aux"), group);
+        verify(fileMonitor).addListenerForFile(libraryDirectory.resolve("paper.aux"), group);
     }
 
     @Test
@@ -176,6 +206,29 @@ class TexGroupTest {
 
         verify(fileMonitor).removeListener(firstAuxFile, group);
         verify(fileMonitor).addListenerForFile(secondAuxFile, group);
+    }
+
+    @Test
+    void auxResolutionRecoversWhenCandidateFilesAppearLater(@TempDir Path tempDir) throws Exception {
+        Path libraryDirectory = Files.createDirectory(tempDir.resolve("library"));
+        Path latexDirectory = Files.createDirectory(tempDir.resolve("latex"));
+        BibEntry inAux = new BibEntry().withCitationKey("Darwin1888");
+
+        metaData.setLibraryPath(libraryDirectory.resolve("library.bib"));
+        metaData.setLatexFileDirectory(USER_AND_HOST, latexDirectory.toString());
+        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, Path.of("paper.aux"), new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
+
+        assertFalse(group.contains(inAux));
+
+        Path libraryAuxFile = copyPaperAux(libraryDirectory);
+        group.fileUpdated();
+        assertEquals(libraryAuxFile, group.getFilePathResolved());
+        assertTrue(group.contains(inAux));
+
+        Path latexAuxFile = copyPaperAux(latexDirectory);
+        group.fileUpdated();
+        assertEquals(latexAuxFile, group.getFilePathResolved());
+        assertTrue(group.contains(inAux));
     }
 
     private static Path paperAuxSource() throws Exception {

--- a/jablib/src/test/java/org/jabref/model/groups/TexGroupTest.java
+++ b/jablib/src/test/java/org/jabref/model/groups/TexGroupTest.java
@@ -127,6 +127,23 @@ class TexGroupTest {
         assertEquals(libraryAuxFile, group.getFilePath());
     }
 
+    @Test
+    void missingAbsolutePathFallsBackToCurrentLatexDirectory(@TempDir Path tempDir) throws Exception {
+        Path libraryDirectory = Files.createDirectory(tempDir.resolve("library"));
+        Path latexDirectory = Files.createDirectory(tempDir.resolve("latex"));
+        Path currentAuxFile = copyPaperAux(latexDirectory);
+        Path missingAbsolutePath = tempDir.resolve("computer-a").resolve("paper.aux").toAbsolutePath();
+        BibEntry inAux = new BibEntry().withCitationKey("Darwin1888");
+
+        metaData.setLibraryPath(libraryDirectory.resolve("library.bib"));
+        metaData.setLatexFileDirectory(USER_AND_HOST, latexDirectory.toString());
+        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, missingAbsolutePath, new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
+
+        assertEquals(currentAuxFile, group.getFilePathResolved());
+        assertTrue(group.contains(inAux));
+        assertEquals("paper.aux", group.getFilePath().toString());
+    }
+
     /// "Save as" moves the library. The aux file then resolves to another directory.
     @Test
     void resolvedPathFollowsTheLibrary(@TempDir Path tempDir) throws Exception {
@@ -184,6 +201,21 @@ class TexGroupTest {
         metaData.setLibraryPath(libraryDirectory.resolve("library.bib"));
         metaData.setLatexFileDirectory(USER_AND_HOST, latexDirectory.toString());
         TexGroup group = TexGroup.create("paper", GroupHierarchyType.INDEPENDENT, Path.of("paper.aux"), new DefaultAuxParser(new BibDatabase()), fileMonitor, metaData, USER_AND_HOST);
+
+        verify(fileMonitor).addListenerForFile(latexDirectory.resolve("paper.aux"), group);
+        verify(fileMonitor).addListenerForFile(libraryDirectory.resolve("paper.aux"), group);
+    }
+
+    @Test
+    void fileMonitorFallsBackToCurrentDirectoriesForMissingAbsolutePath(@TempDir Path tempDir) throws Exception {
+        Path libraryDirectory = Files.createDirectory(tempDir.resolve("library"));
+        Path latexDirectory = Files.createDirectory(tempDir.resolve("latex"));
+        Path missingAbsolutePath = tempDir.resolve("computer-a").resolve("paper.aux").toAbsolutePath();
+        FileUpdateMonitor fileMonitor = mock(FileUpdateMonitor.class);
+
+        metaData.setLibraryPath(libraryDirectory.resolve("library.bib"));
+        metaData.setLatexFileDirectory(USER_AND_HOST, latexDirectory.toString());
+        TexGroup group = TexGroup.create("paper", GroupHierarchyType.INDEPENDENT, missingAbsolutePath, new DefaultAuxParser(new BibDatabase()), fileMonitor, metaData, USER_AND_HOST);
 
         verify(fileMonitor).addListenerForFile(latexDirectory.resolve("paper.aux"), group);
         verify(fileMonitor).addListenerForFile(libraryDirectory.resolve("paper.aux"), group);

--- a/jablib/src/test/java/org/jabref/model/groups/TexGroupTest.java
+++ b/jablib/src/test/java/org/jabref/model/groups/TexGroupTest.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import org.jabref.architecture.AllowedToUseLogic;
+import org.jabref.logic.auxparser.AuxParser;
 import org.jabref.logic.auxparser.DefaultAuxParser;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
@@ -238,6 +239,19 @@ class TexGroupTest {
 
         verify(fileMonitor).removeListener(firstAuxFile, group);
         verify(fileMonitor).addListenerForFile(secondAuxFile, group);
+    }
+
+    @Test
+    void missingAuxDoesNotTriggerParsing(@TempDir Path tempDir) {
+        Path libraryDirectory = tempDir.resolve("library");
+        AuxParser auxParser = mock(AuxParser.class);
+        BibEntry inAux = new BibEntry().withCitationKey("Darwin1888");
+
+        metaData.setLibraryPath(libraryDirectory.resolve("library.bib"));
+        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, Path.of("paper.aux"), auxParser, new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
+
+        assertFalse(group.contains(inAux));
+        verifyNoInteractions(auxParser);
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/model/groups/TexGroupTest.java
+++ b/jablib/src/test/java/org/jabref/model/groups/TexGroupTest.java
@@ -1,6 +1,6 @@
 package org.jabref.model.groups;
 
-import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.jabref.architecture.AllowedToUseLogic;
@@ -9,16 +9,23 @@ import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.model.util.DummyFileUpdateMonitor;
+import org.jabref.model.util.FileUpdateMonitor;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @AllowedToUseLogic("because class under test relies on logic classes")
 class TexGroupTest {
+
+    private static final String USER_AND_HOST = "Darwin";
 
     private MetaData metaData;
 
@@ -28,32 +35,143 @@ class TexGroupTest {
     }
 
     @Test
-    void containsReturnsTrueForEntryInAux() throws URISyntaxException {
-        Path auxFile = Path.of(TexGroupTest.class.getResource("paper.aux").toURI());
-        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, auxFile, new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, "userandHost");
-        BibEntry inAux = new BibEntry();
-        inAux.setCitationKey("Darwin1888");
+    void containsReturnsTrueForEntryInAux() throws Exception {
+        Path auxFile = paperAuxSource();
+        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, auxFile, new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
+        BibEntry inAux = new BibEntry().withCitationKey("Darwin1888");
 
         assertTrue(group.contains(inAux));
     }
 
     @Test
-    void containsReturnsTrueForEntryNotInAux() throws URISyntaxException {
-        Path auxFile = Path.of(TexGroupTest.class.getResource("paper.aux").toURI());
-        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, auxFile, new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, "userandHost");
-        BibEntry notInAux = new BibEntry();
-        notInAux.setCitationKey("NotInAux2017");
+    void containsReturnsFalseForEntryNotInAux() throws Exception {
+        Path auxFile = paperAuxSource();
+        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, auxFile, new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
+        BibEntry notInAux = new BibEntry().withCitationKey("NotInAux2017");
 
         assertFalse(group.contains(notInAux));
     }
 
     @Test
-    void getFilePathReturnsRelativePath() throws URISyntaxException {
-        Path auxFile = Path.of(TexGroupTest.class.getResource("paper.aux").toURI());
-        String user = "Darwin";
-        metaData.setLatexFileDirectory(user, auxFile.getParent().toString());
-        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, auxFile, new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, user);
+    void getFilePathReturnsRelativePath() throws Exception {
+        Path auxFile = paperAuxSource();
+        metaData.setLatexFileDirectory(USER_AND_HOST, auxFile.getParent().toString());
+        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, auxFile, new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
 
         assertEquals("paper.aux", group.getFilePath().toString());
+    }
+
+    @Test
+    void getFilePathReturnsPathRelativeToLibrary(@TempDir Path tempDir) throws Exception {
+        Path auxFile = copyPaperAux(tempDir);
+        metaData.setLibraryPath(tempDir.resolve("library.bib"));
+        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, auxFile, new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
+
+        assertEquals("paper.aux", group.getFilePath().toString());
+    }
+
+    /// The location of the `.bib` file is unknown while the library is parsed. The group must
+    /// therefore resolve the aux file after the location becomes known.
+    @Test
+    void relativePathIsResolvedWhenLibraryPathBecomesKnown(@TempDir Path tempDir) throws Exception {
+        Path auxFile = copyPaperAux(tempDir);
+        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, Path.of("paper.aux"), new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
+
+        metaData.setLibraryPath(tempDir.resolve("library.bib"));
+
+        BibEntry inAux = new BibEntry().withCitationKey("Darwin1888");
+        assertEquals(auxFile, group.getFilePathResolved());
+        assertTrue(group.contains(inAux));
+    }
+
+    @Test
+    void latexDirectoryTakesPrecedenceOverLibraryPath(@TempDir Path tempDir) throws Exception {
+        Path libraryDirectory = Files.createDirectory(tempDir.resolve("library"));
+        Path latexDirectory = Files.createDirectory(tempDir.resolve("latex"));
+        copyPaperAux(libraryDirectory);
+        Path latexAuxFile = copyPaperAux(latexDirectory);
+
+        metaData.setLibraryPath(libraryDirectory.resolve("library.bib"));
+        metaData.setLatexFileDirectory(USER_AND_HOST, latexDirectory.toString());
+        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, Path.of("paper.aux"), new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
+
+        assertEquals(latexAuxFile, group.getFilePathResolved());
+    }
+
+    /// "Save as" moves the library. The aux file then resolves to another directory.
+    @Test
+    void resolvedPathFollowsTheLibrary(@TempDir Path tempDir) throws Exception {
+        Path firstDir = Files.createDirectory(tempDir.resolve("first"));
+        Path secondDir = Files.createDirectory(tempDir.resolve("second"));
+        Path firstAuxFile = copyPaperAux(firstDir);
+        Path secondAuxFile = copyPaperAux(secondDir);
+
+        metaData.setLibraryPath(firstDir.resolve("library.bib"));
+        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, Path.of("paper.aux"), new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
+        assertEquals(firstAuxFile, group.getFilePathResolved());
+
+        metaData.setLibraryPath(secondDir.resolve("library.bib"));
+
+        assertEquals(secondAuxFile, group.getFilePathResolved());
+    }
+
+    @Test
+    void rebindingToNewMetaDataUpdatesResolution(@TempDir Path tempDir) throws Exception {
+        Path firstDir = Files.createDirectory(tempDir.resolve("first"));
+        Path secondDir = Files.createDirectory(tempDir.resolve("second"));
+        copyPaperAux(firstDir);
+        Path secondAuxFile = copyPaperAux(secondDir);
+
+        metaData.setLibraryPath(firstDir.resolve("library.bib"));
+        TexGroup group = new TexGroup("paper", GroupHierarchyType.INDEPENDENT, Path.of("paper.aux"), new DefaultAuxParser(new BibDatabase()), new DummyFileUpdateMonitor(), metaData, USER_AND_HOST);
+        assertEquals(firstDir.resolve("paper.aux"), group.getFilePathResolved());
+
+        MetaData newMetaData = new MetaData();
+        newMetaData.setLibraryPath(secondDir.resolve("library.bib"));
+        newMetaData.setGroups(GroupTreeNode.fromGroup(group));
+
+        assertEquals(secondAuxFile, group.getFilePathResolved());
+    }
+
+    @Test
+    void fileMonitorIsArmedWhenLibraryPathBecomesKnown(@TempDir Path tempDir) throws Exception {
+        Path auxFile = copyPaperAux(tempDir);
+        FileUpdateMonitor fileMonitor = mock(FileUpdateMonitor.class);
+
+        TexGroup group = TexGroup.create("paper", GroupHierarchyType.INDEPENDENT, Path.of("paper.aux"), new DefaultAuxParser(new BibDatabase()), fileMonitor, metaData, USER_AND_HOST);
+        verifyNoInteractions(fileMonitor);
+
+        metaData.setLibraryPath(tempDir.resolve("library.bib"));
+
+        verify(fileMonitor).addListenerForFile(auxFile, group);
+    }
+
+    @Test
+    void fileMonitorMovesWhenResolutionChanges(@TempDir Path tempDir) throws Exception {
+        Path firstDir = Files.createDirectory(tempDir.resolve("first"));
+        Path secondDir = Files.createDirectory(tempDir.resolve("second"));
+        Path firstAuxFile = copyPaperAux(firstDir);
+        Path secondAuxFile = copyPaperAux(secondDir);
+        FileUpdateMonitor fileMonitor = mock(FileUpdateMonitor.class);
+
+        metaData.setLibraryPath(firstDir.resolve("library.bib"));
+        TexGroup group = TexGroup.create("paper", GroupHierarchyType.INDEPENDENT, Path.of("paper.aux"), new DefaultAuxParser(new BibDatabase()), fileMonitor, metaData, USER_AND_HOST);
+
+        verify(fileMonitor).addListenerForFile(firstAuxFile, group);
+
+        metaData.setLibraryPath(secondDir.resolve("library.bib"));
+
+        verify(fileMonitor).removeListener(firstAuxFile, group);
+        verify(fileMonitor).addListenerForFile(secondAuxFile, group);
+    }
+
+    private static Path paperAuxSource() throws Exception {
+        return Path.of(TexGroupTest.class.getResource("paper.aux").toURI());
+    }
+
+    private static Path copyPaperAux(Path directory) throws Exception {
+        Path auxFile = directory.resolve("paper.aux");
+        Files.copy(paperAuxSource(), auxFile);
+        return auxFile;
     }
 }

--- a/jablib/src/test/java/org/jabref/model/metadata/MetaDataTest.java
+++ b/jablib/src/test/java/org/jabref/model/metadata/MetaDataTest.java
@@ -1,5 +1,6 @@
 package org.jabref.model.metadata;
 
+import java.nio.file.Path;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +25,14 @@ class MetaDataTest {
     @Test
     void getLatexFileDirectoryReturnsEmptyWhenNotSet() {
         assertEquals(Optional.empty(), metaData.getLatexFileDirectory("user-host"));
+    }
+
+    @Test
+    void storesLibraryPath() {
+        Path libraryPath = Path.of("library.bib");
+        metaData.setLibraryPath(libraryPath);
+
+        assertEquals(Optional.of(libraryPath), metaData.getLibraryPath());
     }
 
     @Test


### PR DESCRIPTION
### Summary

TODO

### Steps to test

TODO

### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/8344

### AI usage

Opus 5 for planning, GPT 5.4 for refinign and implementation. Have done a non-thorough manual review.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
