### PR TITLE
Fix pinned labeling

### DIFF
--- a/.github/workflows/link-issue.yml
+++ b/.github/workflows/link-issue.yml
@@ -130,7 +130,34 @@ jobs:
           packages: jq
           version: 1.0
       - name: Add label "📌 Pinned"
-        run: gh issue edit ${{ needs.determine_issue_number.outputs.issue_number }} --add-label "📌 Pinned"
+        run: |
+          set -e
+
+          ISSUE_NUMBER="${{ needs.determine_issue_number.outputs.issue_number }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+
+          echo "Checking assignees for issue #$ISSUE_NUMBER"
+          ASSIGNEES=$(gh api  api /repos/JabRef/jabref/issues/$ISSUE_NUMBER --jq '[.assignees[].login]')
+
+          if echo "$ASSIGNEES" | jq -e --arg u "$PR_AUTHOR" 'index($u)' >/dev/null; then
+            echo "✅ '$PR_AUTHOR' is already assigned. Pinning."
+            gh issue edit "$ISSUE_NUMBER" --add-label "📌 Pinned"
+            exit 0
+          fi
+
+          if [ "$(echo "$ASSIGNEES" | jq 'length')" -eq 0 ]; then
+            echo "No assignees yet. Assigning '$PR_AUTHOR'."
+            gh api -X PATCH /repos/JabRef/jabref/issues/$ISSUE_NUMBER \
+              --input <(echo "{\"assignees\": [\"$PR_AUTHOR\"]}")
+            gh issue edit "$ISSUE_NUMBER" --add-label "📌 Pinned"
+            exit 0
+          fi
+
+          echo "🚫 Issue #$ISSUE_NUMBER is already assigned to: $ASSIGNEES"
+          echo "PR author '$PR_AUTHOR' is not among them. Not pinning."
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --body "⚠️ Issue #$ISSUE_NUMBER is already assigned to someone else."
+          exit 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Assign PR creator to issue

--- a/.github/workflows/link-issue.yml
+++ b/.github/workflows/link-issue.yml
@@ -137,7 +137,7 @@ jobs:
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
 
           echo "Checking assignees for issue #$ISSUE_NUMBER"
-          ASSIGNEES=$(gh api  api /repos/JabRef/jabref/issues/$ISSUE_NUMBER --jq '[.assignees[].login]')
+          ASSIGNEES=$(gh api /repos/JabRef/jabref/issues/$ISSUE_NUMBER --jq '[.assignees[].login]')
 
           if echo "$ASSIGNEES" | jq -e --arg u "$PR_AUTHOR" 'index($u)' >/dev/null; then
             echo "✅ '$PR_AUTHOR' is already assigned. Pinning."


### PR DESCRIPTION
### Summary

Fix pinned labeling when a contributor opens a PR for an issue they are not assigned to.
3 cases: 
1. Contributor opens a PR for an issue they are assigned to, the pinned label is added.
2. Contributor opens a PR for a free issue, the pinned label is added, and the contributor is assigned to that issue.
3. Contributor opens a PR to an issue that is assigned to another contributor, the pinned label isn't added, and a warning is sent to the contributor who opened the PR that the issue isn't free.

### Related issues and pull requests

Found here https://github.com/JabRef/jabref/issues/16736

### AI usage

Claude Sonnet 5 used to fix the syntax errors in the workflow script

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
