### PR TITLE
Show group changes in Git diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the packaged JabRef application produced an exception when trying to use fulltext search and indexing. [#16738](https://github.com/JabRef/jabref/pull/16738)
 - We fixed freezing while scrolling results in the Search for unlinked local files dialog. [#16696](https://github.com/JabRef/jabref/pull/16696)
 - We fixed an issue where "File > Git > Commit" refused to commit when the repository had no remote or the remote could not be reached. [#16720](https://github.com/JabRef/jabref/pull/16720)
+- We fixed Git diffs so group tree changes are highlighted. [#16729](https://github.com/JabRef/jabref/issues/16729)
 - We fixed the unreadable hit count on group badges that turn green because they contain selected entries. [#16700](https://github.com/JabRef/jabref/pull/16700)
 - We fixed an issue where resolving external library conflicts through the merge dialog could discard the merged result. [#16537](https://github.com/JabRef/jabref/issues/16537)
 - We fixed an issue where switching entries in the source tab could throw an exception or overwrite another entry. [#16534](https://github.com/JabRef/jabref/issues/16534)

--- a/docs/requirements/git.md
+++ b/docs/requirements/git.md
@@ -35,6 +35,7 @@ Needs: impl
 `req~git.commit.preview-current-library~1`
 
 Before committing a Git-tracked library, JabRef should let the user preview semantic changes from the committed version to the saved current file for that library.
+Selecting a groups tree change must display the old and new trees with highlighted differences and respect the selected word or character highlighting mode.
 
 Needs: impl
 

--- a/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
@@ -38,7 +38,7 @@ public final class GroupChangeDetailsView extends DatabaseChangeDetailsView {
                 Optional.ofNullable(groupChange.getGroupDiff().getOriginalGroupRoot()),
                 Optional.ofNullable(groupChange.getGroupDiff().getNewGroupRoot()),
                 leftLabelText, rightLabelText, diffMethod);
-        VBox container = new VBox(15, label, diffPane);
+        VBox container = new VBox(12, label, diffPane);
         VBox.setVgrow(diffPane, Priority.ALWAYS);
         setAllAnchorsAndAttachChild(container);
     }
@@ -71,8 +71,8 @@ public final class GroupChangeDetailsView extends DatabaseChangeDetailsView {
         Label onDisk = new Label(rightLabelText);
         onDisk.getStyleClass().addAll(StyleClasses.CHANGE_VIEW_HEADER);
 
-        VBox leftContainer = new VBox(5, inJabRef, leftScrollPane);
-        VBox rightContainer = new VBox(5, onDisk, rightScrollPane);
+        VBox leftContainer = new VBox(4, inJabRef, leftScrollPane);
+        VBox rightContainer = new VBox(4, onDisk, rightScrollPane);
         VBox.setVgrow(leftScrollPane, Priority.ALWAYS);
         VBox.setVgrow(rightScrollPane, Priority.ALWAYS);
 

--- a/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
@@ -1,10 +1,24 @@
 package org.jabref.gui.collab.groupchange;
 
+import java.util.Optional;
+
+import javafx.geometry.Orientation;
 import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.SplitPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
 
 import org.jabref.gui.collab.DatabaseChangeDetailsView;
+import org.jabref.gui.mergeentries.threewaymerge.diffhighlighter.DiffHighlighter;
+import org.jabref.gui.mergeentries.threewaymerge.diffhighlighter.SplitDiffHighlighter;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.groups.GroupTreeNode;
 
+import org.fxmisc.richtext.StyleClassedTextArea;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
 public final class GroupChangeDetailsView extends DatabaseChangeDetailsView {
 
     public GroupChangeDetailsView(GroupChange groupChange) {
@@ -12,9 +26,117 @@ public final class GroupChangeDetailsView extends DatabaseChangeDetailsView {
     }
 
     public GroupChangeDetailsView(GroupChange groupChange, String labelValue) {
+        this(groupChange, labelValue, Localization.lang("In JabRef"), Localization.lang("On disk"), DiffHighlighter.BasicDiffMethod.CHARS);
+    }
+
+    public GroupChangeDetailsView(GroupChange groupChange, String labelValue, String leftLabelText, String rightLabelText, DiffHighlighter.BasicDiffMethod diffMethod) {
         Label label = new Label(labelValue);
         label.setWrapText(true);
 
-        this.setAllAnchorsAndAttachChild(label);
+        SplitPane diffPane = createGroupDiffSplitPane(
+                Optional.ofNullable(groupChange.getGroupDiff().getOriginalGroupRoot()),
+                Optional.ofNullable(groupChange.getGroupDiff().getNewGroupRoot()),
+                leftLabelText, rightLabelText, diffMethod);
+        VBox container = new VBox(15, label, diffPane);
+        VBox.setVgrow(diffPane, Priority.ALWAYS);
+        setAllAnchorsAndAttachChild(container);
+    }
+
+    /// Creates a split pane showing differences in groups tree structure.
+    ///
+    /// @return Configured SplitPane showing groups differences
+    public static SplitPane createGroupDiffSplitPane(Optional<GroupTreeNode> originalGroups, Optional<GroupTreeNode> newGroups, String leftLabelText, String rightLabelText, DiffHighlighter.BasicDiffMethod diffMethod) {
+        StyleClassedTextArea jabrefTextArea = createConfiguredTextArea();
+        StyleClassedTextArea diskTextArea = createConfiguredTextArea();
+
+        String jabRefContent = originalGroups.map(GroupChangeDetailsView::convertGroupTreeToString).orElse("");
+        String diskContent = newGroups.map(GroupChangeDetailsView::convertGroupTreeToString).orElse("");
+
+        jabrefTextArea.replaceText(jabRefContent);
+        diskTextArea.replaceText(diskContent);
+
+        if (originalGroups.isEmpty()) {
+            diskTextArea.setStyleClass(0, diskContent.length(), "addition");
+        } else {
+            SplitDiffHighlighter highlighter = new SplitDiffHighlighter(jabrefTextArea, diskTextArea, diffMethod);
+            highlighter.highlight();
+        }
+
+        ScrollPane leftScrollPane = createScrollPane(jabrefTextArea);
+        ScrollPane rightScrollPane = createScrollPane(diskTextArea);
+
+        Label inJabRef = new Label(leftLabelText);
+        inJabRef.getStyleClass().add("lib-change-header");
+        Label onDisk = new Label(rightLabelText);
+        onDisk.getStyleClass().add("lib-change-header");
+
+        VBox leftContainer = new VBox(5, inJabRef, leftScrollPane);
+        VBox rightContainer = new VBox(5, onDisk, rightScrollPane);
+        VBox.setVgrow(leftScrollPane, Priority.ALWAYS);
+        VBox.setVgrow(rightScrollPane, Priority.ALWAYS);
+
+        SplitPane splitPane = new SplitPane(leftContainer, rightContainer);
+        splitPane.setOrientation(Orientation.HORIZONTAL);
+        splitPane.setDividerPositions(0.5);
+
+        Label legendLabel = new Label(Localization.lang("Red: Removed, Blue: Changed, Green: Added"));
+        legendLabel.getStyleClass().add("lib-change-legend");
+
+        VBox resultContainer = new VBox(splitPane, legendLabel);
+        resultContainer.setSpacing(5);
+        VBox.setVgrow(splitPane, Priority.ALWAYS);
+
+        return new SplitPane(resultContainer);
+    }
+
+    /// Creates a configured scroll pane for a text area.
+    ///
+    /// @param textArea The text area to wrap in a scroll pane
+    /// @return Configured ScrollPane
+    private static ScrollPane createScrollPane(StyleClassedTextArea textArea) {
+        ScrollPane scrollPane = new ScrollPane(textArea);
+        scrollPane.setFitToWidth(true);
+        scrollPane.setFitToHeight(true);
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+        scrollPane.getStyleClass().add("lib-change-scroll-pane");
+        return scrollPane;
+    }
+
+    /// Creates a configured text area for displaying diff content.
+    ///
+    /// @return Configured StyleClassedTextArea
+    private static StyleClassedTextArea createConfiguredTextArea() {
+        StyleClassedTextArea textArea = new StyleClassedTextArea();
+        textArea.setEditable(false);
+        textArea.setWrapText(false);
+        textArea.setAutoHeight(true);
+        textArea.getStyleClass().add("lib-change-text-area");
+        return textArea;
+    }
+
+    /// Converts a group tree to a string representation with indentation.
+    ///
+    /// @param node The root node of the group tree
+    /// @return String representation of the group tree
+    private static String convertGroupTreeToString(GroupTreeNode node) {
+        StringBuilder builder = new StringBuilder();
+        appendGroupTreeNode(node, builder, 0);
+        return builder.toString();
+    }
+
+    /// Recursively appends a group tree node to the string builder.
+    ///
+    /// @param node    The current node to append
+    /// @param builder The string builder to append to
+    /// @param level   The current depth level in the tree (for indentation)
+    private static void appendGroupTreeNode(GroupTreeNode node, StringBuilder builder, int level) {
+        builder.repeat("|  ", level)
+               .append(node.getName())
+               .append("\n");
+
+        for (GroupTreeNode child : node.getChildren()) {
+            appendGroupTreeNode(child, builder, level + 1);
+        }
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
@@ -22,7 +22,11 @@ import org.jspecify.annotations.NullMarked;
 public final class GroupChangeDetailsView extends DatabaseChangeDetailsView {
 
     public GroupChangeDetailsView(GroupChange groupChange) {
-        this(groupChange, Localization.lang("%0. Accepting the change replaces the complete groups tree with the externally modified groups tree.", groupChange.getName()));
+        this(groupChange,
+                Localization.lang("%0. Accepting the change replaces the complete groups tree with the externally modified groups tree.", groupChange.getName()),
+                Localization.lang("In JabRef"),
+                Localization.lang("On disk"),
+                DiffHighlighter.BasicDiffMethod.CHARS);
     }
 
     public GroupChangeDetailsView(GroupChange groupChange, String labelValue, String leftLabelText, String rightLabelText, DiffHighlighter.BasicDiffMethod diffMethod) {

--- a/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
@@ -25,10 +25,6 @@ public final class GroupChangeDetailsView extends DatabaseChangeDetailsView {
         this(groupChange, Localization.lang("%0. Accepting the change replaces the complete groups tree with the externally modified groups tree.", groupChange.getName()));
     }
 
-    public GroupChangeDetailsView(GroupChange groupChange, String labelValue) {
-        this(groupChange, labelValue, Localization.lang("In JabRef"), Localization.lang("On disk"), DiffHighlighter.BasicDiffMethod.CHARS);
-    }
-
     public GroupChangeDetailsView(GroupChange groupChange, String labelValue, String leftLabelText, String rightLabelText, DiffHighlighter.BasicDiffMethod diffMethod) {
         Label label = new Label(labelValue);
         label.setWrapText(true);

--- a/jabgui/src/main/java/org/jabref/gui/collab/metedatachange/MetadataChangeDetailsView.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/metedatachange/MetadataChangeDetailsView.java
@@ -1,21 +1,15 @@
 package org.jabref.gui.collab.metedatachange;
 
-import javafx.geometry.Orientation;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
-import javafx.scene.control.SplitPane;
 import javafx.scene.layout.VBox;
 
 import org.jabref.gui.collab.DatabaseChangeDetailsView;
+import org.jabref.gui.collab.groupchange.GroupChangeDetailsView;
 import org.jabref.gui.mergeentries.threewaymerge.diffhighlighter.DiffHighlighter;
-import org.jabref.gui.mergeentries.threewaymerge.diffhighlighter.SplitDiffHighlighter;
 import org.jabref.logic.bibtex.comparator.MetaDataDiff;
 import org.jabref.logic.citationkeypattern.GlobalCitationKeyPatterns;
 import org.jabref.logic.l10n.Localization;
-import org.jabref.model.groups.GroupTreeNode;
-import org.jabref.model.metadata.MetaData;
-
-import org.fxmisc.richtext.StyleClassedTextArea;
 
 public final class MetadataChangeDetailsView extends DatabaseChangeDetailsView {
 
@@ -60,7 +54,10 @@ public final class MetadataChangeDetailsView extends DatabaseChangeDetailsView {
 
         // Show appropriate view based on difference type
         if (diff.differenceType() == MetaDataDiff.DifferenceType.GROUPS) {
-            container.getChildren().add(createGroupDiffSplitPane(metadataChange, leftLabelText, rightLabelText, diffMethod));
+            container.getChildren().add(GroupChangeDetailsView.createGroupDiffSplitPane(
+                    metadataChange.getMetaDataDiff().getOriginalMetaData().getGroups(),
+                    metadataChange.getMetaDataDiff().getNewMetaData().getGroups(),
+                    leftLabelText, rightLabelText, diffMethod));
         } else {
             container.getChildren().add(createDefaultDiffScrollPane(diff));
         }
@@ -80,109 +77,6 @@ public final class MetadataChangeDetailsView extends DatabaseChangeDetailsView {
         ScrollPane scrollPane = new ScrollPane(diffContainer);
         scrollPane.setFitToWidth(true);
         return scrollPane;
-    }
-
-    /// Creates a split pane showing differences in groups tree structure.
-    ///
-    /// @param metadataChange The metadata change containing groups differences
-    /// @return Configured SplitPane showing groups differences
-    private SplitPane createGroupDiffSplitPane(MetadataChange metadataChange, String leftLabelText, String rightLabelText, DiffHighlighter.BasicDiffMethod diffMethod) {
-        StyleClassedTextArea jabrefTextArea = createConfiguredTextArea();
-        StyleClassedTextArea diskTextArea = createConfiguredTextArea();
-
-        String jabRefContent = getMetadataGroupsContent(metadataChange.getMetaDataDiff().getOriginalMetaData());
-        String diskContent = getMetadataGroupsContent(metadataChange.getMetaDataDiff().getNewMetaData());
-
-        jabrefTextArea.replaceText(jabRefContent);
-        diskTextArea.replaceText(diskContent);
-
-        SplitDiffHighlighter highlighter = new SplitDiffHighlighter(jabrefTextArea, diskTextArea, diffMethod);
-        highlighter.highlight();
-
-        ScrollPane leftScrollPane = createScrollPane(jabrefTextArea);
-        ScrollPane rightScrollPane = createScrollPane(diskTextArea);
-
-        Label inJabRef = new Label(leftLabelText);
-        inJabRef.getStyleClass().add("lib-change-header");
-        Label onDisk = new Label(rightLabelText);
-        onDisk.getStyleClass().add("lib-change-header");
-
-        VBox leftContainer = new VBox(5, inJabRef, leftScrollPane);
-        VBox rightContainer = new VBox(5, onDisk, rightScrollPane);
-
-        SplitPane splitPane = new SplitPane(leftContainer, rightContainer);
-        splitPane.setOrientation(Orientation.HORIZONTAL);
-        splitPane.setDividerPositions(0.5);
-
-        Label legendLabel = new Label(Localization.lang("Red: Removed, Blue: Changed, Green: Added"));
-        legendLabel.getStyleClass().add("lib-change-legend");
-
-        VBox resultContainer = new VBox(splitPane, legendLabel);
-        resultContainer.setSpacing(5);
-
-        return new SplitPane(resultContainer);
-    }
-
-    /// Creates a configured scroll pane for a text area.
-    ///
-    /// @param textArea The text area to wrap in a scroll pane
-    /// @return Configured ScrollPane
-    private ScrollPane createScrollPane(StyleClassedTextArea textArea) {
-        ScrollPane scrollPane = new ScrollPane(textArea);
-        scrollPane.setFitToWidth(true);
-        scrollPane.setFitToHeight(true);
-        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
-        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
-        scrollPane.getStyleClass().add("lib-change-scroll-pane");
-        setAllAnchorsAndAttachChild(scrollPane);
-        return scrollPane;
-    }
-
-    /// Creates a configured text area for displaying diff content.
-    ///
-    /// @return Configured StyleClassedTextArea
-    private StyleClassedTextArea createConfiguredTextArea() {
-        StyleClassedTextArea textArea = new StyleClassedTextArea();
-        textArea.setEditable(false);
-        textArea.setWrapText(false);
-        textArea.setAutoHeight(true);
-        textArea.getStyleClass().add("lib-change-text-area");
-        return textArea;
-    }
-
-    /// Extracts the groups tree content from metadata as a string.
-    ///
-    /// @param metadata The metadata containing groups
-    /// @return String representation of groups tree, or empty string if no groups
-    private String getMetadataGroupsContent(MetaData metadata) {
-        return metadata.getGroups()
-                       .map(this::convertGroupTreeToString)
-                       .orElse("");
-    }
-
-    /// Converts a group tree to a string representation with indentation.
-    ///
-    /// @param node The root node of the group tree
-    /// @return String representation of the group tree
-    private String convertGroupTreeToString(GroupTreeNode node) {
-        StringBuilder builder = new StringBuilder();
-        appendGroupTreeNode(node, builder, 0);
-        return builder.toString();
-    }
-
-    /// Recursively appends a group tree node to the string builder.
-    ///
-    /// @param node    The current node to append
-    /// @param builder The string builder to append to
-    /// @param level   The current depth level in the tree (for indentation)
-    private void appendGroupTreeNode(GroupTreeNode node, StringBuilder builder, int level) {
-        builder.append("|  ".repeat(level))
-               .append(node.getName())
-               .append("\n");
-
-        for (GroupTreeNode child : node.getChildren()) {
-            appendGroupTreeNode(child, builder, level + 1);
-        }
     }
 
     private String getDifferenceString(MetaDataDiff.DifferenceType changeType) {

--- a/jabgui/src/main/java/org/jabref/gui/collab/metedatachange/MetadataChangeDetailsView.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/metedatachange/MetadataChangeDetailsView.java
@@ -69,7 +69,7 @@ public final class MetadataChangeDetailsView extends DatabaseChangeDetailsView {
     /// @param diff The difference to display
     /// @return Configured ScrollPane showing the difference
     private ScrollPane createDefaultDiffScrollPane(MetaDataDiff.Difference diff) {
-        VBox diffContainer = new VBox(15);
+        VBox diffContainer = new VBox(12);
 
         // Show both original and new values
         diffContainer.getChildren().add(new Label(diff.originalObject().toString()));

--- a/jabgui/src/main/java/org/jabref/gui/git/GitDiffDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/git/GitDiffDialogView.java
@@ -170,7 +170,7 @@ public class GitDiffDialogView extends BaseDialog<Void> {
                             getDiffMethod()
                     );
             case GroupChange groupChange ->
-                    new GroupChangeDetailsView(groupChange, groupChange.getName() + '.');
+                    new GroupChangeDetailsView(groupChange, groupChange.getName() + '.', oldVersionLabel, newVersionLabel, getDiffMethod());
             case PreambleChange preambleChange ->
                     new PreambleChangeDetailsView(preambleChange);
             case BibTexStringAdd stringAdd ->

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/DiffMethod.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/DiffMethod.java
@@ -1,5 +1,5 @@
 package org.jabref.gui.mergeentries.threewaymerge;
 
 public interface DiffMethod {
-    public String separator();
+    String separator();
 }

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/GroupDiffMode.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/GroupDiffMode.java
@@ -1,15 +1,5 @@
 package org.jabref.gui.mergeentries.threewaymerge;
 
-public class GroupDiffMode implements DiffMethod {
+public record GroupDiffMode(String separator) implements DiffMethod {
 
-    private final String separator;
-
-    public GroupDiffMode(String separator) {
-        this.separator = separator;
-    }
-
-    @Override
-    public String separator() {
-        return this.separator;
-    }
 }

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/GroupDiffMode.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/GroupDiffMode.java
@@ -1,5 +1,4 @@
 package org.jabref.gui.mergeentries.threewaymerge;
 
 public record GroupDiffMode(String separator) implements DiffMethod {
-
 }

--- a/jabgui/src/test/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsViewTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsViewTest.java
@@ -1,0 +1,87 @@
+package org.jabref.gui.collab.groupchange;
+
+import java.util.List;
+
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.SplitPane;
+import javafx.scene.layout.VBox;
+
+import org.jabref.gui.mergeentries.threewaymerge.diffhighlighter.DiffHighlighter;
+import org.jabref.logic.bibtex.comparator.GroupDiff;
+import org.jabref.model.groups.ExplicitGroup;
+import org.jabref.model.groups.GroupHierarchyType;
+import org.jabref.model.groups.GroupTreeNode;
+import org.jabref.model.metadata.MetaData;
+
+import org.fxmisc.richtext.StyleClassedTextArea;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.testfx.framework.junit5.ApplicationTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@NullMarked
+@ResourceLock("Localization.lang")
+class GroupChangeDetailsViewTest extends ApplicationTest {
+
+    @ParameterizedTest
+    @EnumSource(DiffHighlighter.BasicDiffMethod.class)
+    void highlightsRenamedGroup(DiffHighlighter.BasicDiffMethod diffMethod) {
+        interact(() -> {
+            SplitPane comparison = comparison("Old", "New", diffMethod);
+            assertEquals("Before", ((Label) ((VBox) comparison.getItems().getFirst()).getChildren().getFirst()).getText());
+            assertEquals("After", ((Label) ((VBox) comparison.getItems().getLast()).getChildren().getFirst()).getText());
+            assertEquals("Old\n", textArea(comparison, 0).getText());
+            assertEquals("New\n", textArea(comparison, 1).getText());
+            assertEquals(List.of("deletion"), List.copyOf(textArea(comparison, 0).getStyleOfChar(0)));
+            assertEquals(List.of("updated"), List.copyOf(textArea(comparison, 1).getStyleOfChar(0)));
+            assertFalse(textArea(comparison, 0).isEditable());
+            assertFalse(textArea(comparison, 1).isEditable());
+        });
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "'', Added, 1, addition",
+            "Removed, '', 0, deletion"
+    })
+    void highlightsAddedOrRemovedTree(String before, String after, int highlightedSide, String style) {
+        interact(() -> {
+            SplitPane comparison = comparison(before, after, DiffHighlighter.BasicDiffMethod.CHARS);
+            assertEquals(before.isEmpty() ? "" : before + '\n', textArea(comparison, 0).getText());
+            assertEquals(after.isEmpty() ? "" : after + '\n', textArea(comparison, 1).getText());
+            assertEquals(List.of(style), List.copyOf(textArea(comparison, highlightedSide).getStyleOfChar(0)));
+        });
+    }
+
+    private SplitPane comparison(String before, String after, DiffHighlighter.BasicDiffMethod diffMethod) {
+        GroupChange change = mock(GroupChange.class);
+        when(change.getGroupDiff()).thenReturn(GroupDiff.compare(metadata(before), metadata(after)).orElseThrow());
+        GroupChangeDetailsView view = new GroupChangeDetailsView(change, "Groups", "Before", "After", diffMethod);
+        VBox container = (VBox) view.getChildren().getFirst();
+        SplitPane outerPane = (SplitPane) container.getChildren().getLast();
+        VBox diffContainer = (VBox) outerPane.getItems().getFirst();
+        return (SplitPane) diffContainer.getChildren().getFirst();
+    }
+
+    private MetaData metadata(String name) {
+        MetaData metadata = new MetaData();
+        if (!name.isEmpty()) {
+            metadata.setGroups(new GroupTreeNode(new ExplicitGroup(name, GroupHierarchyType.INDEPENDENT, ',')));
+        }
+        return metadata;
+    }
+
+    private StyleClassedTextArea textArea(SplitPane comparison, int side) {
+        VBox container = (VBox) comparison.getItems().get(side);
+        ScrollPane scrollPane = (ScrollPane) container.getChildren().getLast();
+        return (StyleClassedTextArea) scrollPane.getContent();
+    }
+}


### PR DESCRIPTION
### Summary

Show the before-and-after group trees, with highlighted additions, removals, and edits, when a Git diff contains a groups tree change. The existing metadata comparison reuses the same view, and the word/character selection applies to both displays.

Analogies: the comparison shows group changes as clearly as honey shows its amber color, chocolate shows its layers, and the moon shows its phases.

jabref-contrib-policy:4.2:reviewed​:ok

<img width="820" height="483" alt="grafik" src="https://github.com/user-attachments/assets/d84ccef7-2dec-4c3a-b932-c62871578bb4" />


### Steps to test

1. Open a Git-tracked library with a changed groups tree.
2. Select "Modified groups tree" in the diff dialog.
3. Confirm that the committed and saved group trees are shown side by side and additions, removals, and changes are highlighted.
4. Switch between word and character highlighting and confirm the tree comparison updates.

Automated coverage verifies renamed groups, additions, and removals for each supported highlighting method.

### Related issues and pull requests

Closes #16729

### AI usage

Codex (models GPT-6 and GPT-5), AIL4. The maintainer authorized this draft PR and must review, understand, and own the submitted code.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [x] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [x] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [x] No `catch (Exception e)` — only specific exceptions are caught.
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [x] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [x] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [x] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [x] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [x] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [x] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.
- [/] Fetcher tests hit the live endpoints — the remote API is not mocked or stubbed (automated-review suggestions to mock it are rejected on purpose).

## 2. Verification commands

- [ ] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [x] `./gradlew modernizer`.
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [x] `./gradlew javadoc`.
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [x] `npm ci && npm run textlint` reports no misspellings (only if Markdown changed).
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.

`jablib:check` currently fails because a local citation-style fixture is missing and an unrelated untracked `DnbFetcher` causes a fetcher-list assertion mismatch.

## 3. Documentation

- [x] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines, sorted in next to existing entries about the same component/feature). Link the issue if one exists; link the PR only when no issue exists. Use `TODO` as the placeholder when neither is known yet — never a fake number. No entry for fixes to changes that were themselves introduced after the last release (feature only in `## [Unreleased]`) — update the existing unreleased entry instead if needed.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [x] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [/] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder (no issue confidently identified yet — an existing issue link always stays), it was replaced with the real PR-number link after PR creation, then committed and pushed. If an issue is identified or created later, the link is switched to the issue.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
