### PR TITLE
add subset search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- We added subset search for CSL styles. [#16693](https://github.com/JabRef/jabref/issues/16693)
 - We added a per-library keyword separator to the library properties, so opening a library no longer rewrites keyword fields. [#16835](https://github.com/JabRef/jabref/pull/16835)
 - We added a "Normalize keyword delimiters" cleanup and save action that rewrites keyword fields to the keyword separator of the library. [#16835](https://github.com/JabRef/jabref/pull/16835)
 - We added a "Commit and push" button which allows to commit and then push in one go for Git operations. [#16339](https://github.com/JabRef/jabref/issues/16339)
@@ -219,7 +220,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- We added subset search for CSL styles. [#16693](https://github.com/JabRef/jabref/issues/16693)
 - Book covers now download automatically when you open an entry with an ISBN. [#14848](https://github.com/JabRef/jabref/issues/14848)
 - We added a new data format and property selection feature, enabling users to select one or more field properties for custom fields. [#9840](https://github.com/JabRef/jabref/issues/9840)
 - We fixed a glitch with the sidepane divider position on startup. [#15394](https://github.com/JabRef/jabref/issues/15394)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- We added subset search for CSL styles. [#16693](https://github.com/JabRef/jabref/issues/16693)
 - Book covers now download automatically when you open an entry with an ISBN. [#14848](https://github.com/JabRef/jabref/issues/14848)
 - We added a new data format and property selection feature, enabling users to select one or more field properties for custom fields. [#9840](https://github.com/JabRef/jabref/issues/9840)
 - We fixed a glitch with the sidepane divider position on startup. [#15394](https://github.com/JabRef/jabref/issues/15394)

--- a/docs/requirements/ux.md
+++ b/docs/requirements/ux.md
@@ -108,7 +108,7 @@ Needs: impl
 `req~ux.text-filtering.case-insensitive-separators~1`
 
 When users filter textual lists, matching must ignore case and treat punctuation or whitespace separators as equivalent.
-For example, a search for `Springer lecture` should match `Springer - Lecture Notes in Computer Science`.
+For example, a search for `Springer lecture` or `SPRINGER LECTURE` or `springer lecture` should match `Springer - Lecture Notes in Computer Science`.
 
 Needs: impl
 

--- a/docs/requirements/ux.md
+++ b/docs/requirements/ux.md
@@ -104,6 +104,14 @@ When a dialog with text input as a main component is opened, the text field shou
 
 Needs: impl
 
+## Text filtering is case-insensitive and separator-aware
+`req~ux.text-filtering.case-insensitive-separators~1`
+
+When users filter textual lists, matching must ignore case and treat punctuation or whitespace separators as equivalent.
+For example, a search for `Springer lecture` should match `Springer - Lecture Notes in Computer Science`.
+
+Needs: impl
+
 ## Show unsaved changes before closing a library
 `req~ux.close.show-diff~1`
 

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.ObjectProperty;
@@ -43,6 +45,8 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntryTypesManager;
 
 public class StyleSelectDialogViewModel {
+
+    private static final Pattern STYLE_SEARCH_SEPARATORS = Pattern.compile("[\\p{P}\\s]+");
 
     private final DialogService dialogService;
 
@@ -231,8 +235,22 @@ public class StyleSelectDialogViewModel {
     }
 
     public void setAvailableCslLayoutsFilter(String searchTerm) {
-        filteredAvailableCslLayouts.setPredicate(layout ->
-                searchTerm.isEmpty() || layout.getDisplayName().toLowerCase().contains(searchTerm.toLowerCase()));
+        filteredAvailableCslLayouts.setPredicate(layout -> matchStyleSearch(layout.getDisplayName(), searchTerm));
+    }
+
+    private static boolean matchStyleSearch(String styleName, String searchTerm) {
+        List<String> searchTerms = STYLE_SEARCH_SEPARATORS.splitAsStream(searchTerm)
+                                                          .filter(term -> !term.isBlank())
+                                                          .toList();
+
+        if (searchTerms.isEmpty()) {
+            return true;
+        }
+
+        String searchableStyleName = STYLE_SEARCH_SEPARATORS.matcher(styleName.toLowerCase(Locale.ROOT))
+                                                            .replaceAll(" ")
+                                                            .trim();
+        return searchTerms.stream().allMatch(searchableStyleName::contains);
     }
 
     /// Handles importing a custom CSL style file

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
@@ -239,6 +239,7 @@ public class StyleSelectDialogViewModel {
     }
 
     public static boolean matchStyleSearch(String styleName, String searchTerm) {
+        // [impl->req~ux.text-filtering.case-insensitive-separators~1]
         List<String> searchTerms = STYLE_SEARCH_SEPARATORS.splitAsStream(searchTerm.toLowerCase(Locale.ROOT))
                                                           .filter(term -> !term.isBlank())
                                                           .toList();

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
@@ -238,8 +238,8 @@ public class StyleSelectDialogViewModel {
         filteredAvailableCslLayouts.setPredicate(layout -> matchStyleSearch(layout.getDisplayName(), searchTerm));
     }
 
-    private static boolean matchStyleSearch(String styleName, String searchTerm) {
-        List<String> searchTerms = STYLE_SEARCH_SEPARATORS.splitAsStream(searchTerm)
+    public static boolean matchStyleSearch(String styleName, String searchTerm) {
+        List<String> searchTerms = STYLE_SEARCH_SEPARATORS.splitAsStream(searchTerm.toLowerCase(Locale.ROOT))
                                                           .filter(term -> !term.isBlank())
                                                           .toList();
 

--- a/jabgui/src/test/java/org/jabref/gui/openoffice/StyleSelectDialogViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/openoffice/StyleSelectDialogViewModelTest.java
@@ -1,0 +1,32 @@
+package org.jabref.gui.openoffice;
+
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@NullMarked
+class StyleSelectDialogViewModelTest {
+
+    @Test
+    void matchStyleSearchIgnoresPunctuationSeparators() {
+        assertTrue(StyleSelectDialogViewModel.matchStyleSearch(
+                "Springer - Lecture Notes in Computer Science",
+                "springer "));
+    }
+
+    @Test
+    void matchStyleSearchFindsCapitalizedSubsetTerms() {
+        assertTrue(StyleSelectDialogViewModel.matchStyleSearch(
+                "Springer - Lecture Notes in Computer Science",
+                "Springer lecture"));
+    }
+
+    @Test
+    void matchStyleSearchKeepsUnmatchedTermsHidden() {
+        assertFalse(StyleSelectDialogViewModel.matchStyleSearch(
+                "Springer - Lecture Notes in Computer Science",
+                "springer medicine"));
+    }
+}


### PR DESCRIPTION
### Summary

Added subset search for CSL styles. 

### Steps to test

search "Springer lecture", styles with "-" can still be searched.
<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/64a67497-67e4-4c89-a27d-5c7f48e230bc" />


### Related issues and pull requests

Closes #16693 

### AI usage
🤖Codex 5.5, code was reviewed by me 

_____
### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
