### PR TITLE
Speed up building

### DIFF
--- a/jablib/build.gradle.kts
+++ b/jablib/build.gradle.kts
@@ -174,6 +174,11 @@ var taskGenerateLtwaListMV = tasks.register<JBangTask>("generateLtwaListMV") {
 // Adds ltwa, journal-list.mv, and citation-style-catalog.json to the resources directory
 sourceSets["main"].resources {
     srcDir(layout.buildDirectory.dir("generated/resources"))
+
+    // JabRef only reads the top-level styles (CitationStyleCatalogGenerator scans with depth 1),
+    // but these ~8000 unused files dominate the cost of processResources on Windows.
+    exclude("csl-styles/dependent/**")
+    exclude("csl-styles/spec/**")
 }
 
 // region processResources


### PR DESCRIPTION
### Summary

`processResouces` was always taking a long time.

### Steps to test

Try to compile on Windows

### Related issues and pull requests

Closes NA

### AI usage

Claude - yesterday or so.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
