### PR TITLE
fix(ai): keep group chat window after library edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where opening "Chat with group" again after editing the library could create a second chat window instead of focusing the existing one. [#16879](https://github.com/JabRef/jabref/pull/16879)
 - We fixed an issue where pressing Escape while a dropdown is open closed the entire dialog instead of just the dropdown. [#16596](https://github.com/JabRef/jabref/issues/16596)
 - We fixed invisible filter text in the keyboard shortcuts preferences when using the light JabRef theme. [#16731](https://github.com/JabRef/jabref/issues/16731)
 - We fixed an issue where a full-text PDF link found by DOI lookup was attached in lowercase and failed. [#16762](https://github.com/JabRef/jabref/pull/16762)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where opening "Chat with group" again after editing the library could create a second chat window instead of focusing the existing one. [TODO](https://github.com/JabRef/jabref/pull/TODO)
 - We fixed an issue where pressing Escape while a dropdown is open closed the entire dialog instead of just the dropdown. [#16596](https://github.com/JabRef/jabref/issues/16596)
 - We fixed invisible filter text in the keyboard shortcuts preferences when using the light JabRef theme. [#16731](https://github.com/JabRef/jabref/issues/16731)
 - We fixed an issue where a full-text PDF link found by DOI lookup was attached in lowercase and failed. [#16762](https://github.com/JabRef/jabref/pull/16762)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where opening "Chat with group" again after editing the library could create a second chat window instead of focusing the existing one. [TODO](https://github.com/JabRef/jabref/pull/TODO)
+- We fixed an issue where opening "Chat with group" again after editing the library could create a second chat window instead of focusing the existing one. [#16879](https://github.com/JabRef/jabref/pull/16879)
 - We fixed an issue where pressing Escape while a dropdown is open closed the entire dialog instead of just the dropdown. [#16596](https://github.com/JabRef/jabref/issues/16596)
 - We fixed invisible filter text in the keyboard shortcuts preferences when using the light JabRef theme. [#16731](https://github.com/JabRef/jabref/issues/16731)
 - We fixed an issue where a full-text PDF link found by DOI lookup was attached in lowercase and failed. [#16762](https://github.com/JabRef/jabref/pull/16762)

--- a/jabgui/src/main/java/org/jabref/gui/JabRefGuiStateManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/JabRefGuiStateManager.java
@@ -80,7 +80,7 @@ public class JabRefGuiStateManager extends AbstractSrvStateManager implements St
     private final ObservableMap<String, DialogWindowState> dialogWindowStates = FXCollections.observableHashMap();
     private final ObservableList<SidePaneType> visibleSidePanes = FXCollections.observableArrayList();
     private final ObservableList<String> searchHistory = FXCollections.observableArrayList();
-    private final Map<BibDatabaseContext, Map<String, AiGroupChatWindow>> groupAiChatWindows = new HashMap<>();
+    private final Map<String, Map<String, AiGroupChatWindow>> groupAiChatWindows = new HashMap<>();
     private final BooleanProperty editorShowing = new SimpleBooleanProperty(false);
     private final OptionalObjectProperty<Walkthrough> activeWalkthrough = OptionalObjectProperty.empty();
     private final BooleanProperty canGoBack = new SimpleBooleanProperty(false);
@@ -259,23 +259,23 @@ public class JabRefGuiStateManager extends AbstractSrvStateManager implements St
 
     @Override
     public Optional<AiGroupChatWindow> getAiChatWindowForGroup(BibDatabaseContext context, String groupName) {
-        return Optional.ofNullable(groupAiChatWindows.get(context))
+        return Optional.ofNullable(groupAiChatWindows.get(context.getUid()))
                        .flatMap(innerMap -> Optional.ofNullable(innerMap.get(groupName)));
     }
 
     @Override
     public void setAiChatWindowForGroup(BibDatabaseContext context, String groupName, AiGroupChatWindow aiGroupChatWindow) {
-        groupAiChatWindows.computeIfAbsent(context, k -> new HashMap<>())
+        groupAiChatWindows.computeIfAbsent(context.getUid(), k -> new HashMap<>())
                           .put(groupName, aiGroupChatWindow);
     }
 
     @Override
     public void removeAiChatWindowForGroup(BibDatabaseContext context, String groupName) {
-        Map<String, AiGroupChatWindow> innerMap = groupAiChatWindows.get(context);
+        Map<String, AiGroupChatWindow> innerMap = groupAiChatWindows.get(context.getUid());
         if (innerMap != null) {
             innerMap.remove(groupName);
             if (innerMap.isEmpty()) {
-                groupAiChatWindows.remove(context);
+                groupAiChatWindows.remove(context.getUid());
             }
         }
     }

--- a/jabgui/src/main/java/org/jabref/gui/JabRefGuiStateManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/JabRefGuiStateManager.java
@@ -80,6 +80,7 @@ public class JabRefGuiStateManager extends AbstractSrvStateManager implements St
     private final ObservableMap<String, DialogWindowState> dialogWindowStates = FXCollections.observableHashMap();
     private final ObservableList<SidePaneType> visibleSidePanes = FXCollections.observableArrayList();
     private final ObservableList<String> searchHistory = FXCollections.observableArrayList();
+    /// Keyed by [BibDatabaseContext#getUid()] instead of [BibDatabaseContext], because [BibDatabaseContext#equals(Object)] (and the matching [BibDatabaseContext#hashCode()]) change with the library content and cannot be used as [HashMap] keys.
     private final Map<String, Map<String, AiGroupChatWindow>> groupAiChatWindows = new HashMap<>();
     private final BooleanProperty editorShowing = new SimpleBooleanProperty(false);
     private final OptionalObjectProperty<Walkthrough> activeWalkthrough = OptionalObjectProperty.empty();

--- a/jabgui/src/test/java/org/jabref/gui/JabRefGuiStateManagerAiChatWindowTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/JabRefGuiStateManagerAiChatWindowTest.java
@@ -1,0 +1,55 @@
+package org.jabref.gui;
+
+import java.util.Optional;
+
+import org.jabref.gui.ai.chat.AiGroupChatWindow;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class JabRefGuiStateManagerAiChatWindowTest {
+
+    private StateManager stateManager;
+    private BibDatabaseContext context;
+    private AiGroupChatWindow window;
+
+    @BeforeEach
+    void setUp() {
+        stateManager = new JabRefGuiStateManager();
+        context = new BibDatabaseContext();
+        window = mock(AiGroupChatWindow.class);
+    }
+
+    @Test
+    void findsWindowAfterDatabaseContentChanges() {
+        String groupName = "My group";
+        stateManager.setAiChatWindowForGroup(context, groupName, window);
+
+        int hashCodeBefore = context.hashCode();
+        context.getDatabase().insertEntry(new BibEntry().withField(StandardField.TITLE, "Changed content"));
+        assertNotEquals(hashCodeBefore, context.hashCode());
+
+        Optional<AiGroupChatWindow> found = stateManager.getAiChatWindowForGroup(context, groupName);
+
+        assertEquals(Optional.of(window), found);
+    }
+
+    @Test
+    void removesWindowAfterDatabaseContentChanges() {
+        String groupName = "My group";
+        stateManager.setAiChatWindowForGroup(context, groupName, window);
+
+        context.getDatabase().insertEntry(new BibEntry().withField(StandardField.TITLE, "Changed content"));
+        stateManager.removeAiChatWindowForGroup(context, groupName);
+
+        assertTrue(stateManager.getAiChatWindowForGroup(context, groupName).isEmpty());
+    }
+}

--- a/jabgui/src/test/java/org/jabref/gui/JabRefGuiStateManagerAiChatWindowTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/JabRefGuiStateManagerAiChatWindowTest.java
@@ -11,8 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class JabRefGuiStateManagerAiChatWindowTest {
@@ -33,13 +31,9 @@ class JabRefGuiStateManagerAiChatWindowTest {
         String groupName = "My group";
         stateManager.setAiChatWindowForGroup(context, groupName, window);
 
-        int hashCodeBefore = context.hashCode();
         context.getDatabase().insertEntry(new BibEntry().withField(StandardField.TITLE, "Changed content"));
-        assertNotEquals(hashCodeBefore, context.hashCode());
 
-        Optional<AiGroupChatWindow> found = stateManager.getAiChatWindowForGroup(context, groupName);
-
-        assertEquals(Optional.of(window), found);
+        assertEquals(Optional.of(window), stateManager.getAiChatWindowForGroup(context, groupName));
     }
 
     @Test
@@ -50,6 +44,6 @@ class JabRefGuiStateManagerAiChatWindowTest {
         context.getDatabase().insertEntry(new BibEntry().withField(StandardField.TITLE, "Changed content"));
         stateManager.removeAiChatWindowForGroup(context, groupName);
 
-        assertTrue(stateManager.getAiChatWindowForGroup(context, groupName).isEmpty());
+        assertEquals(Optional.empty(), stateManager.getAiChatWindowForGroup(context, groupName));
     }
 }


### PR DESCRIPTION
### Related issues and pull requests

Closes NA

### PR Description

Open AI "Chat with group" windows were tracked in a `HashMap` keyed by `BibDatabaseContext`. That class's `equals`/`hashCode` include the library contents, so after the user edits entries the map could no longer find an already-open window and JabRef opened a duplicate. The map now keys by the stable `BibDatabaseContext.getUid()`, matching how selected groups are already stored in the same state manager.

jabref-contrib-policy:4.2:reviewed​:ok

Analogies: Like honey, this change is sticky where it matters—the UID keeps the chat window attached to the same library instance. Like chocolate, the fix is small and melts into the existing pattern without changing the public API. Like the moon, the UID is a constant face while the library content waxes and wanes.

### Steps to test

1. Open a library with at least one group and enable AI features.
2. Right-click a group and open "Chat with group".
3. Add or edit an entry in the library (so the database content changes).
4. Open "Chat with group" for the same group again — the existing window should come to the front; a second window should not appear.
5. Close the chat window and open it again — a new window should open normally.

### AI usage

Cursor (Auto / Composer)

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [x] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [/] No `catch (Exception e)` — only specific exceptions are caught.
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [/] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [x] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [x] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [x] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.

## 2. Verification commands

- [x] `./gradlew :jablib:check` (or `./gradlew check` for all modules). — ran `:jabgui:test --tests org.jabref.gui.JabRefGuiStateManagerAiChatWindowTest` successfully
- [ ] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [ ] `./gradlew modernizer`.
- [ ] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [ ] `./gradlew javadoc`.
- [/] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.

## 3. Documentation

- [/] `CHANGELOG.md` entry added if the change is visible to the user (end-user wording, no extra blank lines). Use `TODO` as the issue/PR reference placeholder when no issue is known and the PR is not yet created — never a fake number.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked only on a confident match, otherwise kept `TODO` (no `closes`/`fixes` for merely-similar issues).
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix (skip for refactors, minor fixes, and internal changes).
- [/] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder, it was replaced with the real PR-number link after PR creation, then committed and pushed.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

