### PR TITLE
AsyncEmbeddingModel: Switch NotNull annotation to NonNull from jspecify.

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/ai/embedding/AsyncEmbeddingModel.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/embedding/AsyncEmbeddingModel.java
@@ -17,7 +17,7 @@ import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.output.Response;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,7 +87,7 @@ public class AsyncEmbeddingModel implements EmbeddingModel, AutoCloseable {
     }
 
     @Override
-    public Response<@NotNull List<Embedding>> embedAll(List<TextSegment> list) {
+    public Response<@NonNull List<Embedding>> embedAll(List<TextSegment> list) {
         if (predictorProperty.get().isEmpty()) {
             // The rationale for RuntimeException here:
             // 1. langchain4j error handling is a mess, and it uses RuntimeExceptions


### PR DESCRIPTION
This cleans up a stray NotNull annotation: JabRef fully switched to jspecify and should therefore use jspecifie's NonNull accordingly. It should be uncritical since it is an annotation-only change.