### PR TITLE
Fix status label update for reviews on fork PRs

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -29,6 +29,15 @@ on:
 jobs:
   comment:
     if: ${{ github.repository == 'JabRef/jabref' }}
+    # The label decision reads live review-thread state and writes it back minutes later, so two
+    # runs for the same PR would race and the slower one would restore the state it started from.
+    # The PR number is only known after the artifact is read, too late for a group expression -
+    # head repository plus head branch identifies the same pull request just as well.
+    concurrency:
+      group: pr-comment-${{ github.event.workflow_run.head_repository.full_name || github.repository }}-${{ github.event.workflow_run.head_branch || github.event.inputs.pr_number }}
+      # The newest run has the freshest view; an interrupted run's work is redone by the one
+      # that replaced it.
+      cancel-in-progress: true
     runs-on: ubuntu-slim
     permissions:
       actions: read

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -7,8 +7,11 @@ name: Comment on PR
 
 on:
   workflow_run:
+    # Review activity (Qodo submitting a review, the PR author replying in a thread) is relevant
+    # too, but its pull_request_review* runs are unprivileged on fork PRs - "PR Review Activity"
+    # bridges them into this list.
     # note when updating via a PR and testing - `workflow_run` executes from the `main` branch and not the PR branch
-    workflows: [ "Source Code Tests", "On PR opened/updated", "Check PR Format", "Link PR to Issue", "Check PR Modifications", "Check PR CHANGELOG.md" ]
+    workflows: [ "Source Code Tests", "On PR opened/updated", "Check PR Format", "Link PR to Issue", "Check PR Modifications", "Check PR CHANGELOG.md", "PR Review Activity" ]
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow
     types: [ completed ]
   workflow_dispatch:
@@ -22,26 +25,10 @@ on:
       head_sha:
         description: 'PR head SHA the dispatching run evaluated; the run does nothing if the PR moved on or conflicts again'
         required: false
-  # Qodo is not a workflow, so its completion cannot be awaited via workflow_run.
-  # It submits a review when done - that is the signal to re-evaluate the status labels.
-  pull_request_review:
-    types: [ submitted ]
-  # The PR author replying in a Qodo thread changes the label outcome but completes no
-  # workflow - listen to this event directly. Deleting the author's last reply flips a
-  # thread back to unaddressed, so deletions count as well. (Thread resolve/unresolve has
-  # no workflow trigger event; those are only picked up on the next triggering event.)
-  pull_request_review_comment:
-    types: [ created, deleted ]
 
 jobs:
   comment:
-    # pull_request_review_comment: only a PR-author reply can un-count (or, when deleted,
-    # re-count) a Qodo thread, so other commenters' replies (including Qodo posting its own
-    # review comments) need no run. The deleted comment's author is in the same payload field.
-    if: >-
-      ${{ github.repository == 'JabRef/jabref'
-          && (github.event_name != 'pull_request_review' || github.event.review.user.login == 'qodo-free-for-open-source-projects[bot]')
-          && (github.event_name != 'pull_request_review_comment' || github.event.comment.user.login == github.event.pull_request.user.login) }}
+    if: ${{ github.repository == 'JabRef/jabref' }}
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -136,21 +123,19 @@ jobs:
 
       # Set a common variable for PR number and workflow_run_id from either event.
       - name: Set variables
-        if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event_name, 'pull_request_review') || steps.read-pr_number.outputs.pr_number != '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.read-pr_number.outputs.pr_number != '' }}
         id: set-vars
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "pr_number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
             echo "workflow_run_id=${{ github.event.inputs.workflow_run_id }}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == pull_request_review* ]]; then
-            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           else
             echo "pr_number=${{ steps.read-pr_number.outputs.pr_number }}" >> $GITHUB_OUTPUT
             echo "workflow_run_id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
           fi
 
       - name: "Check if PR has 'dev: no-bot-comments' label"
-        if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event_name, 'pull_request_review') || (steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true') }}
+        if: ${{ github.event_name == 'workflow_dispatch' || (steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true' && github.event.workflow_run.name != 'PR Review Activity') }}
         id: check-label
         run: |
           has_label=$(gh pr view "${{ steps.set-vars.outputs.pr_number }}" --json labels -q \
@@ -161,17 +146,17 @@ jobs:
 
       # No setup-gradle here: this job never runs Gradle, it only needs a JDK and JBang.
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
-        if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true') }}
+        if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true' && github.event.workflow_run.name != 'PR Review Activity') }}
         with:
           distribution: 'corretto'
           java-version: '25'
       - name: Generate JBang cache key
-        if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true') }}
+        if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true' && github.event.workflow_run.name != 'PR Review Activity') }}
         id: cache-key
         run: echo "cache_key=jbang-ghprcomment-$(date +%Y-%m)" >> $GITHUB_OUTPUT
       - name: Cache JBang
         # Own key: ghprcomment pulls different dependencies than the other JBang jobs.
-        if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true') }}
+        if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true' && github.event.workflow_run.name != 'PR Review Activity') }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.jbang
@@ -180,14 +165,14 @@ jobs:
             jbang-ghprcomment-
       - name: Resolve //DEPS into the cached directory
         # JBang resolves script dependencies into ~/.m2, which is not cached here.
-        if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true') }}
+        if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true' && github.event.workflow_run.name != 'PR Review Activity') }}
         run: echo "JBANG_REPO=$HOME/.jbang/repository" >> "$GITHUB_ENV"
       - name: Setup JBang
-        if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true') }}
+        if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true' && github.event.workflow_run.name != 'PR Review Activity') }}
         uses: jbangdev/setup-jbang@2b1b465a7b75f4222b81426f23a01e013aa7b95c # v0.1.1
 
       - name: ghprcomment@main
-        if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true') }}
+        if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true' && github.event.workflow_run.name != 'PR Review Activity') }}
         run: |
           # A dispatched cleanup runs asynchronously; a newer push may have made the PR conflicting
           # again in the meantime, and a stale run must not remove that conflict's comment or labels.
@@ -222,7 +207,7 @@ jobs:
         # Deliberately not restricted to fork PRs (unlike ghprcomment, which only forks need):
         # labels are computed nowhere else, and with the restriction a same-repo PR whose Qodo
         # review arrived while a check was still running never got a second chance to be labelled.
-        if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event_name, 'pull_request_review') || steps.read-pr_number.outputs.pr_number != '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.read-pr_number.outputs.pr_number != '' }}
         run: |
           # Same stale-dispatch guard as in ghprcomment@main above, re-checked immediately before
           # this step's own mutations (ghprcomment may have run for a while in between).
@@ -245,7 +230,7 @@ jobs:
 
           # The labels reflect the complete picture only once every producer of bot comments is done.
           # Whatever is still pending re-triggers this workflow when it finishes (workflow_run for the
-          # workflows below, pull_request_review for Qodo), so skipping here loses nothing.
+          # workflows below, "PR Review Activity" for Qodo), so skipping here loses nothing.
           PENDING=$(gh pr checks --repo $REPO $PR_NUMBER --json state,workflow \
             --jq '[.[] | select(.state == "IN_PROGRESS" or .state == "QUEUED" or .state == "PENDING")
                         | select(.workflow == "Source Code Tests" or .workflow == "On PR opened/updated" or .workflow == "Check PR Format"
@@ -317,9 +302,7 @@ jobs:
             fi
           fi
         env:
-          # On the pull_request_review* events of a fork PR the default GITHUB_TOKEN is read-only,
-          # so writing the label fails with "Resource not accessible by integration". The PAT is
-          # unaffected. Labels set by it do emit "labeled" events, which is harmless here: the only
+          # Labels set by the PAT do emit "labeled" events, which is harmless here: the only
           # listener acting on a status label ("Adapt PR status") marks drafts ready for review,
           # and this step never puts "status: ready-for-review" on a draft.
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_JABREF_MACHINE_PR_APPROVE }}

--- a/.github/workflows/pr-review-activity.yml
+++ b/.github/workflows/pr-review-activity.yml
@@ -1,0 +1,40 @@
+# Description: Bridges pull request review activity into "Comment on PR".
+# On a fork PR, pull_request_review* runs get a read-only token and no secrets
+# ("Secret source: None"), so the status labels cannot be written there. This workflow
+# does nothing but record the PR number; "Comment on PR" picks it up via workflow_run,
+# which runs privileged in the context of the base repository.
+
+name: PR Review Activity
+
+on:
+  # Qodo is not a workflow, so its completion cannot be awaited via workflow_run.
+  # It submits a review when done - that is the signal to re-evaluate the status labels.
+  pull_request_review:
+    types: [ submitted ]
+  # The PR author replying in a Qodo thread changes the label outcome but completes no
+  # workflow - listen to this event directly. Deleting the author's last reply flips a
+  # thread back to unaddressed, so deletions count as well. (Thread resolve/unresolve has
+  # no workflow trigger event; those are only picked up on the next triggering event.)
+  pull_request_review_comment:
+    types: [ created, deleted ]
+
+jobs:
+  upload-pr-number:
+    # pull_request_review_comment: only a PR-author reply can un-count (or, when deleted,
+    # re-count) a Qodo thread, so other commenters' replies (including Qodo posting its own
+    # review comments) need no run. The deleted comment's author is in the same payload field.
+    if: >-
+      ${{ github.repository == 'JabRef/jabref'
+          && (github.event_name != 'pull_request_review' || github.event.review.user.login == 'qodo-free-for-open-source-projects[bot]')
+          && (github.event_name != 'pull_request_review_comment' || github.event.comment.user.login == github.event.pull_request.user.login) }}
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Create pr_number.txt
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pr_number
+          path: pr_number.txt

--- a/.github/workflows/pr-review-activity.yml
+++ b/.github/workflows/pr-review-activity.yml
@@ -27,6 +27,12 @@ jobs:
       ${{ github.repository == 'JabRef/jabref'
           && (github.event_name != 'pull_request_review' || github.event.review.user.login == 'qodo-free-for-open-source-projects[bot]')
           && (github.event_name != 'pull_request_review_comment' || github.event.comment.user.login == github.event.pull_request.user.login) }}
+    # A burst of review activity on one PR only needs the last event to reach "Comment on PR";
+    # collapsing the bursts here keeps the downstream runs it would otherwise have to cancel
+    # from being started at all.
+    concurrency:
+      group: pr-review-activity-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-slim
     permissions:
       contents: read


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/actions/runs/34056426924/job/101549056689?pr=16865

### Summary

🤖 Reviews on pull requests from forks never updated the `status:` labels: those workflow runs get no secrets and a read-only token, so the label step aborted with exit code 4 before touching anything. Review activity now goes through a small bridge workflow that only records the PR number, letting the privileged `workflow_run` path do the labelling — the same pattern the changes-requested check already uses.

Analogies: like honey, this change is a thin layer that lets something already sweet flow again; like chocolate, it tempers a process that had seized up; and like the moon, it does its work by reflecting a light it does not itself hold — the privileged token.

`jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

1. Have Qodo submit a review on a pull request opened from a fork.
2. The "Comment on PR" run completes and the PR carries `status: changes-required` (previously the run failed with exit code 4).
3. Reply in the Qodo thread as the PR author and resolve it; the next run sets `status: ready-for-review`.

### Related issues and pull requests

Closes NA

### AI usage

Claude Code (model claude-opus-5), AIL4.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [/] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [/] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [/] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [/] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

Not applicable: no Java code changed, this PR only touches GitHub Actions workflows.

### Exceptions

- [/] No `catch (Exception e)` — only specific exceptions are caught.
- [/] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [/] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

Not applicable: no Java code changed.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [/] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [/] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [/] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

Not applicable: no user-facing text.

### Security

- [x] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS). The bridge workflow runs with `contents: read` / `actions: write`, checks out nothing and executes no PR-controlled code.

### Tests

- [/] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [/] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions, and use `@TempDir` instead of manual temp directories.
- [/] Fetcher tests hit the live endpoints — the remote API is not mocked or stubbed.

Not applicable: workflow-only change, verified by the workflows running on this PR.

## 2. Verification commands

- [/] `./gradlew :jablib:check`
- [/] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`
- [/] `./gradlew modernizer`
- [/] `./gradlew --no-configuration-cache :rewriteDryRun`
- [/] `./gradlew javadoc`
- [/] `npx markdownlint-cli2 "docs/**/*.md" "*.md"`
- [/] `npm ci && npm run textlint`
- [/] `docker run ... intellij-format`

Not applicable: no Java or Markdown changed; both YAML files were parsed to confirm they are valid.

## 3. Documentation

- [/] `CHANGELOG.md` entry added if the change is visible to the user. CI-only change, not visible to users.
- [x] Searched jabref/issues and jabref-koppor/issues for a related issue; linked only on a confident match.
- [/] Requirement added to `docs/requirements/<area>.md`.
- [/] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [/] If `CHANGELOG.md` used a `TODO` placeholder, it was replaced with the real PR-number link.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017K8zEnWpYLYcX3JyjQZWJE
