### PR TITLE
Css more unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We changed the default macOS shortcuts for "Search document identifier online" and "Focus group list" to not insert special characters. [#16528](https://github.com/JabRef/jabref/issues/16528)
 - We changed the extension of backup files from `.bak` to `.bib`, so that they can be opened in JabRef. [#11454](https://github.com/JabRef/jabref/issues/11454)
 - We changed spacing, padding and font sizes across the interface for a more consistent look and feel. [#16042](https://github.com/JabRef/jabref/issues/16042)
+- We reduced the amount of special spacing, padding and font sizes across the interface for a more unified interface. [#16887](https://github.com/JabRef/jabref/pull/16887)
 - We changed the delete and rename file dialogs to state that undo does not restore files on disk. [#16680](https://github.com/JabRef/jabref/pull/16680)
 - We reworked the appearance preferences: you now choose a theme (e.g. "JabRef", "Primer") and a color scheme ("Follow System", "Light", "Dark") separately; the "Use System Preference" checkbox is gone. [#15625](https://github.com/JabRef/jabref/issues/15625)
 - A custom theme (CSS file) is now applied on top of the selected theme instead of replacing it entirely. [#15625](https://github.com/JabRef/jabref/issues/15625)

--- a/jabgui/src/main/java/org/jabref/gui/FXDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/FXDialog.java
@@ -56,14 +56,8 @@ public class FXDialog extends Alert {
             initModality(Modality.NONE);
         }
 
-        getDialogPane().addEventHandler(KeyEvent.KEY_PRESSED, event -> {
-            KeyBindingRepository keyBindingRepository = Injector.instantiateModelOrService(KeyBindingRepository.class);
-            if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLOSE, event)) {
-                dialogWindow.close();
-                event.consume();
-            }
-        });
-        this.setOnShowing(_ -> BaseDialog.applyButtonFix(this.getDialogPane()));
+        getDialogPane().addEventHandler(KeyEvent.KEY_PRESSED, event -> BaseDialog.closeOnKeyBindingMatch(event, this));
+        this.setOnShown(_ -> BaseDialog.applyButtonFix(this.getDialogPane()));
     }
 
     public FXDialog(AlertType type) {

--- a/jabgui/src/main/java/org/jabref/gui/FXDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/FXDialog.java
@@ -7,11 +7,7 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 
 import org.jabref.gui.icon.IconTheme;
-import org.jabref.gui.keyboard.KeyBinding;
-import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.util.BaseDialog;
-
-import com.airhacks.afterburner.injection.Injector;
 
 /// This class provides a super class for all dialogs implemented in JavaFX.
 ///
@@ -57,7 +53,7 @@ public class FXDialog extends Alert {
         }
 
         getDialogPane().addEventHandler(KeyEvent.KEY_PRESSED, event -> BaseDialog.closeOnKeyBindingMatch(event, this));
-        this.setOnShown(_ -> BaseDialog.applyButtonFix(this.getDialogPane()));
+        setOnShown(_ -> BaseDialog.applyButtonFix(this.getDialogPane()));
     }
 
     public FXDialog(AlertType type) {

--- a/jabgui/src/main/java/org/jabref/gui/ai/chat/AiChatView.java
+++ b/jabgui/src/main/java/org/jabref/gui/ai/chat/AiChatView.java
@@ -146,7 +146,7 @@ public class AiChatView extends StackPane {
         followUpQuestionsSimpleListView.itemsProperty().bind(viewModel.followUpQuestionsProperty());
         followUpQuestionsSimpleListView.setRenderer(question -> {
             Button button = new Button(question);
-            button.getStyleClass().addAll("exampleQuestionStyle", "padding-2-10");
+            button.getStyleClass().addAll("exampleQuestionStyle", "padding-2-12");
             button.setOnAction(_ -> viewModel.sendFollowUpMessage(question));
             return button;
         });

--- a/jabgui/src/main/java/org/jabref/gui/ai/chat/AiChatView.java
+++ b/jabgui/src/main/java/org/jabref/gui/ai/chat/AiChatView.java
@@ -146,7 +146,7 @@ public class AiChatView extends StackPane {
         followUpQuestionsSimpleListView.itemsProperty().bind(viewModel.followUpQuestionsProperty());
         followUpQuestionsSimpleListView.setRenderer(question -> {
             Button button = new Button(question);
-            button.getStyleClass().addAll("exampleQuestionStyle", "padding-2-12");
+            button.getStyleClass().addAll("exampleQuestionStyle", "padding-4-12");
             button.setOnAction(_ -> viewModel.sendFollowUpMessage(question));
             return button;
         });

--- a/jabgui/src/main/java/org/jabref/gui/backup/BackupResolverDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/backup/BackupResolverDialog.java
@@ -29,7 +29,6 @@ public class BackupResolverDialog extends FXDialog {
     public BackupResolverDialog(Path originalPath, Path backupDir, ExternalApplicationsPreferences externalApplicationsPreferences) {
         super(AlertType.CONFIRMATION, Localization.lang("Backup found"), true);
         setHeaderText(null);
-        getDialogPane().setMinHeight(180);
         getDialogPane().getButtonTypes().setAll(RESTORE_FROM_BACKUP, REVIEW_BACKUP, IGNORE_BACKUP);
 
         Optional<Path> backupPathOpt = BackupFileUtil.getPathOfLatestExistingBackupFile(originalPath, backupDir);
@@ -41,10 +40,10 @@ public class BackupResolverDialog extends FXDialog {
                 Localization.lang("Backup size: %0", backupSize) + "\n" +
                 Localization.lang("This could indicate that JabRef did not shut down cleanly last time the file was used.") + "\n\n" +
                 Localization.lang("Do you want to recover the library from the backup file?");
-        setContentText(content);
 
         HyperlinkLabel contentLabel = new HyperlinkLabel(content);
         contentLabel.setPrefWidth(360);
+        contentLabel.setPrefHeight(180);
         contentLabel.setOnAction(e -> {
             if (backupPathOpt.isPresent()) {
                 if (!(e.getSource() instanceof Hyperlink)) {

--- a/jabgui/src/main/java/org/jabref/gui/bibtexhighlighter/BibTeXHighlighter.java
+++ b/jabgui/src/main/java/org/jabref/gui/bibtexhighlighter/BibTeXHighlighter.java
@@ -163,8 +163,7 @@ public class BibTeXHighlighter implements SyntaxDecorator {
         }
     }
 
-    /// Helper to add a text segment, splitting it if it intersects with search matches to apply
-    /// the `search-highlight-text` CSS class dynamically.
+    /// Helper to add a text segment, splitting it if it intersects with search matches.
     private void addSegmentWithSearchCheck(RichParagraph.Builder builder, String segmentText, int segmentStart, @org.jspecify.annotations.Nullable String baseStyleClass, List<Range> matches) {
         int segmentEnd = segmentStart + segmentText.length();
         int cursor = segmentStart;
@@ -207,9 +206,9 @@ public class BibTeXHighlighter implements SyntaxDecorator {
 
         if (isSearchMatch) {
             if (baseStyleClass != null) {
-                builder.addWithStyleNames(text, baseStyleClass, "search-highlight-text");
+                builder.addWithStyleNames(text, baseStyleClass);
             } else {
-                builder.addWithStyleNames(text, "search-highlight-text");
+                builder.addWithStyleNames(text);
             }
         } else {
             if (baseStyleClass != null) {

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -594,8 +594,8 @@ public class AllFieldsTab extends FieldsEditorTab {
         Runnable addAction = () -> addFreeFormField(bibDatabaseContext, entry, fieldNameBox.getEditor().getText());
         addButton.setOnAction(_ -> addAction.run());
         fieldNameBox.getEditor().setOnAction(_ -> addAction.run());
-        HBox freeFormRow = new HBox(fieldNameBox, addButton);
-        freeFormRow.getStyleClass().addAll("spacing-4", "padding-top-4");
+        HBox freeFormRow = new HBox(4, fieldNameBox, addButton);
+        freeFormRow.getStyleClass().add("padding-top-4");
         freeFormRow.setAlignment(Pos.CENTER_LEFT);
         return freeFormRow;
     }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -157,7 +157,7 @@ public class AllFieldsTab extends FieldsEditorTab {
         String defaultOwner = NON_ALPHANUMERIC.matcher(
                 preferences.getOwnerPreferences().getDefaultOwner().toLowerCase(Locale.ROOT)).replaceAll("-");
         this.userSpecificCommentField = new UserSpecificCommentField(defaultOwner);
-        this.listContainer.getStyleClass().addAll("all-fields-container", "padding-10-16", "spacing-8");
+        this.listContainer.getStyleClass().addAll("all-fields-container", "padding-12-16", "spacing-8");
 
         setText(EntryEditorTabModel.BuiltIn.ALL_FIELDS.displayName());
         setTooltip(new Tooltip(Localization.lang("Show all fields")));

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -515,7 +515,7 @@ public class AllFieldsTab extends FieldsEditorTab {
         SequencedSet<Field> chipFields = FieldListSections.subtract(sectionMemberFields(type), editors.keySet());
         if (!chipFields.isEmpty()) {
             FlowPane chips = new FlowPane();
-            chips.getStyleClass().add("gap-6");
+            chips.getStyleClass().add("gap-4");
             chipFields.forEach(field -> chips.getChildren().add(createAddChip(bibDatabaseContext, entry, field)));
             content.getChildren().add(chips);
         }
@@ -547,7 +547,7 @@ public class AllFieldsTab extends FieldsEditorTab {
         BibDatabaseMode mode = getDatabaseMode();
 
         FlowPane chips = new FlowPane();
-        chips.getStyleClass().add("gap-6");
+        chips.getStyleClass().add("gap-4");
 
         entryTypesManager.enrich(entry.getType(), mode).ifPresent(entryType -> {
             List<Field> shown = List.copyOf(editors.keySet());
@@ -596,14 +596,14 @@ public class AllFieldsTab extends FieldsEditorTab {
         addButton.setOnAction(_ -> addAction.run());
         fieldNameBox.getEditor().setOnAction(_ -> addAction.run());
         HBox freeFormRow = new HBox(fieldNameBox, addButton);
-        freeFormRow.getStyleClass().addAll("spacing-6", "padding-top-4");
+        freeFormRow.getStyleClass().addAll("spacing-4", "padding-top-4");
         freeFormRow.setAlignment(Pos.CENTER_LEFT);
         return freeFormRow;
     }
 
     private Button createAddChip(BibDatabaseContext bibDatabaseContext, BibEntry entry, Field field) {
         Button chip = new Button(Localization.lang("+ %0", FieldsUtil.getDisplayName(field)));
-        chip.getStyleClass().addAll("all-fields-add-chip", "padding-2-12");
+        chip.getStyleClass().addAll("all-fields-add-chip", "padding-4-12");
         chip.setOnAction(_ -> showFieldEditor(bibDatabaseContext, entry, field));
         return chip;
     }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -131,7 +131,7 @@ public class AllFieldsTab extends FieldsEditorTab {
     private Optional<BibEntry> subscribedEntry = Optional.empty();
 
     /// Scroll content: main grid + chip bar + section panes + free-form add row.
-    private final VBox listContainer = new VBox();
+    private final VBox listContainer = new VBox(8);
 
     public AllFieldsTab(UndoManager undoManager,
                         UndoAction undoAction,
@@ -157,7 +157,7 @@ public class AllFieldsTab extends FieldsEditorTab {
         String defaultOwner = NON_ALPHANUMERIC.matcher(
                 preferences.getOwnerPreferences().getDefaultOwner().toLowerCase(Locale.ROOT)).replaceAll("-");
         this.userSpecificCommentField = new UserSpecificCommentField(defaultOwner);
-        this.listContainer.getStyleClass().addAll("all-fields-container", "padding-12-16", "spacing-8");
+        this.listContainer.getStyleClass().addAll("all-fields-container", "padding-12");
 
         setText(EntryEditorTabModel.BuiltIn.ALL_FIELDS.displayName());
         setTooltip(new Tooltip(Localization.lang("Show all fields")));
@@ -470,8 +470,7 @@ public class AllFieldsTab extends FieldsEditorTab {
                                          Map<Field, Label> labelForField,
                                          BibDatabaseContext bibDatabaseContext,
                                          BibEntry entry) {
-        VBox content = new VBox();
-        content.getStyleClass().add("spacing-8");
+        VBox content = new VBox(8);
 
         Runnable populateContent = () -> populateSectionContent(
                 content,

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
@@ -119,7 +119,7 @@ public class LatexCitationsTab extends EntryEditorTab {
     }
 
     private VBox getCitationsPane() {
-        VBox citationsBox = new VBox(30, citationsDisplay);
+        VBox citationsBox = new VBox(24, citationsDisplay);
         VBox.setVgrow(citationsDisplay, Priority.ALWAYS);
         citationsBox.getStyleClass().add("padding-0");
         return citationsBox;
@@ -132,7 +132,7 @@ public class LatexCitationsTab extends EntryEditorTab {
         Text notFoundText = new Text(Localization.lang("No LaTeX files containing this entry were found."));
         notFoundText.getStyleClass().add("italic");
 
-        VBox notFoundBox = new VBox(30, titleLabel, notFoundText);
+        VBox notFoundBox = new VBox(24, titleLabel, notFoundText);
         notFoundBox.getStyleClass().add("padding-24");
         return notFoundBox;
     }
@@ -142,7 +142,7 @@ public class LatexCitationsTab extends EntryEditorTab {
         titleLabel.getStyleClass().addAll("text-danger", "h3", "bold");
         Text errorMessageText = new Text();
         errorMessageText.textProperty().bind(viewModel.searchErrorProperty());
-        VBox errorMessageBox = new VBox(30, titleLabel, errorMessageText);
+        VBox errorMessageBox = new VBox(24, titleLabel, errorMessageText);
         errorMessageBox.getStyleClass().add("padding-24");
         return errorMessageBox;
     }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
@@ -133,7 +133,7 @@ public class LatexCitationsTab extends EntryEditorTab {
         notFoundText.getStyleClass().add("italic");
 
         VBox notFoundBox = new VBox(30, titleLabel, notFoundText);
-        notFoundBox.getStyleClass().add("padding-32");
+        notFoundBox.getStyleClass().add("padding-24");
         return notFoundBox;
     }
 
@@ -143,7 +143,7 @@ public class LatexCitationsTab extends EntryEditorTab {
         Text errorMessageText = new Text();
         errorMessageText.textProperty().bind(viewModel.searchErrorProperty());
         VBox errorMessageBox = new VBox(30, titleLabel, errorMessageText);
-        errorMessageBox.getStyleClass().add("padding-32");
+        errorMessageBox.getStyleClass().add("padding-24");
         return errorMessageBox;
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
@@ -72,7 +72,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
     private StackPane getRelatedArticlesPane(BibEntry entry) {
         StackPane root = new StackPane();
         root.setId("related-articles-tab");
-        root.getStyleClass().add("padding-20");
+        root.getStyleClass().add("padding-24");
         ProgressIndicator progress = new ProgressIndicator();
         progress.setMaxSize(100, 100);
 
@@ -127,7 +127,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
         for (BibEntry entry : list) {
             HBox hBox = new HBox();
             hBox.setSpacing(5.0);
-            hBox.getStyleClass().add("padding-left-20");
+            hBox.getStyleClass().add("padding-left-24");
 
             String title = entry.getTitle().orElse("");
             String journal = entry.getField(StandardField.JOURNAL).orElse("");
@@ -181,7 +181,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
     private ScrollPane getPrivacyDialog(BibEntry entry) {
         ScrollPane root = new ScrollPane();
         root.setId("related-articles-tab");
-        root.getStyleClass().add("padding-20");
+        root.getStyleClass().add("padding-24");
         VBox vbox = new VBox();
         vbox.getStyleClass().addAll("gdpr-notice", "h4", "padding-12");
         vbox.setSpacing(20.0);

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -143,7 +143,7 @@ public class SourceTab extends EntryEditorTab {
                 codeArea.getModel().replace(null, caretPos, caretPos, committed);
             }
         });
-        codeArea.getStyleClass().addAll("bibtex-code-area", "font-size-090");
+        codeArea.getStyleClass().addAll("bibtex-code-area");
 
         codeArea.addEventFilter(KeyEvent.KEY_PRESSED, event -> CodeAreaKeyBindings.call(codeArea, event, keyBindingRepository));
         codeArea.addEventFilter(KeyEvent.KEY_PRESSED, this::listenForSaveKeybinding);

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/BibEntryView.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/BibEntryView.java
@@ -49,7 +49,7 @@ public class BibEntryView {
 
         entry.getFieldOrAliasLatexFree(StandardField.ABSTRACT).ifPresent(summaryText -> {
             Node summary = createSummary(summaryText);
-            summary.getStyleClass().add("padding-top-6");
+            summary.getStyleClass().add("padding-top-4");
             entryContainer.getChildren().add(summary);
         });
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -282,7 +282,7 @@ public class CitationRelationsTab extends EntryEditorTab {
         Label titleLabel = new Label(Localization.lang("Error"));
         titleLabel.getStyleClass().addAll("h3", "bold", "text-danger");
         Text errorMessageText = new Text(citationsRelationsTabViewModel.searchErrorProperty().get());
-        VBox errorMessageBox = new VBox(30, titleLabel, errorMessageText);
+        VBox errorMessageBox = new VBox(24, titleLabel, errorMessageText);
         errorMessageBox.getStyleClass().add("padding-24");
         return errorMessageBox;
     }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -283,7 +283,7 @@ public class CitationRelationsTab extends EntryEditorTab {
         titleLabel.getStyleClass().addAll("h3", "bold", "text-danger");
         Text errorMessageText = new Text(citationsRelationsTabViewModel.searchErrorProperty().get());
         VBox errorMessageBox = new VBox(30, titleLabel, errorMessageText);
-        errorMessageBox.getStyleClass().add("padding-32");
+        errorMessageBox.getStyleClass().add("padding-24");
         return errorMessageBox;
     }
 
@@ -594,7 +594,7 @@ public class CitationRelationsTab extends EntryEditorTab {
                     vContainer.getChildren().addLast(showEntrySource);
 
                     hContainer.getChildren().addAll(entryNode, separator, vContainer);
-                    hContainer.getStyleClass().add("padding-6-0");
+                    hContainer.getStyleClass().add("padding-4-0");
 
                     return hContainer;
                 })
@@ -712,7 +712,7 @@ public class CitationRelationsTab extends EntryEditorTab {
     /// @param label       label to style
     /// @param tooltipText tooltip text
     private void styleLabel(Label label, String tooltipText) {
-        label.getStyleClass().add("padding-6");
+        label.getStyleClass().add("padding-4");
         label.setAlignment(Pos.CENTER);
         label.setTooltip(new Tooltip(tooltipText));
         label.setMaxWidth(Double.MAX_VALUE);

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -280,8 +280,7 @@ public class CitationRelationsTab extends EntryEditorTab {
 
     private VBox getErrorPane() {
         Label titleLabel = new Label(Localization.lang("Error"));
-        titleLabel.setId("scite-error-label");
-        titleLabel.getStyleClass().addAll("h3", "bold");
+        titleLabel.getStyleClass().addAll("h3", "bold", "text-danger");
         Text errorMessageText = new Text(citationsRelationsTabViewModel.searchErrorProperty().get());
         VBox errorMessageBox = new VBox(30, titleLabel, errorMessageText);
         errorMessageBox.getStyleClass().add("padding-32");

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabView.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabView.java
@@ -94,7 +94,7 @@ public class FileAnnotationTabView {
         Label date = new Label(annotation.getDate());
         Label page = new Label(Localization.lang("Page") + ": " + annotation.getPage());
 
-        marking.getStyleClass().addAll("bold", "font-size-075");
+        marking.getStyleClass().addAll("bold", "font-size-090");
         marking.setMaxHeight(30);
 
         Tooltip markingTooltip = new Tooltip(annotation.getMarking());

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabView.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabView.java
@@ -94,7 +94,7 @@ public class FileAnnotationTabView {
         Label date = new Label(annotation.getDate());
         Label page = new Label(Localization.lang("Page") + ": " + annotation.getPage());
 
-        marking.getStyleClass().addAll("bold", "font-size-090");
+        marking.getStyleClass().addAll("bold");
         marking.setMaxHeight(30);
 
         Tooltip markingTooltip = new Tooltip(annotation.getMarking());

--- a/jabgui/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleView.java
+++ b/jabgui/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleView.java
@@ -86,14 +86,12 @@ public class ErrorConsoleView extends BaseDialog<Void> {
             private final Label stacktrace;
 
             {
-                graphic = new HBox();
-                graphic.getStyleClass().add("spacing-12");
+                graphic = new HBox(12);
                 heading = new Label();
                 stacktrace = new Label();
-                message = new VBox();
+                message = new VBox(4);
                 message.setAlignment(Pos.CENTER_LEFT);
                 message.getChildren().setAll(heading, stacktrace);
-                message.getStyleClass().add("spacing-4");
                 setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
                 getStyleClass().addAll("error-console-cell", "padding-8");
             }

--- a/jabgui/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleView.java
+++ b/jabgui/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleView.java
@@ -93,7 +93,7 @@ public class ErrorConsoleView extends BaseDialog<Void> {
                 message = new VBox();
                 message.setAlignment(Pos.CENTER_LEFT);
                 message.getChildren().setAll(heading, stacktrace);
-                message.getStyleClass().add("spacing-6");
+                message.getStyleClass().add("spacing-4");
                 setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
                 getStyleClass().addAll("error-console-cell", "padding-8-12");
             }

--- a/jabgui/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleView.java
+++ b/jabgui/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleView.java
@@ -95,7 +95,7 @@ public class ErrorConsoleView extends BaseDialog<Void> {
                 message.getChildren().setAll(heading, stacktrace);
                 message.getStyleClass().add("spacing-4");
                 setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
-                getStyleClass().addAll("error-console-cell", "padding-8-12");
+                getStyleClass().addAll("error-console-cell", "padding-8");
             }
 
             @Override

--- a/jabgui/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleView.java
+++ b/jabgui/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleView.java
@@ -87,7 +87,7 @@ public class ErrorConsoleView extends BaseDialog<Void> {
 
             {
                 graphic = new HBox();
-                graphic.getStyleClass().add("spacing-10");
+                graphic.getStyleClass().add("spacing-12");
                 heading = new Label();
                 stacktrace = new Label();
                 message = new VBox();

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/FileSelectionPage.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/FileSelectionPage.java
@@ -127,7 +127,7 @@ public class FileSelectionPage extends WizardPane {
         BorderPane mainLayout = new BorderPane();
 
         progressPane = new VBox(10);
-        progressPane.getStyleClass().addAll("align-center", "padding-20");
+        progressPane.getStyleClass().addAll("align-center", "padding-24");
 
         ProgressIndicator progressIndicator = new ProgressIndicator();
         progressIndicator.progressProperty().bind(viewModel.progressValueProperty());

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/ImportResultsPage.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/ImportResultsPage.java
@@ -53,7 +53,7 @@ public class ImportResultsPage extends WizardPane {
 
         /// Progress pane
         progressPane = new VBox(10);
-        progressPane.getStyleClass().addAll("align-center", "padding-20");
+        progressPane.getStyleClass().addAll("align-center", "padding-24");
         progressPane.setMaxWidth(Double.MAX_VALUE);
         progressPane.setMaxHeight(Double.MAX_VALUE);
 

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -275,7 +275,9 @@ public class LinkedFilesEditor extends VBox implements FieldEditorFX {
 
         HBox info = new HBox(8);
         HBox.setHgrow(info, Priority.ALWAYS);
-        info.getStyleClass().add("padding-6-0"); // To align with buttons below which also have 0.5em padding
+        // Centered rather than padded to the buttons' own padding, so the row stays aligned
+        // whatever padding '.icon-button' carries.
+        info.getStyleClass().add("align-center-left");
         info.getChildren().setAll(label, progressIndicator);
 
         Button acceptAutoLinkedFile = ControlHelper.iconButton(IconTheme.JabRefIcons.AUTO_LINKED_FILE);

--- a/jabgui/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
@@ -211,7 +211,7 @@ public class ImportEntriesDialog extends BaseDialog<Boolean> {
                     Node entryNode = BibEntryView.getEntryNode(entry);
                     HBox.setHgrow(entryNode, Priority.ALWAYS);
                     HBox container = new HBox(entryNode, separator, addToggle);
-                    container.getStyleClass().add("padding-6-0");
+                    container.getStyleClass().add("padding-4-0");
                     container.prefWidthProperty().bind(entriesListView.widthProperty().subtract(25));
 
                     BackgroundTask.wrap(() -> viewModel.hasDuplicate(entry)).onSuccess(duplicateFound -> {

--- a/jabgui/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneView.java
+++ b/jabgui/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneView.java
@@ -110,7 +110,7 @@ public class WebSearchPaneView extends VBox {
         modeIndicator.textProperty().bind(viewModel.searchModeIndicatorProperty());
         modeIndicator.managedProperty().bind(modeIndicator.visibleProperty());
         modeIndicator.visibleProperty().bind(modeIndicator.textProperty().isNotEmpty());
-        modeIndicator.getStyleClass().addAll("text-muted", "font-size-090");
+        modeIndicator.getStyleClass().addAll("text-muted");
         modeIndicator.setMaxWidth(Double.MAX_VALUE);
         return modeIndicator;
     }

--- a/jabgui/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneView.java
+++ b/jabgui/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneView.java
@@ -110,7 +110,7 @@ public class WebSearchPaneView extends VBox {
         modeIndicator.textProperty().bind(viewModel.searchModeIndicatorProperty());
         modeIndicator.managedProperty().bind(modeIndicator.visibleProperty());
         modeIndicator.visibleProperty().bind(modeIndicator.textProperty().isNotEmpty());
-        modeIndicator.getStyleClass().addAll("mode-indicator", "font-size-090");
+        modeIndicator.getStyleClass().addAll("text-muted", "font-size-090");
         modeIndicator.setMaxWidth(Double.MAX_VALUE);
         return modeIndicator;
     }

--- a/jabgui/src/main/java/org/jabref/gui/linkedfile/DeleteFileAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/linkedfile/DeleteFileAction.java
@@ -143,7 +143,7 @@ public class DeleteFileAction extends SimpleCommand {
         warning.setGlyphSize(24.0);
         Label header = new Label(description, warning);
         header.setWrapText(true);
-        header.getStyleClass().addAll("delete-files-dialog", "padding-10");
+        header.getStyleClass().addAll("delete-files-dialog", "padding-12");
 
         ListView<LinkedFileViewModel> filesToDeleteList = new ListView<>(FXCollections.observableArrayList(filesToDelete));
         new ViewModelListCellFactory<LinkedFileViewModel>()

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/multiwaymerge/MultiMergeEntriesView.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/multiwaymerge/MultiMergeEntriesView.java
@@ -167,7 +167,7 @@ public class MultiMergeEntriesView extends BaseDialog<BibEntry> {
         // add header
         int columnIndex = supplierHeader.getChildren().size();
         ToggleButton header = generateEntryHeader(entrySourceColumn, columnIndex);
-        header.getStyleClass().addAll("toggle-button", "padding-6");
+        header.getStyleClass().addAll("toggle-button", "padding-4");
         HBox.setHgrow(header, Priority.ALWAYS);
         supplierHeader.getChildren().add(header);
         header.setMinWidth(250);

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
@@ -156,7 +156,7 @@ public class NewEntryView extends BaseDialog<BibEntry> {
         ViewLoader.view(this).load().setAsDialogPane(this);
 
         generateButton = (Button) this.getDialogPane().lookupButton(generateButtonType);
-        generateButton.getStyleClass().addAll("customGenerateButton", "padding-6-24");
+        generateButton.getStyleClass().addAll("customGenerateButton", "padding-4-24");
         Screen screen = Screen.getPrimary();
         Rectangle2D bounds = screen.getVisualBounds();
         double width = Math.clamp(bounds.getWidth() * 0.60, 400, 1100);

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
@@ -156,7 +156,7 @@ public class NewEntryView extends BaseDialog<BibEntry> {
         ViewLoader.view(this).load().setAsDialogPane(this);
 
         generateButton = (Button) this.getDialogPane().lookupButton(generateButtonType);
-        generateButton.getStyleClass().addAll("customGenerateButton", "padding-4-24");
+        generateButton.getStyleClass().addAll("customGenerateButton", "padding-4");
         Screen screen = Screen.getPrimary();
         Rectangle2D bounds = screen.getVisualBounds();
         double width = Math.clamp(bounds.getWidth() * 0.60, 400, 1100);

--- a/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
@@ -93,7 +93,7 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
             if (content instanceof Region region) {
                 region.prefWidthProperty().bind(preferencesContainer.widthProperty().subtract(10d));
             }
-            content.getStyleClass().add("padding-6");
+            content.getStyleClass().add("padding-4");
         });
 
         if (this.preferencesTabToSelectClass != null) {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTab.java
@@ -43,7 +43,7 @@ public class CitationKeyPatternTab extends AbstractPreferenceTabView<CitationKey
                         .checkbox(Localization.lang("Overwrite existing keys"), viewModel.overwriteAllowProperty())
                         .checkbox(Localization.lang("Warn before overwriting existing keys"), viewModel.overwriteWarningProperty(),
                                 warn -> warn.disableWhen(viewModel.overwriteAllowProperty().not())
-                                            .styleClass("padding-left-20"))
+                                            .styleClass("padding-left-24"))
                         .checkbox(Localization.lang("Generate keys before saving (only for entries without a key)"), viewModel.generateOnSaveProperty())
                         .checkbox(Localization.lang("Generate new keys for imported entries (overwriting their default)"), viewModel.generateKeyOnImportProperty())
 
@@ -53,7 +53,7 @@ public class CitationKeyPatternTab extends AbstractPreferenceTabView<CitationKey
                                                 .radio(Localization.lang("Start on second duplicate key with letter A (a, b, ...)"), viewModel.letterStartAProperty())
                                                 .radio(Localization.lang("Start on second duplicate key with letter B (b, c, ...)"), viewModel.letterStartBProperty())
                                                 .radio(Localization.lang("Always add letter (a, b, ...) to generated keys"), viewModel.letterAlwaysAddProperty())),
-                                indent -> indent.styleClass("padding-left-20"))
+                                indent -> indent.styleClass("padding-left-24"))
 
                         // `[regex] by [replacement]` — one labelled field, so the two stay adjacent.
                         .stringField(Localization.lang("Replace (regular expression)"), viewModel.keyPatternRegexProperty(),

--- a/jabgui/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
@@ -88,7 +88,7 @@ public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabView
         new ViewModelTreeTableCellFactory<KeyBindingViewModel>()
                 .withGraphic(keyBinding -> keyBinding.getResetIcon().map(JabRefIcon::getGraphicNode).orElse(null))
                 .withOnMouseClickedEvent(keyBinding -> _ -> keyBinding.resetToDefault())
-                .withStyleClasses(() -> List.of("align-center-right", "padding-right-6"))
+                .withStyleClasses(() -> List.of("align-center-right", "padding-right-4"))
                 .install(resetColumn);
 
         TreeTableColumn<KeyBindingViewModel, KeyBindingViewModel> clearColumn = new TreeTableColumn<>();
@@ -98,7 +98,7 @@ public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabView
         new ViewModelTreeTableCellFactory<KeyBindingViewModel>()
                 .withGraphic(keyBinding -> keyBinding.getClearIcon().map(JabRefIcon::getGraphicNode).orElse(null))
                 .withOnMouseClickedEvent(keyBinding -> _ -> keyBinding.clear())
-                .withStyleClasses(() -> List.of("align-center-right", "padding-right-6"))
+                .withStyleClasses(() -> List.of("align-center-right", "padding-right-4"))
                 .install(clearColumn);
 
         keyBindingsTable.getColumns().add(actionColumn);

--- a/jabgui/src/main/java/org/jabref/gui/preferences/table/TableTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/table/TableTab.java
@@ -63,7 +63,7 @@ public class TableTab extends AbstractPreferenceTabView<TableTabViewModel> {
                                                                 .radio(Localization.lang("Show names unchanged"), viewModel.nameAsIsProperty())
                                                                 .radio(Localization.lang("Show 'Firstname Lastname'"), viewModel.nameFirstLastProperty())
                                                                 .radio(Localization.lang("Show 'Lastname, Firstname'"), viewModel.nameLastFirstProperty())),
-                                                indent -> indent.styleClass("padding-left-20").spacing(4.0)))
+                                                indent -> indent.styleClass("padding-left-24").spacing(4.0)))
                                 .group(abbreviation -> abbreviation
                                         .label(Localization.lang("Abbreviations"))
                                         .group(choices -> choices
@@ -71,7 +71,7 @@ public class TableTab extends AbstractPreferenceTabView<TableTabViewModel> {
                                                                 .radio(Localization.lang("Do not abbreviate names"), viewModel.abbreviationDisabledProperty())
                                                                 .radio(Localization.lang("Abbreviate names"), viewModel.abbreviationEnabledProperty())
                                                                 .radio(Localization.lang("Show last names only"), viewModel.abbreviationLastNameOnlyProperty())),
-                                                indent -> indent.styleClass("padding-left-20")
+                                                indent -> indent.styleClass("padding-left-24")
                                                                 .spacing(4.0)
                                                                 // Natbib and "unchanged" render names verbatim,
                                                                 // so abbreviation does not apply.

--- a/jabgui/src/main/java/org/jabref/gui/preferences/websearch/ApiKeyDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/websearch/ApiKeyDialog.java
@@ -60,7 +60,7 @@ public class ApiKeyDialog extends FXDialog {
             apiKeyValid.set(newValue.isEmpty());
             testButton.setGraphic(null);
             testButton.setText(Localization.lang("Test connection"));
-            testButton.getStyleClass().removeAll("success", "error");
+            testButton.getStyleClass().removeAll("text-success", "text-danger");
         });
 
         persistApiKeysCheckBox.selectedProperty().bindBidirectional(viewModel.getApikeyPersistProperty());
@@ -87,8 +87,8 @@ public class ApiKeyDialog extends FXDialog {
             testButton.setDisable(false);
 
             testButton.setGraphic(success ? IconTheme.JabRefIcons.SUCCESS.getGraphicNode() : IconTheme.JabRefIcons.ERROR.getGraphicNode());
-            testButton.getStyleClass().removeAll("success", "error");
-            testButton.getStyleClass().add(success ? "success" : "error");
+            testButton.getStyleClass().removeAll("text-success", "text-danger");
+            testButton.getStyleClass().add(success ? "text-success" : "text-danger");
             testButton.setText(success ? Localization.lang("API Key Valid") : Localization.lang("API Key Invalid"));
             apiKeyValid.set(success);
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.java
@@ -180,7 +180,7 @@ public class WebSearchTab extends AbstractPreferenceTabView<WebSearchTabViewMode
 
     private Node createFetcherNode(WebSearchTabViewModel.FetcherViewModel item) {
         HBox container = new HBox();
-        container.getStyleClass().addAll("fetcher-list-cell", "padding-4-8", "align-center-left", "spacing-6");
+        container.getStyleClass().addAll("fetcher-list-cell", "padding-4-8", "align-center-left", "spacing-4");
         container.setAlignment(Pos.CENTER_LEFT);
 
         CheckBox enabledCheckBox = new CheckBox();
@@ -202,7 +202,7 @@ public class WebSearchTab extends AbstractPreferenceTabView<WebSearchTabViewMode
         }
 
         Button configureButton = new Button(Localization.lang("Configure API key"));
-        configureButton.getStyleClass().addAll("configure-button", "padding-4-6");
+        configureButton.getStyleClass().addAll("configure-button", "padding-4");
         configureButton.setOnAction(_ -> showApiKeyDialog(item));
         configureButton.setVisible(item.isCustomizable());
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.java
@@ -179,8 +179,8 @@ public class WebSearchTab extends AbstractPreferenceTabView<WebSearchTabViewMode
     }
 
     private Node createFetcherNode(WebSearchTabViewModel.FetcherViewModel item) {
-        HBox container = new HBox();
-        container.getStyleClass().addAll("fetcher-list-cell", "padding-4-8", "align-center-left", "spacing-4");
+        HBox container = new HBox(4);
+        container.getStyleClass().addAll("fetcher-list-cell", "padding-4-8", "align-center-left");
         container.setAlignment(Pos.CENTER_LEFT);
 
         CheckBox enabledCheckBox = new CheckBox();

--- a/jabgui/src/main/java/org/jabref/gui/sidepane/SidePaneComponent.java
+++ b/jabgui/src/main/java/org/jabref/gui/sidepane/SidePaneComponent.java
@@ -65,7 +65,7 @@ public class SidePaneComponent extends BorderPane {
         BorderPane headerView = new BorderPane();
         headerView.setLeft(label);
         headerView.setRight(buttonContainer);
-        headerView.getStyleClass().addAll("sidePaneComponentHeader", "padding-4-10");
+        headerView.getStyleClass().addAll("sidePaneComponentHeader", "padding-4-12");
 
         return headerView;
     }

--- a/jabgui/src/main/java/org/jabref/gui/theme/StyleClasses.java
+++ b/jabgui/src/main/java/org/jabref/gui/theme/StyleClasses.java
@@ -11,7 +11,7 @@ public final class StyleClasses {
     public static final List<String> CHANGE_VIEW_HEADER = List.of("h4", "padding-4");
 
     /// Explanatory legend below a change/diff view.
-    public static final List<String> CHANGE_VIEW_LEGEND = List.of("font-size-090", "text-subtle", "padding-4");
+    public static final List<String> CHANGE_VIEW_LEGEND = List.of("text-subtle", "padding-4");
 
     /// Header introducing a section within a tab or form.
     public static final List<String> SECTION_HEADER = List.of("h4", "padding-top-12");

--- a/jabgui/src/main/java/org/jabref/gui/theme/StyleClasses.java
+++ b/jabgui/src/main/java/org/jabref/gui/theme/StyleClasses.java
@@ -8,7 +8,7 @@ import java.util.List;
 public final class StyleClasses {
 
     /// Header above one side of a two-pane change/diff view.
-    public static final List<String> CHANGE_VIEW_HEADER = List.of("h4", "padding-2");
+    public static final List<String> CHANGE_VIEW_HEADER = List.of("h4", "padding-4");
 
     /// Explanatory legend below a change/diff view.
     public static final List<String> CHANGE_VIEW_LEGEND = List.of("font-size-090", "text-subtle", "padding-4");

--- a/jabgui/src/main/java/org/jabref/gui/util/BaseDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/util/BaseDialog.java
@@ -31,7 +31,7 @@ public class BaseDialog<T> extends Dialog<T> {
         });
         setupKeyBindings(getDialogPane());
 
-        this.setOnShown(_ -> applyButtonFix(this.getDialogPane()));
+        setOnShown(_ -> applyButtonFix(this.getDialogPane()));
 
         setDialogIcon(IconTheme.getJabRefIcon());
         setResizable(true);

--- a/jabgui/src/main/java/org/jabref/gui/util/BaseDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/util/BaseDialog.java
@@ -31,19 +31,33 @@ public class BaseDialog<T> extends Dialog<T> {
         });
         setupKeyBindings(getDialogPane());
 
-        this.setOnShowing(_ -> applyButtonFix(this.getDialogPane()));
+        this.setOnShown(_ -> applyButtonFix(this.getDialogPane()));
 
         setDialogIcon(IconTheme.getJabRefIcon());
         setResizable(true);
     }
 
+    public static boolean closeOnKeyBindingMatch(KeyEvent event, Dialog<?> dialog) {
+        KeyBindingRepository keyBindingRepository = Injector.instantiateModelOrService(KeyBindingRepository.class);
+        if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLOSE, event)) {
+            dialog.close();
+            event.consume();
+
+            return true;
+        }
+
+        return false;
+    }
+
     private void setupKeyBindings(DialogPane dialogPane) {
         dialogPane.addEventHandler(KeyEvent.KEY_PRESSED, event -> {
+            boolean closed = closeOnKeyBindingMatch(event, this);
+            if (closed) {
+                return;
+            }
+
             KeyBindingRepository keyBindingRepository = Injector.instantiateModelOrService(KeyBindingRepository.class);
-            if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLOSE, event)) {
-                close();
-                event.consume();
-            } else if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.DEFAULT_DIALOG_ACTION, event)) {
+            if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.DEFAULT_DIALOG_ACTION, event)) {
                 getDefaultButton().ifPresent(Button::fire);
                 event.consume();
             }
@@ -95,6 +109,8 @@ public class BaseDialog<T> extends Dialog<T> {
                 button.applyCss();
             }
         }
+
+        pane.requestLayout();
     }
 
     public static void bringToFront(Dialog<?> dialog) {

--- a/jabgui/src/main/java/org/jabref/gui/util/ControlHelper.java
+++ b/jabgui/src/main/java/org/jabref/gui/util/ControlHelper.java
@@ -22,9 +22,9 @@ import org.jabref.gui.theme.StyleClasses;
 public class ControlHelper {
 
     // Pseudo-classes for drag and drop
-    private static PseudoClass dragOverBottom = PseudoClass.getPseudoClass("dragOver-bottom");
-    private static PseudoClass dragOverCenter = PseudoClass.getPseudoClass("dragOver-center");
-    private static PseudoClass dragOverTop = PseudoClass.getPseudoClass("dragOver-top");
+    private static final PseudoClass DRAG_OVER_BOTTOM = PseudoClass.getPseudoClass("drag-over-bottom");
+    private static final PseudoClass DRAG_OVER_CENTER = PseudoClass.getPseudoClass("drag-over-center");
+    private static final PseudoClass DRAG_OVER_TOP = PseudoClass.getPseudoClass("drag-over-top");
 
     public enum EllipsisPosition { BEGINNING, CENTER, ENDING }
 
@@ -123,24 +123,24 @@ public class ControlHelper {
         removeDroppingPseudoClasses(cell);
         switch (getDroppingMouseLocation(cell, event)) {
             case BOTTOM:
-                cell.pseudoClassStateChanged(dragOverBottom, true);
+                cell.pseudoClassStateChanged(DRAG_OVER_BOTTOM, true);
                 break;
             case CENTER:
-                cell.pseudoClassStateChanged(dragOverCenter, true);
+                cell.pseudoClassStateChanged(DRAG_OVER_CENTER, true);
                 break;
             case TOP:
-                cell.pseudoClassStateChanged(dragOverTop, true);
+                cell.pseudoClassStateChanged(DRAG_OVER_TOP, true);
                 break;
         }
     }
 
     public static void setDroppingPseudoClasses(Cell<?> cell) {
         removeDroppingPseudoClasses(cell);
-        cell.pseudoClassStateChanged(dragOverCenter, true);
+        cell.pseudoClassStateChanged(DRAG_OVER_CENTER, true);
     }
 
     public static void removeDroppingPseudoClasses(Cell<?> cell) {
-        removePseudoClasses(cell, dragOverBottom, dragOverCenter, dragOverTop);
+        removePseudoClasses(cell, DRAG_OVER_BOTTOM, DRAG_OVER_CENTER, DRAG_OVER_TOP);
     }
 
     /// If needed, truncates a given string to `maxCharacters`, adding `ellipsisString` instead.

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
@@ -112,7 +112,7 @@ public class WalkthroughRenderer {
 
     private Node render(InfoBlock infoBlock) {
         HBox infoContainer = new HBox();
-        infoContainer.getStyleClass().addAll("walkthrough-info-container", "padding-left-12", "spacing-6", "align-top-left");
+        infoContainer.getStyleClass().addAll("walkthrough-info-container", "padding-left-12", "spacing-4", "align-top-left");
 
         JabRefIconView icon = new JabRefIconView(IconTheme.JabRefIcons.INTEGRITY_INFO);
 
@@ -148,7 +148,7 @@ public class WalkthroughRenderer {
 
         HBox rightActions = new HBox();
         rightActions.setAlignment(Pos.CENTER_RIGHT);
-        rightActions.getStyleClass().add("spacing-6");
+        rightActions.getStyleClass().add("spacing-4");
 
         component.skipButtonText()
                  .ifPresent(text ->
@@ -181,7 +181,7 @@ public class WalkthroughRenderer {
     /// @param text the already localized button text
     private Button makeButton(String text, String styleClass, Runnable beforeNavigate, Runnable navigationAction) {
         Button button = new Button(text);
-        button.getStyleClass().addAll(styleClass, "h5", "padding-4-6");
+        button.getStyleClass().addAll(styleClass, "h5", "padding-4");
         button.setOnAction(_ -> {
             beforeNavigate.run();
             navigationAction.run();

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
@@ -29,8 +29,8 @@ public class WalkthroughRenderer {
     /// @param beforeNavigate Runnable to execute before any navigation action
     /// @return The rendered tooltip content node
     public Node render(TooltipStep step, Walkthrough walkthrough, Runnable beforeNavigate) {
-        VBox tooltip = new VBox();
-        tooltip.getStyleClass().addAll("root", "padding-12", "spacing-12");
+        VBox tooltip = new VBox(12);
+        tooltip.getStyleClass().addAll("root", "padding-12");
 
         StackPane titleContainer = new StackPane();
         titleContainer.getStyleClass().add("walkthrough-title-container");
@@ -40,11 +40,9 @@ public class WalkthroughRenderer {
         titleContainer.getChildren().add(titleFlow);
 
         VBox contentContainer = createContent(step, walkthrough, beforeNavigate);
-        contentContainer.getStyleClass().add("spacing-16");
         VBox.setVgrow(contentContainer, Priority.ALWAYS);
 
         HBox actionsContainer = createActions(step, walkthrough, beforeNavigate);
-        actionsContainer.getStyleClass().add("spacing-0");
 
         step.maxHeight().ifPresent(tooltip::setMaxHeight);
         step.maxWidth().ifPresent(tooltip::setMaxWidth);
@@ -134,9 +132,8 @@ public class WalkthroughRenderer {
     }
 
     private HBox createActions(VisibleComponent component, Walkthrough walkthrough, Runnable beforeNavigate) {
-        HBox actions = new HBox();
+        HBox actions = new HBox(0);
         actions.setAlignment(Pos.CENTER_LEFT);
-        actions.getStyleClass().add("spacing-0");
 
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
@@ -163,8 +160,7 @@ public class WalkthroughRenderer {
     }
 
     private VBox createContent(VisibleComponent component, Walkthrough walkthrough, Runnable beforeNavigate) {
-        VBox contentBox = new VBox();
-        contentBox.getStyleClass().add("spacing-16");
+        VBox contentBox = new VBox(16);
         contentBox.getChildren().addAll(component.content().stream().map(block ->
                 switch (block) {
                     case TextBlock textBlock ->

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
@@ -80,12 +80,12 @@ public class WalkthroughRenderer {
         boolean isVertical = step.position() == PanelPosition.LEFT || step.position() == PanelPosition.RIGHT;
 
         if (isVertical) {
-            panel.getStyleClass().addAll("walkthrough-side-panel-vertical", "padding-24", "spacing-12");
+            panel.getStyleClass().addAll("walkthrough-side-panel-vertical", "padding-24");
             VBox.setVgrow(panel, Priority.ALWAYS);
             panel.setMaxHeight(Double.MAX_VALUE);
             step.maxWidth().ifPresent(panel::setMaxWidth);
         } else if (step.position() == PanelPosition.TOP || step.position() == PanelPosition.BOTTOM) {
-            panel.getStyleClass().addAll("walkthrough-side-panel-horizontal", "padding-24", "spacing-12");
+            panel.getStyleClass().addAll("walkthrough-side-panel-horizontal", "padding-24");
             HBox.setHgrow(panel, Priority.ALWAYS);
             panel.setMaxWidth(Double.MAX_VALUE);
             step.maxHeight().ifPresent(panel::setMaxHeight);
@@ -109,8 +109,8 @@ public class WalkthroughRenderer {
     }
 
     private Node render(InfoBlock infoBlock) {
-        HBox infoContainer = new HBox();
-        infoContainer.getStyleClass().addAll("walkthrough-info-container", "padding-left-12", "spacing-4", "align-top-left");
+        HBox infoContainer = new HBox(4);
+        infoContainer.getStyleClass().addAll("walkthrough-info-container", "padding-left-12", "align-top-left");
 
         JabRefIconView icon = new JabRefIconView(IconTheme.JabRefIcons.INTEGRITY_INFO);
 
@@ -126,7 +126,7 @@ public class WalkthroughRenderer {
     }
 
     private VBox makePanel() {
-        VBox container = new VBox();
+        VBox container = new VBox(12);
         container.getStyleClass().add("walkthrough-panel");
         return container;
     }
@@ -143,9 +143,8 @@ public class WalkthroughRenderer {
                          actions.getChildren()
                                 .add(makeButton(text, "walkthrough-back-button", beforeNavigate, walkthrough::previousStep)));
 
-        HBox rightActions = new HBox();
+        HBox rightActions = new HBox(4);
         rightActions.setAlignment(Pos.CENTER_RIGHT);
-        rightActions.getStyleClass().add("spacing-4");
 
         component.skipButtonText()
                  .ifPresent(text ->

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
@@ -112,7 +112,7 @@ public class WalkthroughRenderer {
 
     private Node render(InfoBlock infoBlock) {
         HBox infoContainer = new HBox();
-        infoContainer.getStyleClass().addAll("walkthrough-info-container", "padding-left-10", "spacing-6", "align-top-left");
+        infoContainer.getStyleClass().addAll("walkthrough-info-container", "padding-left-12", "spacing-6", "align-top-left");
 
         JabRefIconView icon = new JabRefIconView(IconTheme.JabRefIcons.INTEGRITY_INFO);
 

--- a/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
@@ -115,11 +115,11 @@ public class WelcomeTab extends Tab {
         this.buildInfo = buildInfo;
         this.stage = stage;
         this.workspacePreferences = workspacePreferences;
-        this.recentLibrariesBox = new VBox();
+        this.recentLibrariesBox = new VBox(8);
         recentLibrariesBox.getStyleClass().add("welcome-recent-libraries");
 
-        main = new VBox(createTopTitles(), new VBox(), createCommunityBox());
-        main.getStyleClass().addAll("welcome-main-container", "spacing-24", "align-center", "padding-24");
+        main = new VBox(24, createTopTitles(), new VBox(), createCommunityBox());
+        main.getStyleClass().addAll("welcome-main-container", "align-center", "padding-24");
         initializeColumns();
 
         VBox container = new VBox(main);
@@ -136,7 +136,7 @@ public class WelcomeTab extends Tab {
 
     private VBox createTopTitles() {
         Label welcomeLabel = new Label(Localization.lang("Welcome to JabRef"));
-        welcomeLabel.getStyleClass().addAll("font-size-250", "text-accent");
+        welcomeLabel.getStyleClass().addAll("h1", "text-accent");
         Label descriptionLabel = new Label(Localization.lang("Stay on top of your literature"));
         descriptionLabel.getStyleClass().add("h2");
         VBox topTitles = new VBox(welcomeLabel, descriptionLabel);
@@ -146,7 +146,7 @@ public class WelcomeTab extends Tab {
 
     private void initializeColumns() {
         GridPane grid = new GridPane();
-        grid.getStyleClass().addAll("gap-24", "align-top-center");
+        grid.getStyleClass().addAll("gap-16", "align-top-center");
 
         VBox leftColumn = createLeftColumn();
         GridPane.setHgrow(leftColumn, Priority.ALWAYS);
@@ -175,19 +175,19 @@ public class WelcomeTab extends Tab {
     }
 
     private VBox createLeftColumn() {
-        VBox leftColumn = new VBox(
+        VBox leftColumn = new VBox(24,
                 createWelcomeStartBox(),
                 createWelcomeRecentBox()
         );
-        leftColumn.getStyleClass().addAll("spacing-24", "align-top-left");
+        leftColumn.getStyleClass().addAll("align-top-left");
         return leftColumn;
     }
 
     private VBox createRightColumn() {
         this.quickSettings = new QuickSettings(preferences, dialogService, taskExecutor);
         this.walkthroughs = new Walkthroughs(stage, tabContainer, stateManager, preferences);
-        VBox rightColumn = new VBox(quickSettings, walkthroughs);
-        rightColumn.getStyleClass().addAll("spacing-24", "align-top-left");
+        VBox rightColumn = new VBox(24, quickSettings, walkthroughs);
+        rightColumn.getStyleClass().addAll("align-top-left");
         return rightColumn;
     }
 
@@ -256,8 +256,8 @@ public class WelcomeTab extends Tab {
                 this::importIntoNewLibrary
         );
 
-        VBox container = new VBox();
-        container.getStyleClass().addAll("spacing-8", "align-top-left");
+        VBox container = new VBox(8);
+        container.getStyleClass().addAll("align-top-left");
         container.getChildren().addAll(newLibraryLink, openExampleLibraryLink, openLibraryLink, importIntoNewLibraryLink);
 
         return createVBoxContainer(header, container);
@@ -309,7 +309,7 @@ public class WelcomeTab extends Tab {
             return;
         }
         recentLibrariesBox.getChildren().clear();
-        recentLibrariesBox.getStyleClass().addAll("spacing-8", "align-top-left");
+        recentLibrariesBox.getStyleClass().addAll("align-top-left");
         fileHistoryMenu.disableProperty().unbind();
         fileHistoryMenu.setDisable(false);
         for (MenuItem item : fileHistoryMenu.getItems()) {
@@ -357,8 +357,8 @@ public class WelcomeTab extends Tab {
     }
 
     private HBox createTextLinksContainer() {
-        HBox container = new HBox();
-        container.getStyleClass().addAll("spacing-16", "align-center-left");
+        HBox container = new HBox(16);
+        container.getStyleClass().addAll("align-center-left");
 
         Hyperlink devVersionLink = createFooterLink(Localization.lang("Download development version"), StandardActions.OPEN_DEV_VERSION_LINK, null);
         Hyperlink changelogLink = createFooterLink(Localization.lang("CHANGELOG"), StandardActions.OPEN_CHANGELOG, null);

--- a/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
@@ -403,7 +403,7 @@ public class WelcomeTab extends Tab {
         HBox container = new HBox();
         container.getStyleClass().addAll("align-center-left", "padding-top-4");
         Label versionLabel = new Label(Localization.lang("Current JabRef version: %0", buildInfo.version));
-        versionLabel.getStyleClass().addAll("font-size-090", "text-subtle");
+        versionLabel.getStyleClass().addAll("text-subtle");
         container.getChildren().add(versionLabel);
         return container;
     }

--- a/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
@@ -139,8 +139,8 @@ public class WelcomeTab extends Tab {
         welcomeLabel.getStyleClass().addAll("h1", "text-accent");
         Label descriptionLabel = new Label(Localization.lang("Stay on top of your literature"));
         descriptionLabel.getStyleClass().add("h2");
-        VBox topTitles = new VBox(welcomeLabel, descriptionLabel);
-        topTitles.getStyleClass().addAll("spacing-12", "align-top-left", "padding-bottom-24");
+        VBox topTitles = new VBox(12, welcomeLabel, descriptionLabel);
+        topTitles.getStyleClass().addAll("align-top-left", "padding-bottom-24");
         return topTitles;
     }
 
@@ -335,8 +335,8 @@ public class WelcomeTab extends Tab {
         FlowPane iconLinksContainer = createIconLinksContainer();
         HBox textLinksContainer = createTextLinksContainer();
         HBox versionContainer = createVersionContainer();
-        VBox container = new VBox();
-        container.getStyleClass().addAll("spacing-12", "align-top-left");
+        VBox container = new VBox(12);
+        container.getStyleClass().add("align-top-left");
         container.getChildren().addAll(iconLinksContainer, textLinksContainer, versionContainer);
         return createVBoxContainer(header, container);
     }
@@ -409,8 +409,8 @@ public class WelcomeTab extends Tab {
     }
 
     private VBox createVBoxContainer(Node... nodes) {
-        VBox box = new VBox();
-        box.getStyleClass().addAll("spacing-12", "align-top-left");
+        VBox box = new VBox(12);
+        box.getStyleClass().add("align-top-left");
         box.getChildren().addAll(nodes);
         return box;
     }

--- a/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
@@ -119,7 +119,7 @@ public class WelcomeTab extends Tab {
         recentLibrariesBox.getStyleClass().add("welcome-recent-libraries");
 
         main = new VBox(createTopTitles(), new VBox(), createCommunityBox());
-        main.getStyleClass().addAll("welcome-main-container", "spacing-24", "align-center", "padding-32-24");
+        main.getStyleClass().addAll("welcome-main-container", "spacing-24", "align-center", "padding-24");
         initializeColumns();
 
         VBox container = new VBox(main);

--- a/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
@@ -140,7 +140,7 @@ public class WelcomeTab extends Tab {
         Label descriptionLabel = new Label(Localization.lang("Stay on top of your literature"));
         descriptionLabel.getStyleClass().add("h2");
         VBox topTitles = new VBox(welcomeLabel, descriptionLabel);
-        topTitles.getStyleClass().addAll("spacing-10", "align-top-left", "padding-bottom-20");
+        topTitles.getStyleClass().addAll("spacing-12", "align-top-left", "padding-bottom-24");
         return topTitles;
     }
 
@@ -369,7 +369,7 @@ public class WelcomeTab extends Tab {
 
     private Hyperlink createFooterLink(String text, StandardActions action, IconTheme.JabRefIcons icon) {
         Hyperlink link = new Hyperlink(text);
-        link.getStyleClass().add("welcome-community-link");
+        link.getStyleClass().addAll("welcome-community-link", "text-accent");
         String url = switch (action) {
             case HELP ->
                     URLs.HELP_URL;

--- a/jabgui/src/main/java/org/jabref/gui/welcome/components/DonationProvider.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/components/DonationProvider.java
@@ -70,25 +70,25 @@ public class DonationProvider {
         Label subtitle = new Label(Localization.lang("Help us improve JabRef by donating."));
         subtitle.getStyleClass().add("font-size-090");
         VBox textBox = new VBox(title, subtitle);
-        textBox.getStyleClass().add("spacing-2");
+        textBox.getStyleClass().add("spacing-4");
 
         Node iconNode = IconTheme.JabRefIcons.DONATE.getGraphicNode();
         HBox leftContent = new HBox(10, iconNode, textBox);
         leftContent.setAlignment(Pos.CENTER_LEFT);
 
         Button neverButton = new Button(Localization.lang("Never show again"));
-        neverButton.getStyleClass().addAll("donation-btn-ghost", "padding-6-12");
+        neverButton.getStyleClass().addAll("donation-btn-ghost", "padding-4-12");
         neverButton.setOnAction(_ -> {
             preferences.getDonationPreferences().setNeverShowAgain(true);
             hideToast();
         });
 
         Button cancelButton = new Button(Localization.lang("Cancel"));
-        cancelButton.getStyleClass().addAll("donation-btn-secondary", "padding-6-12");
+        cancelButton.getStyleClass().addAll("donation-btn-secondary", "padding-4-12");
         cancelButton.setOnAction(_ -> hideToast());
 
         Button donateButton = new Button(Localization.lang("Donate"));
-        donateButton.getStyleClass().addAll("donation-btn-primary", "padding-6-12");
+        donateButton.getStyleClass().addAll("donation-btn-primary", "padding-4-12");
         donateButton.setDefaultButton(true);
         donateButton.setOnAction(_ -> {
             new OpenBrowserAction(DONATION_URL, dialogService, preferences.getExternalApplicationsPreferences()).execute();

--- a/jabgui/src/main/java/org/jabref/gui/welcome/components/DonationProvider.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/components/DonationProvider.java
@@ -102,7 +102,7 @@ public class DonationProvider {
         HBox.setHgrow(textSpacer, Priority.ALWAYS);
 
         donationToast = new HBox(leftContent, textSpacer, rightButtons);
-        donationToast.getStyleClass().addAll("donation-toast", "padding-10-12", "spacing-12", "align-center-left");
+        donationToast.getStyleClass().addAll("donation-toast", "padding-12", "spacing-12", "align-center-left");
         donationToast.setMaxWidth(Region.USE_PREF_SIZE);
         donationToast.setMinWidth(Region.USE_PREF_SIZE);
         donationToast.setTranslateY(-40);

--- a/jabgui/src/main/java/org/jabref/gui/welcome/components/DonationProvider.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/components/DonationProvider.java
@@ -68,7 +68,6 @@ public class DonationProvider {
         Label title = new Label(Localization.lang("Support JabRef"));
         title.getStyleClass().add("bold");
         Label subtitle = new Label(Localization.lang("Help us improve JabRef by donating."));
-        subtitle.getStyleClass().add("font-size-090");
         VBox textBox = new VBox(title, subtitle);
         textBox.getStyleClass().add("spacing-4");
 

--- a/jabgui/src/main/java/org/jabref/gui/welcome/components/DonationProvider.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/components/DonationProvider.java
@@ -68,8 +68,7 @@ public class DonationProvider {
         Label title = new Label(Localization.lang("Support JabRef"));
         title.getStyleClass().add("bold");
         Label subtitle = new Label(Localization.lang("Help us improve JabRef by donating."));
-        VBox textBox = new VBox(title, subtitle);
-        textBox.getStyleClass().add("spacing-4");
+        VBox textBox = new VBox(4, title, subtitle);
 
         Node iconNode = IconTheme.JabRefIcons.DONATE.getGraphicNode();
         HBox leftContent = new HBox(10, iconNode, textBox);
@@ -100,8 +99,8 @@ public class DonationProvider {
         Region textSpacer = new Region();
         HBox.setHgrow(textSpacer, Priority.ALWAYS);
 
-        donationToast = new HBox(leftContent, textSpacer, rightButtons);
-        donationToast.getStyleClass().addAll("donation-toast", "padding-12", "spacing-12", "align-center-left");
+        donationToast = new HBox(12, leftContent, textSpacer, rightButtons);
+        donationToast.getStyleClass().addAll("donation-toast", "padding-12", "align-center-left");
         donationToast.setMaxWidth(Region.USE_PREF_SIZE);
         donationToast.setMinWidth(Region.USE_PREF_SIZE);
         donationToast.setTranslateY(-40);

--- a/jabgui/src/main/java/org/jabref/gui/welcome/components/QuickSettings.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/components/QuickSettings.java
@@ -35,7 +35,8 @@ public class QuickSettings extends VBox {
         this.dialogService = dialogService;
         this.taskExecutor = taskExecutor;
 
-        getStyleClass().addAll("spacing-12", "align-top-left");
+        setSpacing(12);
+        getStyleClass().add("align-top-left");
 
         header = new Label(Localization.lang("Quick settings"));
         header.getStyleClass().addAll(StyleClasses.WELCOME_HEADER);
@@ -101,7 +102,7 @@ public class QuickSettings extends VBox {
                 IconTheme.JabRefIcons.TOGGLE_GROUPS,
                 this::showEntryTableConfigurationDialog);
 
-        VBox newContent = new VBox(
+        VBox newContent = new VBox(4,
                 httpServerToggle,
                 coverImagesDownloadToggle,
                 mainFileDirButton,
@@ -110,7 +111,7 @@ public class QuickSettings extends VBox {
                 entryTableButton,
                 pushApplicationButton,
                 onlineServicesButton);
-        newContent.getStyleClass().addAll("spacing-4", "align-top-left");
+        newContent.getStyleClass().add("align-top-left");
         return newContent;
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/welcome/components/QuickSettings.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/components/QuickSettings.java
@@ -128,7 +128,7 @@ public class QuickSettings extends VBox {
     private Button createButton(String text, IconTheme.JabRefIcons icon, Runnable action) {
         Button button = new Button(text);
         button.setGraphic(icon.getGraphicNode());
-        button.getStyleClass().addAll("quick-settings-button", "padding-12-16", "align-center-left");
+        button.getStyleClass().addAll("quick-settings-button", "padding-12", "align-center-left");
         button.setMaxWidth(Double.MAX_VALUE);
         button.setOnAction(event -> action.run());
         return button;

--- a/jabgui/src/main/java/org/jabref/gui/welcome/components/QuickSettings.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/components/QuickSettings.java
@@ -128,7 +128,7 @@ public class QuickSettings extends VBox {
     private Button createButton(String text, IconTheme.JabRefIcons icon, Runnable action) {
         Button button = new Button(text);
         button.setGraphic(icon.getGraphicNode());
-        button.getStyleClass().addAll("quick-settings-button", "padding-10-16", "align-center-left");
+        button.getStyleClass().addAll("quick-settings-button", "padding-12-16", "align-center-left");
         button.setMaxWidth(Double.MAX_VALUE);
         button.setOnAction(event -> action.run());
         return button;

--- a/jabgui/src/main/java/org/jabref/gui/welcome/components/Walkthroughs.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/components/Walkthroughs.java
@@ -103,7 +103,7 @@ public class Walkthroughs extends VBox {
     private Button createWalkthroughButton(String text, IconTheme.JabRefIcons icon, String walkthroughId) {
         Button button = new Button(text);
         button.setGraphic(icon.getGraphicNode());
-        button.getStyleClass().addAll("quick-settings-button", "padding-12-16", "align-center-left");
+        button.getStyleClass().addAll("quick-settings-button", "padding-12", "align-center-left");
         button.setMaxWidth(Double.MAX_VALUE);
         button.setOnAction(_ -> new WalkthroughAction(stage, tabContainer, stateManager, preferences, walkthroughId).execute());
         return button;

--- a/jabgui/src/main/java/org/jabref/gui/welcome/components/Walkthroughs.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/components/Walkthroughs.java
@@ -30,7 +30,8 @@ public class Walkthroughs extends VBox {
         this.stateManager = stateManager;
         this.preferences = preferences;
 
-        getStyleClass().addAll("spacing-12", "align-top-left");
+        setSpacing(12);
+        getStyleClass().add("align-top-left");
 
         header = new Label(Localization.lang("Walkthroughs"));
         header.getStyleClass().addAll(StyleClasses.WELCOME_HEADER);
@@ -56,8 +57,8 @@ public class Walkthroughs extends VBox {
     }
 
     private VBox createWalkthroughContent() {
-        VBox content = new VBox();
-        content.getStyleClass().addAll("spacing-4", "align-top-left");
+        VBox content = new VBox(4);
+        content.getStyleClass().add("align-top-left");
 
         Button mainFileDirWalkthroughButton = createWalkthroughButton(
                 Localization.lang("Set main file directory"),

--- a/jabgui/src/main/java/org/jabref/gui/welcome/components/Walkthroughs.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/components/Walkthroughs.java
@@ -103,7 +103,7 @@ public class Walkthroughs extends VBox {
     private Button createWalkthroughButton(String text, IconTheme.JabRefIcons icon, String walkthroughId) {
         Button button = new Button(text);
         button.setGraphic(icon.getGraphicNode());
-        button.getStyleClass().addAll("quick-settings-button", "padding-10-16", "align-center-left");
+        button.getStyleClass().addAll("quick-settings-button", "padding-12-16", "align-center-left");
         button.setMaxWidth(Double.MAX_VALUE);
         button.setOnAction(_ -> new WalkthroughAction(stage, tabContainer, stateManager, preferences, walkthroughId).execute());
         return button;

--- a/jabgui/src/main/resources/org/jabref/gui/ai/AiPrivacyNotice.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/ai/AiPrivacyNotice.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.text.Text?>
 <fx:root
         type="ScrollPane"
-        styleClass="ai-tab,padding-20"
+        styleClass="ai-tab,padding-24"
         xmlns="http://javafx.com/javafx/17.0.2-ea"
         xmlns:fx="http://javafx.com/fxml/1"
         fx:controller="org.jabref.gui.ai.AiPrivacyNoticeView">

--- a/jabgui/src/main/resources/org/jabref/gui/ai/chat/AiChatStatus.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/ai/chat/AiChatStatus.fxml
@@ -27,7 +27,7 @@
     </padding>
 
     <Label text="%Chat Status"
-           styleClass="h3,padding-bottom-6"/>
+           styleClass="h3,padding-bottom-4"/>
 
     <VBox spacing="10">
         <Label text="%Chatting parameters"

--- a/jabgui/src/main/resources/org/jabref/gui/edit/automaticfieldeditor/clearcontent/ClearContentTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/edit/automaticfieldeditor/clearcontent/ClearContentTab.fxml
@@ -14,7 +14,7 @@
         prefHeight="400.0"
         prefWidth="600.0"
         type="VBox"
-        styleClass="edit-field-content-pane,padding-0-12,spacing-12"
+        spacing="12" styleClass="edit-field-content-pane,padding-0-12"
         xmlns="http://javafx.com/javafx/17"
         xmlns:fx="http://javafx.com/fxml/1"
         fx:controller="org.jabref.gui.edit.automaticfieldeditor.clearcontent.ClearContentTabView">

--- a/jabgui/src/main/resources/org/jabref/gui/edit/automaticfieldeditor/copyormovecontent/CopyOrMoveFieldContentTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/edit/automaticfieldeditor/copyormovecontent/CopyOrMoveFieldContentTab.fxml
@@ -11,7 +11,7 @@
 <?import javafx.scene.layout.VBox?>
 <fx:root
         type="VBox"
-        styleClass="edit-field-content-pane,padding-0-12,spacing-12"
+        spacing="12" styleClass="edit-field-content-pane,padding-0-12"
         xmlns="http://javafx.com/javafx/17"
         xmlns:fx="http://javafx.com/fxml/1"
         fx:controller="org.jabref.gui.edit.automaticfieldeditor.copyormovecontent.CopyOrMoveFieldContentTabView">
@@ -52,7 +52,7 @@
             fx:id="overwriteFieldContentCheckBox"
             mnemonicParsing="false"
             text="%Overwrite field content"/>
-    <HBox styleClass="spacing-8,align-baseline-left">
+    <HBox spacing="8" styleClass="align-baseline-left">
         <Button fx:id="copyContentButton"
                 mnemonicParsing="false"
                 onAction="#copyContent"

--- a/jabgui/src/main/resources/org/jabref/gui/edit/automaticfieldeditor/editfieldcontent/EditFieldContentTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/edit/automaticfieldeditor/editfieldcontent/EditFieldContentTab.fxml
@@ -10,13 +10,13 @@
 <?import javafx.scene.layout.VBox?>
 <fx:root
         type="VBox"
-        styleClass="edit-field-content-pane,padding-0-12,spacing-12"
+        spacing="12" styleClass="edit-field-content-pane,padding-0-12"
         xmlns="http://javafx.com/javafx/17"
         xmlns:fx="http://javafx.com/fxml/1"
         fx:controller="org.jabref.gui.edit.automaticfieldeditor.editfieldcontent.EditFieldContentTabView">
     <Label styleClass="h4,padding-top-12"
            text="%Edit field content for selected entries"/>
-    <HBox styleClass="spacing-8,align-baseline-left">
+    <HBox spacing="8" styleClass="align-baseline-left">
         <ComboBox
                 fx:id="fieldComboBox"
                 editable="true"
@@ -35,7 +35,7 @@
             fx:id="overwriteFieldContentCheckBox"
             mnemonicParsing="false"
             text="%Overwrite field content"/>
-    <HBox styleClass="spacing-8,align-baseline-left">
+    <HBox spacing="8" styleClass="align-baseline-left">
         <Button fx:id="setValueButton"
                 mnemonicParsing="false"
                 onAction="#setFieldValue"

--- a/jabgui/src/main/resources/org/jabref/gui/edit/automaticfieldeditor/renamefield/RenameFieldTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/edit/automaticfieldeditor/renamefield/RenameFieldTab.fxml
@@ -8,13 +8,13 @@
 <?import javafx.scene.layout.VBox?>
 <fx:root
         type="VBox"
-        styleClass="edit-field-content-pane,padding-0-12,spacing-12"
+        spacing="12" styleClass="edit-field-content-pane,padding-0-12"
         xmlns="http://javafx.com/javafx/17"
         xmlns:fx="http://javafx.com/fxml/1"
         fx:controller="org.jabref.gui.edit.automaticfieldeditor.renamefield.RenameFieldTabView">
     <Label styleClass="h4,padding-top-12"
            text="%Rename field"/>
-    <HBox styleClass="spacing-8,align-baseline-left">
+    <HBox spacing="8" styleClass="align-baseline-left">
         <ComboBox
                 fx:id="fieldComboBox"
                 editable="true"

--- a/jabgui/src/main/resources/org/jabref/gui/entryeditor/EntryEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/entryeditor/EntryEditor.fxml
@@ -27,7 +27,7 @@
             </Button>
             <Pane prefHeight="10" VBox.vgrow="ALWAYS"/>
             <Group>
-                <Label fx:id="typeLabel" rotate="270" styleClass="h5,padding-2">
+                <Label fx:id="typeLabel" rotate="270" styleClass="h5,padding-4">
                     <tooltip>
                         <Tooltip text="%Change entry type"/>
                     </tooltip>

--- a/jabgui/src/main/resources/org/jabref/gui/errorconsole/ErrorConsole.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/errorconsole/ErrorConsole.fxml
@@ -14,7 +14,7 @@
                   BorderPane.alignment="CENTER"/>
     </content>
     <header>
-        <Label fx:id="descriptionLabel" styleClass="info-section,h5,padding-8-12"
+        <Label fx:id="descriptionLabel" styleClass="info-section,h5,padding-8"
                text="%The event log displays information regarding JabRef's internal processes. This data can be useful for debugging. If you encounter a problem, please consider reporting it to the development team."
                wrapText="true"/>
     </header>

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/journalinfo/JournalInfo.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/journalinfo/JournalInfo.fxml
@@ -29,7 +29,7 @@
             <RowConstraints />
         </rowConstraints>
         <VBox prefHeight="200.0" prefWidth="100.0" styleClass="grid-cell-r">
-            <Label styleClass="info-label,h4" text="%h-index">
+            <Label styleClass="h4,text-accent" text="%h-index">
                 <VBox.margin>
                     <Insets bottom="10.0" />
                 </VBox.margin>
@@ -40,7 +40,7 @@
             </padding>
         </VBox>
         <VBox prefHeight="200.0" prefWidth="100.0" styleClass="grid-cell-r" GridPane.columnIndex="1">
-            <Label styleClass="info-label,h4" text="%Publisher">
+            <Label styleClass="h4,text-accent" text="%Publisher">
                 <VBox.margin>
                     <Insets bottom="10.0" />
                 </VBox.margin>
@@ -51,7 +51,7 @@
             </padding>
         </VBox>
         <VBox prefHeight="200.0" prefWidth="100.0" GridPane.columnIndex="2">
-            <Label styleClass="info-label,h4" text="%ISSN">
+            <Label styleClass="h4,text-accent" text="%ISSN">
                 <VBox.margin>
                     <Insets bottom="10.0" />
                 </VBox.margin>

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/journalinfo/JournalInfo.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/journalinfo/JournalInfo.fxml
@@ -13,7 +13,7 @@
          styleClass="journalInfo" type="VBox"
          xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1"
          fx:controller="org.jabref.gui.fieldeditors.journalinfo.JournalInfoView">
-    <Label fx:id="title" styleClass="text-accent,font-size-250">
+    <Label fx:id="title" styleClass="h1,text-accent">
         <opaqueInsets>
             <Insets bottom="1.0" right="10.0" top="10.0" />
         </opaqueInsets>

--- a/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
@@ -35,18 +35,18 @@
                     <Label managed="${controller.viewModel.isDevelopmentVersion}" styleClass="dev-heading,h3"
                            text="${controller.viewModel.developmentVersion}"
                            visible="${controller.viewModel.isDevelopmentVersion}"/>
-                    <Hyperlink onAction="#openChangeLog" styleClass="padding-top-6" text="%What's new in this version?"/>
+                    <Hyperlink onAction="#openChangeLog" styleClass="padding-top-4" text="%What's new in this version?"/>
                     <Label styleClass="filler"/>
                     <HBox alignment="CENTER_LEFT">
-                        <Label styleClass="padding-right-6" text="${controller.viewModel.license}" wrapText="true"/>
+                        <Label styleClass="padding-right-4" text="${controller.viewModel.license}" wrapText="true"/>
                         <Hyperlink onAction="#openLicense" text="MIT"/>
                     </HBox>
                     <Hyperlink onAction="#openPrivacyPolicy" text="Privacy Policy"/>
                     <Hyperlink onAction="#openExternalLibrariesWebsite" text="%Used libraries"/>
                     <HBox alignment="CENTER_LEFT">
-                        <Label styleClass="padding-right-6" text="%Want to help?" wrapText="true"/>
+                        <Label styleClass="padding-right-4" text="%Want to help?" wrapText="true"/>
                         <Hyperlink onAction="#openDonation" text="%Make a donation"/>
-                        <Label styleClass="padding-0-6" text="%or" wrapText="true"/>
+                        <Label styleClass="padding-0-4" text="%or" wrapText="true"/>
                         <Hyperlink onAction="#openGithub" text="%get involved"/>
                         <Label text="."/>
                     </HBox>
@@ -87,7 +87,7 @@
             <Label alignment="CENTER" styleClass="padding-4" prefHeight="100.0" text="${controller.viewModel.maintainers}" textAlignment="JUSTIFY" wrapText="true"/>
             <Label styleClass="h3,padding-4" text="%Contributors"/>
             <HBox alignment="CENTER_LEFT">
-                <Hyperlink styleClass="padding-6" onAction="#openContributors" text="%JabRef would not have been possible without the help of our contributors." wrapText="true"/>
+                <Hyperlink styleClass="padding-4" onAction="#openContributors" text="%JabRef would not have been possible without the help of our contributors." wrapText="true"/>
             </HBox>
             <TextArea fx:id="textAreaVersions" editable="false" prefHeight="100.0" prefWidth="200.0" styleClass="padding-4"/>
         </VBox>

--- a/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
@@ -24,7 +24,7 @@
             <AnchorPane>
                 <VBox alignment="CENTER_LEFT" spacing="1.0" styleClass="padding-bottom-16"
                       AnchorPane.leftAnchor="0" AnchorPane.topAnchor="0">
-                    <Label alignment="CENTER" contentDisplay="CENTER" onMouseClicked="#copyVersionToClipboard" styleClass="about-heading,font-size-250" text="${controller.viewModel.heading}" textFill="#2c3e50" wrapText="true">
+                    <Label alignment="CENTER" contentDisplay="CENTER" onMouseClicked="#copyVersionToClipboard" styleClass="about-heading,font-size-250,text-accent" text="${controller.viewModel.heading}" wrapText="true">
                         <cursor>
                             <Cursor fx:constant="HAND"/>
                         </cursor>

--- a/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
@@ -24,7 +24,7 @@
             <AnchorPane>
                 <VBox alignment="CENTER_LEFT" spacing="1.0" styleClass="padding-bottom-16"
                       AnchorPane.leftAnchor="0" AnchorPane.topAnchor="0">
-                    <Label alignment="CENTER" contentDisplay="CENTER" onMouseClicked="#copyVersionToClipboard" styleClass="about-heading,font-size-250,text-accent" text="${controller.viewModel.heading}" wrapText="true">
+                    <Label alignment="CENTER" contentDisplay="CENTER" onMouseClicked="#copyVersionToClipboard" styleClass="h1,about-heading,text-accent" text="${controller.viewModel.heading}" wrapText="true">
                         <cursor>
                             <Cursor fx:constant="HAND"/>
                         </cursor>

--- a/jabgui/src/main/resources/org/jabref/gui/importer/ImportEntriesDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/importer/ImportEntriesDialog.fxml
@@ -40,7 +40,7 @@
                     <VBox fx:id="bibTeXDataBox" visible="false" managed="false">
                         <Label fx:id="bibTeXDataLabel"/>
                         <CodeArea fx:id="bibTeXData"
-                                styleClass="bibtex-code-area,font-size-090"
+                                styleClass="bibtex-code-area"
                                 editable="false"
                                 minHeight="30.0"
                                 prefHeight="200.0"

--- a/jabgui/src/main/resources/org/jabref/gui/mergeentries/multiwaymerge/MultiMergeEntries.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/mergeentries/multiwaymerge/MultiMergeEntries.fxml
@@ -16,7 +16,7 @@
             id="multiMergeEntries">
 
     <content>
-        <VBox styleClass="spacing-12">
+        <VBox spacing="12">
             <SplitPane dividerPositions="0.1, 0.6, 0.3" VBox.vgrow="ALWAYS">
                 <VBox>
                     <Region prefHeight="${topScrollPane.height}" VBox.vgrow="NEVER">
@@ -24,12 +24,12 @@
                         <maxHeight><Control fx:constant="USE_PREF_SIZE" /></maxHeight>
                    </Region>
                     <ScrollPane fx:id="leftScrollPane" hbarPolicy="NEVER" vbarPolicy="NEVER" VBox.vgrow="ALWAYS">
-                        <VBox fx:id="fieldHeader" styleClass="spacing-12"/>
+                        <VBox fx:id="fieldHeader" spacing="12"/>
                     </ScrollPane>
                 </VBox>
                 <VBox>
                     <ScrollPane fx:id="topScrollPane" hbarPolicy="NEVER" vbarPolicy="NEVER" VBox.vgrow="NEVER">
-                        <HBox fx:id="supplierHeader" styleClass="spacing-12"/>
+                        <HBox fx:id="supplierHeader" spacing="12"/>
                     </ScrollPane>
                     <ScrollPane fx:id="centerScrollPane" vbarPolicy="NEVER" VBox.vgrow="ALWAYS">
                         <GridPane fx:id="optionsGrid" styleClass="gap-12"/>
@@ -41,12 +41,12 @@
                         <maxHeight><Control fx:constant="USE_PREF_SIZE" /></maxHeight>
                    </Label>
                     <ScrollPane fx:id="rightScrollPane" hbarPolicy="NEVER" VBox.vgrow="ALWAYS" fitToWidth="true">
-                        <VBox fx:id="fieldEditor" styleClass="spacing-12"/>
+                        <VBox fx:id="fieldEditor" spacing="12"/>
                     </ScrollPane>
                 </VBox>
             </SplitPane>
             <Label fx:id="failedSuppliers"/>
-            <HBox styleClass="spacing-12">
+            <HBox spacing="12">
                 <Label text="%Show diff" prefHeight="${diffMode.height}"/>
                 <ComboBox fx:id="diffMode"/>
             </HBox>

--- a/jabgui/src/main/resources/org/jabref/gui/mergeentries/multiwaymerge/MultiMergeEntries.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/mergeentries/multiwaymerge/MultiMergeEntries.fxml
@@ -16,7 +16,7 @@
             id="multiMergeEntries">
 
     <content>
-        <VBox styleClass="spacing-10">
+        <VBox styleClass="spacing-12">
             <SplitPane dividerPositions="0.1, 0.6, 0.3" VBox.vgrow="ALWAYS">
                 <VBox>
                     <Region prefHeight="${topScrollPane.height}" VBox.vgrow="NEVER">
@@ -24,15 +24,15 @@
                         <maxHeight><Control fx:constant="USE_PREF_SIZE" /></maxHeight>
                    </Region>
                     <ScrollPane fx:id="leftScrollPane" hbarPolicy="NEVER" vbarPolicy="NEVER" VBox.vgrow="ALWAYS">
-                        <VBox fx:id="fieldHeader" styleClass="spacing-10"/>
+                        <VBox fx:id="fieldHeader" styleClass="spacing-12"/>
                     </ScrollPane>
                 </VBox>
                 <VBox>
                     <ScrollPane fx:id="topScrollPane" hbarPolicy="NEVER" vbarPolicy="NEVER" VBox.vgrow="NEVER">
-                        <HBox fx:id="supplierHeader" styleClass="spacing-10"/>
+                        <HBox fx:id="supplierHeader" styleClass="spacing-12"/>
                     </ScrollPane>
                     <ScrollPane fx:id="centerScrollPane" vbarPolicy="NEVER" VBox.vgrow="ALWAYS">
-                        <GridPane fx:id="optionsGrid" styleClass="gap-10"/>
+                        <GridPane fx:id="optionsGrid" styleClass="gap-12"/>
                     </ScrollPane>
                 </VBox>
                <VBox alignment="TOP_CENTER">
@@ -41,12 +41,12 @@
                         <maxHeight><Control fx:constant="USE_PREF_SIZE" /></maxHeight>
                    </Label>
                     <ScrollPane fx:id="rightScrollPane" hbarPolicy="NEVER" VBox.vgrow="ALWAYS" fitToWidth="true">
-                        <VBox fx:id="fieldEditor" styleClass="spacing-10"/>
+                        <VBox fx:id="fieldEditor" styleClass="spacing-12"/>
                     </ScrollPane>
                 </VBox>
             </SplitPane>
             <Label fx:id="failedSuppliers"/>
-            <HBox styleClass="spacing-10">
+            <HBox styleClass="spacing-12">
                 <Label text="%Show diff" prefHeight="${diffMode.height}"/>
                 <ComboBox fx:id="diffMode"/>
             </HBox>

--- a/jabgui/src/main/resources/org/jabref/gui/openoffice/StyleSelectDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/openoffice/StyleSelectDialog.fxml
@@ -115,7 +115,7 @@
                     <Insets left="10.0" right="10.0" bottom="10.0"/>
                 </padding>
                 <Label text="%Currently set style:"/>
-                <Label fx:id="currentStyleNameLabel" styleClass="currentStyleNameLabel,bold"/>
+                <Label fx:id="currentStyleNameLabel" styleClass="bold,text-accent"/>
             </HBox>
         </VBox>
     </content>

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/PreferencesDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/PreferencesDialog.fxml
@@ -75,7 +75,7 @@
                 </HBox>
             </VBox>
             <VBox>
-                <Label fx:id="tabTitle" styleClass="h3,padding-bottom-6">
+                <Label fx:id="tabTitle" styleClass="h3,padding-bottom-4">
                     <padding>
                         <Insets bottom="4.0" left="10.0" right="10.0" top="10.0"/>
                     </padding>

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/websearch/ApiKeyDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/websearch/ApiKeyDialog.fxml
@@ -20,7 +20,7 @@
             <HBox alignment="CENTER_LEFT" spacing="10">
                 <Label text="%API Key"/>
                 <TextField fx:id="apiKeyField" HBox.hgrow="ALWAYS"/>
-                <Button fx:id="testButton" onAction="#testApiKey" styleClass="padding-4-6" text="%Test connection"/>
+                <Button fx:id="testButton" onAction="#testApiKey" styleClass="padding-4" text="%Test connection"/>
             </HBox>
             <CheckBox fx:id="persistApiKeysCheckBox" text="%Save API key to use in future?">
                 <tooltip>

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -68,7 +68,6 @@
 .h6 { -fx-font-size: 1em; }
 
 /* Off-scale sizes: below h6 and above h1 */
-.font-size-090 { -fx-font-size: 0.9em; }
 .font-size-250 { -fx-font-size: 2.5em; }
 
 /* Font style */

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -54,14 +54,10 @@
  * default root font (9pt = 12px, see ThemeManager). The value itself is
  * written in `em`, so all spacing scales with the user's font size setting:
  *
- *     0 -> 0          8 -> 0.667em    20 -> 1.667em
- *     2 -> 0.167em   10 -> 0.833em    24 -> 2em
- *     4 -> 0.333em   12 -> 1em        32 -> 2.667em
- *     6 -> 0.5em     16 -> 1.333em
- *
- * Font sizes are ALWAYS relative (em) -- never px and never %. The one place
- * where `-fx-font-size` survives outside this block is on `.glyph-icon` /
- * `.ikonli-font-icon` selectors: for those the font size *is* the icon size.
+ *     0 -> 0          8 -> 0.667em    24 -> 2em
+ *     2 -> 0.167em   12 -> 1em
+ *     4 -> 0.333em   16 -> 1.333em
+ *     6 -> 0.5em
  * ========================================================================== */
 
 /* Type scale */
@@ -73,13 +69,11 @@
 .h6 { -fx-font-size: 1em; }
 
 /* Off-scale sizes: below h6 and above h1 */
-.font-size-075 { -fx-font-size: 0.75em; }
 .font-size-090 { -fx-font-size: 0.9em; }
 .font-size-250 { -fx-font-size: 2.5em; }
 
 /* Font style */
 .bold { -fx-font-weight: bold; }
-.normal-weight { -fx-font-weight: normal; }
 .italic { -fx-font-style: italic; }
 .font-monospace { -fx-font-family: monospace; }
 
@@ -93,88 +87,45 @@
 .text-warning { -fx-text-fill: -color-warning; -fx-fill: -color-warning; }
 .text-success { -fx-text-fill: -color-success; -fx-fill: -color-success; }
 
-/* Padding: all sides */
+/* Padding: all sides. The full scale, so any step can be picked without editing this file. */
 .padding-0 { -fx-padding: 0; }
 .padding-2 { -fx-padding: 0.167em; }
 .padding-4 { -fx-padding: 0.333em; }
 .padding-6 { -fx-padding: 0.5em; }
 .padding-8 { -fx-padding: 0.667em; }
-.padding-10 { -fx-padding: 0.833em; }
 .padding-12 { -fx-padding: 1em; }
 .padding-16 { -fx-padding: 1.333em; }
-.padding-20 { -fx-padding: 1.667em; }
 .padding-24 { -fx-padding: 2em; }
 .padding-32 { -fx-padding: 2.667em; }
 
-/* Padding: <vertical>-<horizontal> */
+/* Padding: <vertical>-<horizontal>. Added on demand -- only the pairs in use exist. */
 .padding-0-6 { -fx-padding: 0 0.5em; }
 .padding-0-12 { -fx-padding: 0 1em; }
-.padding-2-10 { -fx-padding: 0.167em 0.833em; }
 .padding-2-12 { -fx-padding: 0.167em 1em; }
-.padding-4-0 { -fx-padding: 0.333em 0; }
 .padding-4-6 { -fx-padding: 0.333em 0.5em; }
 .padding-4-8 { -fx-padding: 0.333em 0.667em; }
-.padding-4-10 { -fx-padding: 0.333em 0.833em; }
 .padding-4-12 { -fx-padding: 0.333em 1em; }
 .padding-6-0 { -fx-padding: 0.5em 0; }
-.padding-6-10 { -fx-padding: 0.5em 0.833em; }
 .padding-6-12 { -fx-padding: 0.5em 1em; }
 .padding-6-24 { -fx-padding: 0.5em 2em; }
-.padding-8-0 { -fx-padding: 0.667em 0; }
-.padding-8-10 { -fx-padding: 0.667em 0.833em; }
 .padding-8-12 { -fx-padding: 0.667em 1em; }
-.padding-8-16 { -fx-padding: 0.667em 1.333em; }
-.padding-10-12 { -fx-padding: 0.833em 1em; }
-.padding-10-16 { -fx-padding: 0.833em 1.333em; }
 .padding-12-16 { -fx-padding: 1em 1.333em; }
-.padding-16-24 { -fx-padding: 1.333em 2em; }
-.padding-20-24 { -fx-padding: 1.667em 2em; }
 .padding-32-24 { -fx-padding: 2.667em 2em; }
 
-/* Padding: single side */
-.padding-top-2 { -fx-padding: 0.167em 0 0 0; }
+/* Padding: single side. Added on demand -- only the steps in use exist. */
 .padding-top-4 { -fx-padding: 0.333em 0 0 0; }
 .padding-top-6 { -fx-padding: 0.5em 0 0 0; }
-.padding-top-8 { -fx-padding: 0.667em 0 0 0; }
-.padding-top-10 { -fx-padding: 0.833em 0 0 0; }
 .padding-top-12 { -fx-padding: 1em 0 0 0; }
-.padding-top-16 { -fx-padding: 1.333em 0 0 0; }
-.padding-top-20 { -fx-padding: 1.667em 0 0 0; }
-.padding-top-24 { -fx-padding: 2em 0 0 0; }
-.padding-top-32 { -fx-padding: 2.667em 0 0 0; }
 
-.padding-right-2 { -fx-padding: 0 0.167em 0 0; }
-.padding-right-4 { -fx-padding: 0 0.333em 0 0; }
 .padding-right-6 { -fx-padding: 0 0.5em 0 0; }
-.padding-right-8 { -fx-padding: 0 0.667em 0 0; }
-.padding-right-10 { -fx-padding: 0 0.833em 0 0; }
-.padding-right-12 { -fx-padding: 0 1em 0 0; }
 .padding-right-16 { -fx-padding: 0 1.333em 0 0; }
-.padding-right-20 { -fx-padding: 0 1.667em 0 0; }
-.padding-right-24 { -fx-padding: 0 2em 0 0; }
-.padding-right-32 { -fx-padding: 0 2.667em 0 0; }
 
-.padding-bottom-2 { -fx-padding: 0 0 0.167em 0; }
-.padding-bottom-4 { -fx-padding: 0 0 0.333em 0; }
 .padding-bottom-6 { -fx-padding: 0 0 0.5em 0; }
-.padding-bottom-8 { -fx-padding: 0 0 0.667em 0; }
-.padding-bottom-10 { -fx-padding: 0 0 0.833em 0; }
-.padding-bottom-12 { -fx-padding: 0 0 1em 0; }
 .padding-bottom-16 { -fx-padding: 0 0 1.333em 0; }
-.padding-bottom-20 { -fx-padding: 0 0 1.667em 0; }
 .padding-bottom-24 { -fx-padding: 0 0 2em 0; }
-.padding-bottom-32 { -fx-padding: 0 0 2.667em 0; }
 
-.padding-left-2 { -fx-padding: 0 0 0 0.167em; }
-.padding-left-4 { -fx-padding: 0 0 0 0.333em; }
-.padding-left-6 { -fx-padding: 0 0 0 0.5em; }
-.padding-left-8 { -fx-padding: 0 0 0 0.667em; }
-.padding-left-10 { -fx-padding: 0 0 0 0.833em; }
 .padding-left-12 { -fx-padding: 0 0 0 1em; }
-.padding-left-16 { -fx-padding: 0 0 0 1.333em; }
-.padding-left-20 { -fx-padding: 0 0 0 1.667em; }
 .padding-left-24 { -fx-padding: 0 0 0 2em; }
-.padding-left-32 { -fx-padding: 0 0 0 2.667em; }
 
 /* Spacing between the children of an HBox / VBox */
 .spacing-0 { -fx-spacing: 0; }
@@ -182,10 +133,8 @@
 .spacing-4 { -fx-spacing: 0.333em; }
 .spacing-6 { -fx-spacing: 0.5em; }
 .spacing-8 { -fx-spacing: 0.667em; }
-.spacing-10 { -fx-spacing: 0.833em; }
 .spacing-12 { -fx-spacing: 1em; }
 .spacing-16 { -fx-spacing: 1.333em; }
-.spacing-20 { -fx-spacing: 1.667em; }
 .spacing-24 { -fx-spacing: 2em; }
 .spacing-32 { -fx-spacing: 2.667em; }
 
@@ -193,10 +142,8 @@
 .gap-4 { -fx-hgap: 0.333em; -fx-vgap: 0.333em; }
 .gap-6 { -fx-hgap: 0.5em; -fx-vgap: 0.5em; }
 .gap-8 { -fx-hgap: 0.667em; -fx-vgap: 0.667em; }
-.gap-10 { -fx-hgap: 0.833em; -fx-vgap: 0.833em; }
 .gap-12 { -fx-hgap: 1em; -fx-vgap: 1em; }
 .gap-16 { -fx-hgap: 1.333em; -fx-vgap: 1.333em; }
-.gap-20 { -fx-hgap: 1.667em; -fx-vgap: 1.667em; }
 .gap-24 { -fx-hgap: 2em; -fx-vgap: 2em; }
 
 /* Alignment */
@@ -205,9 +152,7 @@
 .align-center-right { -fx-alignment: center-right; }
 .align-top-left { -fx-alignment: top-left; }
 .align-top-center { -fx-alignment: top-center; }
-.align-top-right { -fx-alignment: top-right; }
 .align-baseline-left { -fx-alignment: baseline-left; }
-.align-baseline-center { -fx-alignment: baseline-center; }
 
 /* Surface */
 .bg-transparent { -fx-background-color: transparent; }
@@ -257,18 +202,14 @@
     -fx-background-color: -color-warning;
 }
 
-.text-field:invalid {
+.text-field:invalid,
+.searchBar:invalid {
     -fx-background-color: -color-danger-subtle;
 }
 
 .menu-item .glyph-icon {
     -fx-fill: -color-fg-default;
     -fx-text-fill: -color-fg-default;
-}
-
-.menu-item:focused .glyph-icon {
-    -fx-fill: -color-fg-menu-active;
-    -fx-text-fill: -color-fg-menu-active;
 }
 
 .column-header .glyph-icon {
@@ -285,7 +226,8 @@
     -fx-text-fill: -fx-text-background-color;
 }
 
-.table-row-cell:dragOver-bottom {
+.table-row-cell:dragOver-bottom,
+#groupTree .tree-table-row-cell:dragOver-bottom {
     -fx-border-color: -color-drag-target;
     -fx-border-width: 0 0 2 0;
     -fx-padding: 0 0 -2 0;
@@ -296,7 +238,8 @@
     -fx-background-color: -color-drag-target-hover;
 }
 
-.table-row-cell:dragOver-top {
+.table-row-cell:dragOver-top,
+#groupTree .tree-table-row-cell:dragOver-top {
     -fx-border-color: -color-drag-target;
     -fx-border-width: 2 0 0 0;
     -fx-padding: -2 0 0 0;
@@ -586,10 +529,6 @@
     -fx-background-color: derive(-color-danger, 70%);
 }
 
-.mode-indicator {
-    -fx-text-fill: -color-fg-muted;
-}
-
 /* The little arrow that shows up when not all tool-bar icons fit into the tool-bar.
 We want to have a look that matches our icons in the tool-bar */
 .mainToolbar .tool-bar-overflow-button > .arrow {
@@ -606,8 +545,8 @@ We want to have a look that matches our icons in the tool-bar */
 }
 
 .mainToolbar .context-menu .glyph-icon:hover {
-    -fx-fill: -color-fg-menu-active;
-    -fx-text-fill: -color-fg-menu-active;
+    -fx-fill: -color-fg-default;
+    -fx-text-fill: -color-fg-default;
     -fx-background-color: -color-overlay-hover;
 }
 
@@ -696,10 +635,6 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-highlight-fill: derive(-color-accent-subtle, 20%);
 }
 
-.searchBar:invalid {
-    -fx-background-color: -color-danger-subtle;
-}
-
 .searchBar:unsupported {
     -fx-background-color: -color-warning-subtle;
 }
@@ -768,7 +703,8 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-fill: -color-fg-subtle;
 }
 
-.main-table .table-row-cell:dragOver-center {
+.main-table .table-row-cell:dragOver-center,
+#groupTree .tree-table-row-cell:dragOver-center {
     -fx-border-color: -color-drag-target;
     -fx-border-width: 1 1 1 1;
     -fx-padding: -1 -1 -1 -1;
@@ -782,10 +718,6 @@ We want to have a look that matches our icons in the tool-bar */
 }
 .main-table .table-row-cell:matching-search-and-groups:odd {
     -fx-background-color: -color-match-1-odd;
-}
-
-.main-table .table-row-cell:matching-search-and-groups:selected {
-    -fx-background-color: -color-selection;
 }
 
 .main-table .table-row-cell:matching-search-and-groups > .table-cell,
@@ -815,10 +747,6 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-background-color: -color-match-2-odd;
 }
 
-.main-table .table-row-cell:matching-search-not-groups:selected {
-    -fx-background-color: -color-selection;
-}
-
 .main-table .table-row-cell:matching-search-not-groups > .table-cell,
 .main-table .table-row-cell:matching-search-not-groups > .table-cell > .ikonli-font-icon {
     -fx-text-fill: -color-match-2-text-color;
@@ -844,10 +772,6 @@ We want to have a look that matches our icons in the tool-bar */
 
 .main-table .table-row-cell:matching-groups-not-search:odd {
     -fx-background-color: -color-match-3-odd;
-}
-
-.main-table .table-row-cell:matching-groups-not-search:selected {
-    -fx-background-color: -color-selection;
 }
 
 .main-table .table-row-cell:matching-groups-not-search > .table-cell,
@@ -877,10 +801,6 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-background-color: -color-match-4-odd;
 }
 
-.main-table .table-row-cell:not-matching-search-and-groups:selected {
-    -fx-background-color: -color-selection;
-}
-
 .main-table .table-row-cell:not-matching-search-and-groups > .table-cell,
 .main-table .table-row-cell:not-matching-search-and-groups > .table-cell > .ikonli-font-icon {
     -fx-text-fill: -color-match-4-text-color;
@@ -896,6 +816,14 @@ We want to have a look that matches our icons in the tool-bar */
 .main-table .table-row-cell:not-matching-search-and-groups:hover > .table-cell > .ikonli-font-icon,
 .main-table .table-row-cell:not-matching-search-and-groups:selected:focused:hover > .table-cell > .ikonli-font-icon {
     -fx-icon-color: derive(-color-match-4-text-color, 10%);
+}
+
+/* Selection and hover both win over every match state, so each is stated once for all four. */
+.main-table .table-row-cell:matching-search-and-groups:selected,
+.main-table .table-row-cell:matching-search-not-groups:selected,
+.main-table .table-row-cell:matching-groups-not-search:selected,
+.main-table .table-row-cell:not-matching-search-and-groups:selected {
+    -fx-background-color: -color-selection;
 }
 
 .main-table .table-row-cell:matching-search-and-groups:selected:hover,
@@ -931,7 +859,7 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-text-fill: -fx-text-inner-color;
 }
 
-.welcome-hyperlink,
+/* Undo the theme's dimmed ':visited' hyperlink color; the resting color already comes from '.hyperlink'. */
 .welcome-hyperlink:visited {
     -fx-text-fill: -color-accent;
 }
@@ -945,10 +873,6 @@ We want to have a look that matches our icons in the tool-bar */
 
 
 /* Welcome Community  */
-.welcome-community-link {
-    -fx-text-fill: -color-accent;
-}
-
 .welcome-community-link:hover {
     -fx-underline: true;
     -fx-text-fill: derive(-color-accent, -20%);
@@ -995,10 +919,6 @@ We want to have a look that matches our icons in the tool-bar */
 }
 
 /* AboutDialog */
-#aboutDialog .about-heading {
-    -fx-text-fill: -color-accent;
-}
-
 #aboutDialog .about-heading:pressed {
     -fx-text-fill: -color-selection;
 }
@@ -1120,10 +1040,6 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-text-fill: -color-fg-subtle;
 }
 
-#entryEditor .code-area .context-menu {
-    -fx-font-family: sans-serif;
-}
-
 #entryEditor #related-articles-tab,
 #entryEditor .ai-tab {
     -fx-background-color: -color-bg-secondary;
@@ -1144,10 +1060,6 @@ We want to have a look that matches our icons in the tool-bar */
 #entryEditor #scitePane Label,
 #entryEditor #scitePane Text {
     -fx-fill: -fx-text-background-color;
-}
-
-#entryEditor #scite-error-label {
-    -fx-text-fill: -color-danger;
 }
 
 /* ErrorConsole */
@@ -1228,7 +1140,8 @@ We want to have a look that matches our icons in the tool-bar */
 
 /* ParseLatexResult */
 
-#parseLatexResultDialog > .split-pane > .split-pane-divider {
+#parseLatexResultDialog > .split-pane > .split-pane-divider,
+#preferencesDialog > .split-pane > .split-pane-divider {
     -fx-padding: 0 4 0 4;
     -fx-background-color: transparent;
 }
@@ -1270,7 +1183,7 @@ We want to have a look that matches our icons in the tool-bar */
 }
 
 #groupTree .numberColumn > .hits .text {
-    -fx-fill: -color-badge-fg;
+    -fx-fill: -color-fg-emphasis;
 }
 
 #groupTree .expansionNodeColumn {
@@ -1282,35 +1195,12 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-alignment: center;
 }
 
-#groupTree .tree-table-row-cell:dragOver-bottom {
-    -fx-border-color: -color-drag-target;
-    -fx-border-width: 0 0 2 0;
-    -fx-padding: 0 0 -2 0;
-}
-
-#groupTree .tree-table-row-cell:dragOver-center {
-    -fx-border-color: -color-drag-target;
-    -fx-border-width: 1 1 1 1;
-    -fx-padding: -1 -1 -1 -1;
-    -fx-background-color: -color-drag-target-hover;
-}
-
-#groupTree .tree-table-row-cell:dragOver-top {
-    -fx-border-color: -color-drag-target;
-    -fx-border-width: 2 0 0 0;
-    -fx-padding: -2 0 0 0;
-}
-
 #groupTree .tree-table-row-cell:sub > .tree-table-cell {
     -fx-padding: 0.20em 0em 0.20em 0em;
 }
 
 #groupTree .tree-table-row-cell:sub > .numberColumn {
     -fx-padding: 0.20em 0.2em 0.20em 0em;
-}
-
-#groupTree .tree-table-row-cell:sub > .addSubgroupColumn {
-    -fx-padding: 0;
 }
 
 #groupTree .tree-table-row-cell:root {
@@ -1328,10 +1218,6 @@ We want to have a look that matches our icons in the tool-bar */
 
 #groupTree .tree-table-row-cell:root > .expansionNodeColumn {
     -fx-padding: 0.45em 0.2em 0.45em 0.2em;
-}
-
-#groupTree .tree-table-row-cell:root > .addSubgroupColumn {
-    -fx-padding: 0;
 }
 
 #groupTree .tree-table-row-cell:empty {
@@ -1397,11 +1283,6 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-border-color: -color-bg-primary;
 }
 
-#preferencesDialog > .split-pane > .split-pane-divider {
-    -fx-padding: 0 4 0 4;
-    -fx-background-color: transparent;
-}
-
 #preferencesDialog *:search-highlight {
     -fx-background-color: -color-danger;
 }
@@ -1462,27 +1343,15 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-text-fill: -color-fg-muted;
 }
 
-#testButton.success {
-    -fx-text-fill: -color-success;
-}
-
-#testButton.success .glyph-icon {
+#testButton.text-success .glyph-icon {
     -fx-icon-color: -color-success;
 }
 
-#testButton.error {
-    -fx-text-fill: -color-danger;
-}
-
-#testButton.error .glyph-icon {
+#testButton.text-danger .glyph-icon {
     -fx-icon-color: -color-danger;
 }
 
 /* CitationRelationsTab */
-
-.journalInfo .info-label {
-    -fx-text-fill: -color-accent;
-}
 
 .journalInfo .grid-cell-r {
     -fx-border-color: transparent -color-border-default transparent transparent;
@@ -1564,10 +1433,6 @@ We want to have a look that matches our icons in the tool-bar */
 
 .chatHistory {
     -fx-border-color: -color-border-default;
-}
-
-#styleSelectDialog .currentStyleNameLabel {
-    -fx-text-fill: -color-accent;
 }
 
 .exampleQuestionStyle {

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -213,20 +213,20 @@
     -fx-text-fill: -fx-text-background-color;
 }
 
-.table-row-cell:dragOver-bottom,
-#groupTree .tree-table-row-cell:dragOver-bottom {
+.table-row-cell:drag-over-bottom,
+#groupTree .tree-table-row-cell:drag-over-bottom {
     -fx-border-color: -color-drag-target;
     -fx-border-width: 0 0 2 0;
     -fx-padding: 0 0 -2 0;
 }
 
-.table-row-cell:dragOver-center,
-.table-row-cell:dragOver-center > .table-cell {
+.table-row-cell:drag-over-center,
+.table-row-cell:drag-over-center > .table-cell {
     -fx-background-color: -color-drag-target-hover;
 }
 
-.table-row-cell:dragOver-top,
-#groupTree .tree-table-row-cell:dragOver-top {
+.table-row-cell:drag-over-top,
+#groupTree .tree-table-row-cell:drag-over-top {
     -fx-border-color: -color-drag-target;
     -fx-border-width: 2 0 0 0;
     -fx-padding: -2 0 0 0;
@@ -690,8 +690,8 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-fill: -color-fg-subtle;
 }
 
-.main-table .table-row-cell:dragOver-center,
-#groupTree .tree-table-row-cell:dragOver-center {
+.main-table .table-row-cell:drag-over-center,
+#groupTree .tree-table-row-cell:drag-over-center {
     -fx-border-color: -color-drag-target;
     -fx-border-width: 1 1 1 1;
     -fx-padding: -1 -1 -1 -1;

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -45,7 +45,7 @@
 /* ==========================================================================
  * Generic utility classes
  * --------------------------------------------------------------------------
- * These are the only style classes that are allowed to declare spacing and
+ * These are the only style classes that are allowed to declare padding and
  * typography. Every other style class in this file describes what a component
  * *looks* like (fills, borders, radii, effects) and leaves how much room it
  * takes up to the utilities below, applied from FXML or Java.
@@ -110,12 +110,6 @@
 
 .padding-left-12 { -fx-padding: 0 0 0 1em; }
 .padding-left-24 { -fx-padding: 0 0 0 2em; }
-
-/* Spacing between the children of an HBox / VBox */
-.spacing-4 { -fx-spacing: 0.333em; }
-.spacing-8 { -fx-spacing: 0.667em; }
-.spacing-12 { -fx-spacing: 1em; }
-.spacing-16 { -fx-spacing: 1.333em; }
 
 /* Gap between the cells of a GridPane / FlowPane / TilePane */
 .gap-4 { -fx-hgap: 0.333em; -fx-vgap: 0.333em; }
@@ -1471,7 +1465,6 @@ We want to have a look that matches our icons in the tool-bar */
 
 .quick-settings-dialog-container > HBox {
     -fx-alignment: center-left;
-    -fx-spacing: 0.667em;
 }
 
 .quick-settings-dialog-container > ScrollPane {

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -54,10 +54,9 @@
  * default root font (9pt = 12px, see ThemeManager). The value itself is
  * written in `em`, so all spacing scales with the user's font size setting:
  *
- *     0 -> 0          8 -> 0.667em    24 -> 2em
- *     2 -> 0.167em   12 -> 1em
- *     4 -> 0.333em   16 -> 1.333em
- *     6 -> 0.5em
+ *     0 -> 0          12 -> 1em
+ *     4 -> 0.333em    16 -> 1.333em
+ *     8 -> 0.667em    24 -> 2em
  * ========================================================================== */
 
 /* Type scale */
@@ -87,40 +86,32 @@
 .text-warning { -fx-text-fill: -color-warning; -fx-fill: -color-warning; }
 .text-success { -fx-text-fill: -color-success; -fx-fill: -color-success; }
 
-/* Padding: all sides. The full scale, so any step can be picked without editing this file. */
+/* Padding: all sides */
 .padding-0 { -fx-padding: 0; }
-.padding-2 { -fx-padding: 0.167em; }
 .padding-4 { -fx-padding: 0.333em; }
-.padding-6 { -fx-padding: 0.5em; }
 .padding-8 { -fx-padding: 0.667em; }
 .padding-12 { -fx-padding: 1em; }
 .padding-16 { -fx-padding: 1.333em; }
 .padding-24 { -fx-padding: 2em; }
-.padding-32 { -fx-padding: 2.667em; }
 
 /* Padding: <vertical>-<horizontal>. Added on demand -- only the pairs in use exist. */
-.padding-0-6 { -fx-padding: 0 0.5em; }
+.padding-0-4 { -fx-padding: 0 0.333em; }
 .padding-0-12 { -fx-padding: 0 1em; }
-.padding-2-12 { -fx-padding: 0.167em 1em; }
-.padding-4-6 { -fx-padding: 0.333em 0.5em; }
+.padding-4-0 { -fx-padding: 0.333em 0; }
 .padding-4-8 { -fx-padding: 0.333em 0.667em; }
 .padding-4-12 { -fx-padding: 0.333em 1em; }
-.padding-6-0 { -fx-padding: 0.5em 0; }
-.padding-6-12 { -fx-padding: 0.5em 1em; }
-.padding-6-24 { -fx-padding: 0.5em 2em; }
+.padding-4-24 { -fx-padding: 0.333em 2em; }
 .padding-8-12 { -fx-padding: 0.667em 1em; }
 .padding-12-16 { -fx-padding: 1em 1.333em; }
-.padding-32-24 { -fx-padding: 2.667em 2em; }
 
 /* Padding: single side. Added on demand -- only the steps in use exist. */
 .padding-top-4 { -fx-padding: 0.333em 0 0 0; }
-.padding-top-6 { -fx-padding: 0.5em 0 0 0; }
 .padding-top-12 { -fx-padding: 1em 0 0 0; }
 
-.padding-right-6 { -fx-padding: 0 0.5em 0 0; }
+.padding-right-4 { -fx-padding: 0 0.333em 0 0; }
 .padding-right-16 { -fx-padding: 0 1.333em 0 0; }
 
-.padding-bottom-6 { -fx-padding: 0 0 0.5em 0; }
+.padding-bottom-4 { -fx-padding: 0 0 0.333em 0; }
 .padding-bottom-16 { -fx-padding: 0 0 1.333em 0; }
 .padding-bottom-24 { -fx-padding: 0 0 2em 0; }
 
@@ -129,18 +120,14 @@
 
 /* Spacing between the children of an HBox / VBox */
 .spacing-0 { -fx-spacing: 0; }
-.spacing-2 { -fx-spacing: 0.167em; }
 .spacing-4 { -fx-spacing: 0.333em; }
-.spacing-6 { -fx-spacing: 0.5em; }
 .spacing-8 { -fx-spacing: 0.667em; }
 .spacing-12 { -fx-spacing: 1em; }
 .spacing-16 { -fx-spacing: 1.333em; }
 .spacing-24 { -fx-spacing: 2em; }
-.spacing-32 { -fx-spacing: 2.667em; }
 
 /* Gap between the cells of a GridPane / FlowPane / TilePane */
 .gap-4 { -fx-hgap: 0.333em; -fx-vgap: 0.333em; }
-.gap-6 { -fx-hgap: 0.5em; -fx-vgap: 0.5em; }
 .gap-8 { -fx-hgap: 0.667em; -fx-vgap: 0.667em; }
 .gap-12 { -fx-hgap: 1em; -fx-vgap: 1em; }
 .gap-16 { -fx-hgap: 1.333em; -fx-vgap: 1.333em; }

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -67,9 +67,6 @@
 .h5 { -fx-font-size: 1.1em; }
 .h6 { -fx-font-size: 1em; }
 
-/* Off-scale sizes: below h6 and above h1 */
-.font-size-250 { -fx-font-size: 2.5em; }
-
 /* Font style */
 .bold { -fx-font-weight: bold; }
 .italic { -fx-font-style: italic; }
@@ -99,9 +96,6 @@
 .padding-4-0 { -fx-padding: 0.333em 0; }
 .padding-4-8 { -fx-padding: 0.333em 0.667em; }
 .padding-4-12 { -fx-padding: 0.333em 1em; }
-.padding-4-24 { -fx-padding: 0.333em 2em; }
-.padding-8-12 { -fx-padding: 0.667em 1em; }
-.padding-12-16 { -fx-padding: 1em 1.333em; }
 
 /* Padding: single side. Added on demand -- only the steps in use exist. */
 .padding-top-4 { -fx-padding: 0.333em 0 0 0; }
@@ -118,19 +112,16 @@
 .padding-left-24 { -fx-padding: 0 0 0 2em; }
 
 /* Spacing between the children of an HBox / VBox */
-.spacing-0 { -fx-spacing: 0; }
 .spacing-4 { -fx-spacing: 0.333em; }
 .spacing-8 { -fx-spacing: 0.667em; }
 .spacing-12 { -fx-spacing: 1em; }
 .spacing-16 { -fx-spacing: 1.333em; }
-.spacing-24 { -fx-spacing: 2em; }
 
 /* Gap between the cells of a GridPane / FlowPane / TilePane */
 .gap-4 { -fx-hgap: 0.333em; -fx-vgap: 0.333em; }
 .gap-8 { -fx-hgap: 0.667em; -fx-vgap: 0.667em; }
 .gap-12 { -fx-hgap: 1em; -fx-vgap: 1em; }
 .gap-16 { -fx-hgap: 1.333em; -fx-vgap: 1.333em; }
-.gap-24 { -fx-hgap: 2em; -fx-vgap: 2em; }
 
 /* Alignment */
 .align-center { -fx-alignment: center; }

--- a/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
@@ -27,7 +27,6 @@
         -color-fg-muted: #404040;
         -color-fg-subtle: #808080;
         -color-fg-emphasis: #FFFFFF;
-        -color-fg-menu-active: #000000;
 
         /* Borders */
         -color-border-default: #DDDDDD;
@@ -75,16 +74,13 @@
         -color-syntax-string: #008000;
         -color-syntax-comment: #008080;
         -color-syntax-punctuation: #808080;
-        -color-search-highlight-bg: #FFFF00;
-        -color-search-highlight-fg: #7800A9;
 
         /* Scrollbars */
         -color-scrollbar-thumb: #999999;
         -color-scrollbar-track: #FCFCFC;
 
-        /* Tooltips */
+        /* Tooltip background; the text uses -color-fg-default. */
         -color-tooltip-bg: #A3B7E6;
-        -color-tooltip-fg: #000000;
 
         /* Drag & drop targets */
         -color-drag-target: #A3B7E6;
@@ -92,7 +88,6 @@
 
         /* Group hit-count badge */
         -color-badge-bg: #6F6F6F;
-        -color-badge-fg: #FFFFFF;
         /* Text on the green badge of a group that contains selected entries */
         -color-badge-selected-fg: #000000;
 
@@ -121,7 +116,6 @@
         -color-fg-muted: #7D8591;
         -color-fg-subtle: #6B7280;
         -color-fg-emphasis: #E5E7EA;
-        -color-fg-menu-active: #EFF1F5;
 
         /* Borders */
         -color-border-default: #424758;
@@ -169,16 +163,13 @@
         -color-syntax-string: #7EE787;
         -color-syntax-comment: #6FD8D2;
         -color-syntax-punctuation: #8B949E;
-        -color-search-highlight-bg: #7A6A00;
-        -color-search-highlight-fg: #E9C7FF;
 
         /* Scrollbars */
         -color-scrollbar-thumb: #E5E7EA;
         -color-scrollbar-track: #040406;
 
-        /* Tooltips */
+        /* Tooltip background; the text uses -color-fg-default. */
         -color-tooltip-bg: #255652;
-        -color-tooltip-fg: #EFF1F5;
 
         /* Drag & drop targets */
         -color-drag-target: #255652;
@@ -186,7 +177,6 @@
 
         /* Group hit-count badge */
         -color-badge-bg: #151924;
-        -color-badge-fg: #E5E7EA;
         /* Text on the green badge of a group that contains selected entries */
         -color-badge-selected-fg: #000000;
 
@@ -411,7 +401,7 @@ TextFlow > .tooltip-text-monospaced {
     -fx-font-size: 1em;
     -fx-font-family: sans-serif;
     -fx-font-weight: normal;
-    -fx-text-fill: -color-tooltip-fg;
+    -fx-text-fill: -color-fg-default;
     -fx-show-delay: 300ms;
     -fx-hide-delay: 300ms;
 }
@@ -492,7 +482,7 @@ TextFlow > .tooltip-text-monospaced {
 .menu-bar > .container > .menu-button:hover > .label,
 .menu-bar > .container > .menu-button:focused > .label,
 .menu-bar > .container > .menu-button:showing > .label {
-    -fx-text-fill: -color-fg-menu-active;
+    -fx-text-fill: -color-fg-default;
 }
 
 .menu-item {
@@ -507,10 +497,6 @@ TextFlow > .tooltip-text-monospaced {
     -fx-text-fill: -color-border-default;
     -fx-background: -color-border-default;
     -fx-background-color: -fx-background;
-}
-
-.menu-item:focused > .label {
-    -fx-text-fill: -color-fg-menu-active;
 }
 
 .menu-button > .label {

--- a/jabgui/src/main/resources/org/jabref/gui/theme/primer-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/primer-theme.css
@@ -133,9 +133,6 @@
         -color-bg-sidepane: -color-bg-inset;
         -color-bg-alt: -color-bg-subtle;
 
-        /* Foreground (-color-fg-default/-muted/-subtle/-emphasis come from Primer) */
-        -color-fg-menu-active: -color-fg-default;
-
         /* Accent */
         -color-accent: -color-accent-emphasis;
 
@@ -170,16 +167,13 @@
         -color-syntax-string: -color-chart-3;
         -color-syntax-comment: -color-chart-4;
         -color-syntax-punctuation: -color-fg-subtle;
-        -color-search-highlight-bg: -color-warning-subtle;
-        -color-search-highlight-fg: -color-fg-default;
 
         /* Scrollbars */
         -color-scrollbar-thumb: -color-base-6;
         -color-scrollbar-track: -color-bg-subtle;
 
-        /* Tooltips */
+        /* Tooltip background; the text uses -color-fg-default. */
         -color-tooltip-bg: -color-bg-overlay;
-        -color-tooltip-fg: -color-fg-default;
 
         /* Drag & drop targets */
         -color-drag-target: -color-accent-emphasis;
@@ -187,7 +181,6 @@
 
         /* Group hit-count badge */
         -color-badge-bg: -color-neutral-emphasis;
-        -color-badge-fg: -color-fg-emphasis;
         /* Text on the green badge of a group that contains selected entries */
         -color-badge-selected-fg: #FFFFFF;
 
@@ -323,9 +316,6 @@
         -color-bg-sidepane: -color-bg-inset;
         -color-bg-alt: -color-bg-subtle;
 
-        /* Foreground (-color-fg-default/-muted/-subtle/-emphasis come from Primer) */
-        -color-fg-menu-active: -color-fg-default;
-
         /* Accent */
         -color-accent: -color-accent-emphasis;
 
@@ -360,16 +350,13 @@
         -color-syntax-string: -color-chart-3;
         -color-syntax-comment: -color-chart-4;
         -color-syntax-punctuation: -color-fg-subtle;
-        -color-search-highlight-bg: -color-warning-subtle;
-        -color-search-highlight-fg: -color-fg-default;
 
         /* Scrollbars */
         -color-scrollbar-thumb: -color-base-6;
         -color-scrollbar-track: -color-bg-subtle;
 
-        /* Tooltips */
+        /* Tooltip background; the text uses -color-fg-default. */
         -color-tooltip-bg: -color-bg-overlay;
-        -color-tooltip-fg: -color-fg-default;
 
         /* Drag & drop targets */
         -color-drag-target: -color-accent-emphasis;
@@ -377,7 +364,6 @@
 
         /* Group hit-count badge */
         -color-badge-bg: -color-neutral-emphasis;
-        -color-badge-fg: -color-fg-emphasis;
         /* Text on the green badge of a group that contains selected entries */
         -color-badge-selected-fg: #000000;
 

--- a/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/EntryTableConfigurationDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/EntryTableConfigurationDialog.fxml
@@ -10,7 +10,7 @@
 <DialogPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
             fx:controller="org.jabref.gui.welcome.quicksettings.EntryTableConfigurationDialog">
     <content>
-        <VBox styleClass="quick-settings-dialog-container,padding-16,spacing-16">
+        <VBox spacing="16" styleClass="quick-settings-dialog-container,padding-16">
             <HBox alignment="CENTER_LEFT" spacing="4">
                 <Label text="%Configure which columns are displayed in the entry table. The citation key column can be toggled to show or hide citation keys."
                        wrapText="true" HBox.hgrow="ALWAYS"/>

--- a/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/LargeLibraryOptimizationDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/LargeLibraryOptimizationDialog.fxml
@@ -10,14 +10,14 @@
 <DialogPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
             fx:controller="org.jabref.gui.welcome.quicksettings.LargeLibraryOptimizationDialog">
     <content>
-        <VBox styleClass="quick-settings-dialog-container,padding-16,spacing-16">
+        <VBox spacing="16" styleClass="quick-settings-dialog-container,padding-16">
             <HBox alignment="CENTER_LEFT" spacing="4">
                 <Label text="%Select features to disable. Disabling these features can significantly improve performance when working with large libraries."
                        wrapText="true" HBox.hgrow="ALWAYS"/>
                 <HelpButton fx:id="helpButton"/>
             </HBox>
 
-            <VBox styleClass="padding-left-12,spacing-16">
+            <VBox spacing="16" styleClass="padding-left-12">
                 <CheckBox fx:id="disableFulltextIndexing" text="%Fulltext indexing"
                           selected="true"/>
                 <CheckBox fx:id="disableCreationDate" text="%Creation date timestamps"

--- a/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/MainFileDirectoryDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/MainFileDirectoryDialog.fxml
@@ -13,7 +13,7 @@
 <DialogPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
             fx:controller="org.jabref.gui.welcome.quicksettings.MainFileDirectoryDialog">
     <content>
-        <VBox styleClass="quick-settings-dialog-container,padding-16,spacing-16">
+        <VBox spacing="16" styleClass="quick-settings-dialog-container,padding-16">
             <HBox alignment="CENTER_LEFT" spacing="4">
                 <Label text="%Set the default directory for storing attached files. Files will be stored relative to this directory unless specified otherwise."
                        wrapText="true" HBox.hgrow="ALWAYS"/>

--- a/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/OnlineServicesDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/OnlineServicesDialog.fxml
@@ -12,7 +12,7 @@
 <DialogPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
             fx:controller="org.jabref.gui.welcome.quicksettings.OnlineServicesDialog">
     <content>
-        <VBox styleClass="quick-settings-dialog-container,padding-16,spacing-16">
+        <VBox spacing="16" styleClass="quick-settings-dialog-container,padding-16">
             <HBox alignment="CENTER_LEFT" spacing="4">
                 <Label text="%Configure online catalogues and services for importing entries. Enable web search, update checking, and metadata extraction services."
                        wrapText="true" HBox.hgrow="ALWAYS"/>
@@ -39,7 +39,7 @@
 
             <ScrollPane fitToWidth="true" maxHeight="288"
                         hbarPolicy="NEVER">
-                <VBox fx:id="fetchersContainer" styleClass="padding-12,spacing-12"/>
+                <VBox fx:id="fetchersContainer" spacing="12" styleClass="padding-12"/>
             </ScrollPane>
         </VBox>
     </content>

--- a/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/PushApplicationDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/PushApplicationDialog.fxml
@@ -14,7 +14,7 @@
 <DialogPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
             fx:controller="org.jabref.gui.welcome.quicksettings.PushApplicationDialog">
     <content>
-        <VBox styleClass="quick-settings-dialog-container,padding-16,spacing-16">
+        <VBox spacing="16" styleClass="quick-settings-dialog-container,padding-16">
             <HBox alignment="CENTER_LEFT" spacing="4.0">
                 <Label text="%Configure external applications to push citations to. Detected applications are highlighted. Applications that are not detected can be set manually by specifying the path to the executable."
                        wrapText="true" HBox.hgrow="ALWAYS"/>

--- a/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/ThemeDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/ThemeDialog.fxml
@@ -17,7 +17,7 @@
 <DialogPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
             fx:controller="org.jabref.gui.welcome.quicksettings.ThemeDialog">
     <content>
-        <VBox styleClass="quick-settings-dialog-container,padding-16,spacing-16">
+        <VBox spacing="16" styleClass="quick-settings-dialog-container,padding-16">
             <Label text="%Choose between different themes, the color scheme or use a custom theme."
                    wrapText="true" HBox.hgrow="ALWAYS"/>
             <GridPane hgap="10.0" vgap="4.0">

--- a/jabgui/src/test/java/org/jabref/gui/theme/ThemeTokenContractTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/theme/ThemeTokenContractTest.java
@@ -30,11 +30,11 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 /// jabref-base.css styles JabRef's own controls exclusively through `-color-*` tokens that the
 /// active theme declares per color scheme. Two things have to hold for a theme to be swappable:
 ///
-/// 1. The base stylesheet must not declare colors of its own. It is installed last, so anything it
-///    declares would silently win over the theme.
+/// 1. The base stylesheet must not declare colors of its own.
+///    It is installed last, so anything it declares would silently win over the theme.
 /// 2. Every theme must declare every token that is used, otherwise JavaFX falls back to a default
-///    and the control silently loses its color. Those warnings are suppressed at runtime by
-///    [org.jabref.gui.logging.JavaFxCssLogFilter], so nothing else would report the gap.
+///    and the control silently loses its color.
+/// 3. Every token a theme declares must be read by someone.
 @AllowedToUseClassGetResource("JavaFX internally handles the passed URLs properly.")
 class ThemeTokenContractTest {
 
@@ -42,11 +42,11 @@ class ThemeTokenContractTest {
 
     private static final String BASE_CSS = "internal/jabref-base.css";
 
-    /// A `-color-…` token. The look-behind keeps `-fx-body-color-bottomup` from reading as a use of `-color-bottomup`.
+    /// A `-color-*` token.
     private static final Pattern TOKEN = Pattern.compile("(?<![A-Za-z0-9])(-color-[a-z0-9-]*[a-z0-9])");
     private static final Pattern COMMENT = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
 
-    /// Hex literals, `rgb()`/`rgba()` literals, and the CSS color keywords JabRef used to hardcode.
+    /// Hex literals, `rgb()`/`rgba()` literals, and the CSS color keywords JabRef should not hardcode.
     private static final Pattern LITERAL_COLOR = Pattern.compile(
             "#[0-9A-Fa-f]{3,8}\\b"
                     + "|rgba?\\(\\s*[0-9]"
@@ -56,11 +56,7 @@ class ThemeTokenContractTest {
     /// them. They follow whatever the theme sets, so they are not part of the contract.
     private static final Pattern DERIVED_IN_BASE = Pattern.compile("-color-(?:match|ai-message)-.*");
 
-    /// JavaFX's own color variables, as read on the value side of a declaration. Each of these is a
-    /// plain alias that the theme's `.root` assigns straight from a token, so reading the token
-    /// instead is equivalent -- and keeps the color visible where a theme author looks for it.
-    ///
-    /// [#LADDER_COLOR] is deliberately not part of this list.
+    /// JavaFX's own color variables, as read on the value side of a declaration.
     private static final Pattern JAVAFX_COLOR = Pattern.compile(
             "-fx-(?:base|background|color|accent|body-color|control-inner-background(?:-alt)?"
                     + "|(?:dark|mid|light)-text-color|focused-text-base-color"
@@ -71,23 +67,20 @@ class ThemeTokenContractTest {
 
     /// Modena computes these three with `ladder()`, picking light, dark or mid-text according to the
     /// brightness of `-fx-color`, `-fx-background` and `-fx-control-inner-background` respectively.
-    ///
-    /// They are welcome in JabRef's stylesheets. Every input to those ladders -- the three surfaces
-    /// and the three `-fx-*-text-color` outputs -- is something the theme sets from a token, so the
-    /// result is fully theme-controlled, exactly like the derived tokens above. Pinning them to a
-    /// single foreground would throw away the automatic light/dark flip that keeps text readable when
-    /// a control's surface changes underneath it (hover, pressed, selected).
     private static final Pattern LADDER_COLOR = Pattern.compile("-fx-text-(?:base|inner|background)-color(?![a-z0-9-])");
 
     /// The right-hand side of every `-property: value;` declaration.
     private static final Pattern DECLARATION = Pattern.compile("^\\s*-[a-z-]+\\s*:(.*)$", Pattern.MULTILINE);
+
+    /// Primer's raw color ramps -- `-color-base-0` - `-color-base-9`.
+    private static final Pattern PALETTE_RAMP = Pattern.compile("-color-(?:base|accent|success|warning|danger)-[0-9]|-color-(?:dark|light)");
 
     @BeforeEach
     void beforeEach() {
         CssParser.errorsProperty().clear();
     }
 
-    /// @return the body of `@media (prefers-color-scheme: <colorScheme>) { … }`, comments stripped
+    /// @return the body of `@media (prefers-color-scheme: <colorScheme>) { ... }`, comments stripped
     private static String colorSchemeBlock(String css, String colorScheme) {
         String content = withoutComments(read(css));
         String header = "@media (prefers-color-scheme: %s)".formatted(colorScheme);
@@ -186,6 +179,29 @@ class ThemeTokenContractTest {
         assertEquals(Set.of(), undeclared, "%s reads -color- tokens it never declares".formatted(themeCss));
     }
 
+    /// The other direction of [#themeDeclaresEveryTokenTheBaseStylesheetUses]: that test only looks at
+    /// tokens something already uses, so a token every theme declares but nobody reads is invisible to
+    /// it.
+    @ParameterizedTest
+    @EnumSource(ThemePreset.class)
+    void themeDeclaresNoTokenNobodyReads(ThemePreset theme) {
+        String themeCss = theme.getStyleSheet().getName();
+
+        Set<String> read = new TreeSet<>(tokens(BASE_CSS, Kind.USE));
+        read.addAll(tokens(ThemePreset.JABREF.getStyleSheet().getName(), Kind.USE));
+        read.addAll(tokens(themeCss, Kind.USE));
+
+        for (String colorScheme : List.of("light", "dark")) {
+            Set<String> unread = new TreeSet<>(tokensIn(colorSchemeBlock(themeCss, colorScheme), Kind.DECLARATION));
+            unread.removeAll(read);
+            unread.removeIf(token -> PALETTE_RAMP.matcher(token).matches());
+
+            assertEquals(Set.of(), unread,
+                    "%s declares -color- tokens for 'prefers-color-scheme: %s' that no stylesheet reads"
+                            .formatted(themeCss, colorScheme));
+        }
+    }
+
     @Test
     void baseStylesheetDeclaresNoThemeColors() {
         Set<String> declared = new TreeSet<>(tokens(BASE_CSS, Kind.DECLARATION));
@@ -211,9 +227,6 @@ class ThemeTokenContractTest {
                 "jabref-base.css should read the -color- token these JavaFX variables are aliases for");
     }
 
-    /// Guards the exception rather than just tolerating it: if these stop being ladders -- because a
-    /// theme pinned them in `.root`, say -- the reasoning in [#LADDER_COLOR] no longer holds and the
-    /// uses in jabref-base.css should be revisited.
     @ParameterizedTest
     @EnumSource(ThemePreset.class)
     void themeLeavesTheLadderColorsToModena(ThemePreset theme) {


### PR DESCRIPTION
### Summary

Further reduce the amount of special or even extra ordinary styles.

In short:
- Padding/Spacing is between 4 and 24. Nothing less (beside 0) or more
- Some colors were removed as they were only used once, replaced with proper alternatives
- Renamed `dragOver` to `drag-over`
- remove font-size-090.
  - I don't think we should render anything below the user font size. The user sets a font size, e.g. 14 in the settings and probably does not expect that anything is rendered below that.

### Steps to test

Run JabRef, check layout.

### Related issues and pull requests

Works towards https://github.com/JabRef/jabref/issues/16787

### AI usage

I let AI reviewing it.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
