### PR TITLE
Lint YAML in CI and remove duplicated keys

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,24 +9,6 @@
 # The component labels themselves are documented at
 # https://devdocs.jabref.org/architecture-and-components.html
 
-"dev: ci-cd":
-  - changed-files:
-      - any-glob-to-any-file:
-          - '.github/workflows/**'
-          - '.github/actions/**'
-          - '.github/labeler.yml'
-          - '.github/dependabot.yml'
-
-"dev: build-system":
-  - changed-files:
-      - any-glob-to-any-file:
-          - '**/*.gradle.kts'
-          - 'gradle/**'
-          - 'gradle.properties'
-          - 'gradlew*'
-          - 'build-logic/**'
-          - 'versions/**'
-
 "component: ai":
   - changed-files:
       - any-glob-to-any-file:
@@ -322,8 +304,9 @@
           - '**/*.gradle.kts'
           - 'build-logic/**'
           - 'gradle/**'
-          - 'gradlew'
-          - 'gradlew.bat'
+          - 'gradle.properties'
+          - 'gradlew*'
+          - 'versions/**'
 
 # Everything that drives CI/CD: workflow definitions, the composite actions they
 # call, and the files those workflows read directly. Listed one by one instead of

--- a/.github/workflows/on-pr-awaiting-second-review-check.yml
+++ b/.github/workflows/on-pr-awaiting-second-review-check.yml
@@ -92,4 +92,3 @@ jobs:
             if (approvers.length < 2) {
               core.setFailed(`PR #${pullNumber} has label "${requiredLabel}" but only ${approvers.length} approval(s). It will be removed from the merge queue.`);
             }
-    

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -31,20 +31,14 @@ jobs:
     if: ${{ github.repository == 'JabRef/jabref' }}
     # The label decision reads live review-thread state and writes it back minutes later, so two
     # runs for the same PR would race and the slower one would restore the state it started from.
+    # Same group as "Auto-remove ready-for-review", so a draft conversion cannot interleave with the
+    # label evaluation below (which re-reads isDraft right before writing the label).
     # The PR number is only known after the artifact is read, too late for a group expression -
-    # head repository plus head branch identifies the same pull request just as well.
+    # head repository plus head branch identifies the same pull request just as well, for fork PRs too.
     concurrency:
-      group: pr-comment-${{ github.event.workflow_run.head_repository.full_name || github.repository }}-${{ github.event.workflow_run.head_branch || github.event.inputs.pr_number }}
-      # The newest run has the freshest view; an interrupted run's work is redone by the one
-      # that replaced it.
-      cancel-in-progress: true
-    runs-on: ubuntu-slim
-    # Serialized with "Auto-remove ready-for-review" per PR, so a draft conversion cannot interleave
-    # with the label evaluation below (which re-reads isDraft right before writing the label).
-    # workflow_run payloads carry no PR number for fork PRs; those fall back to an unshared group.
-    concurrency:
-      group: pr-status-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
+      group: pr-status-${{ github.event.workflow_run.head_repository.full_name || github.repository }}-${{ github.event.workflow_run.head_branch || github.event.inputs.pr_number }}
       cancel-in-progress: false
+    runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/remove-ready-for-review.yml
+++ b/.github/workflows/remove-ready-for-review.yml
@@ -7,15 +7,14 @@ on:
 jobs:
   # A draft is not reviewable; the label is re-added by "Comment on PR" once the PR is ready again
   # (the label workflows only listen to "labeled", so removing it here triggers nothing further).
-  # Race with "Comment on PR": it re-reads isDraft immediately before writing the label, so the
-  # remaining window is one API round-trip. A shared per-PR concurrency group cannot close it -
-  # that job runs on workflow_run, where the PR number is only known after a step has run.
+  # Shares a concurrency group with the label evaluation in "Comment on PR", keyed by head
+  # repository and branch because that job runs on workflow_run, where the PR number is only known
+  # after a step has run.
   remove-label-on-draft:
     runs-on: ubuntu-slim
     if: github.event.action == 'converted_to_draft'
-    # Same group as the label evaluation in "Comment on PR": the removal must not interleave with it.
     concurrency:
-      group: pr-status-${{ github.event.pull_request.number }}
+      group: pr-status-${{ github.event.pull_request.head.repo.full_name }}-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: false
     permissions:
       pull-requests: write

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -239,6 +239,18 @@ jobs:
             *.md
             docs/**/*.md
 
+  yaml:
+    name: YAML
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          submodules: 'false'
+          show-progress: 'false'
+      - name: yamllint
+        run: pipx run yamllint==1.38.0 --strict .
+
   textlint:
     name: Textlint
     runs-on: ubuntu-slim

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,16 @@
+# Catches what a merge or a hand edit silently breaks: duplicate keys, invalid
+# syntax, trailing whitespace. Style rules stay off so existing files keep
+# their formatting.
+extends: relaxed
+
+rules:
+  line-length: disable
+  colons: disable
+
+ignore:
+  # Git submodules with their own upstream
+  - jablib/src/main/resources/csl-locales/
+  - jablib/src/main/resources/csl-styles/
+  - jablib/src/main/resources/ltwa/
+  # Test fixtures, some with deliberate CRLF line endings
+  - jablib/src/test/resources/


### PR DESCRIPTION
<!-- policy --> jabref-contrib-policy:4.2:reviewed​:ok

### 🤖 PR Description

Since today the "Pull Request Labeler" workflow fails on every pull request with `duplicated mapping key`, and GitHub refuses to run "Comment on PR" at all: in both files two PRs merged the same day each added the same key at different positions, so git merged them without a conflict. This removes both duplicates and adds a yamllint job to the source code tests so a duplicate key, broken syntax, or trailing whitespace in any YAML file fails CI from now on.

Closes NA

### Analogies

Like honey, this PR is sticky: it glues two halves back into one. Like chocolate, it is small and does the job. Like the moon, it only shows one face per label again.

### AI usage

Written with Claude Code; the config was verified by parsing it with js-yaml (the parser actions/labeler uses), which rejects the current `main` and accepts this branch.

### Steps to test

1. Open any PR after this is merged; "Label PR by changed files" and "Comment on PR" run green.
2. Change a `.gradle.kts` or `.github/**` file in a PR; the `dev: build-system` / `dev: ci-cd` label is applied.
3. Duplicate a key in any YAML file in a PR; the "YAML" job fails.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I have read the [contribution policy](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md) and the [CHECKLIST.md](https://github.com/JabRef/jabref/blob/main/CHECKLIST.md)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the average user) — not applicable, CI-only
- [x] Tests created for changes (if applicable) — not applicable, YAML config
- [x] Manually tested changed features in running JabRef (always required) — not applicable, CI-only
- [x] Screenshots added in PR description (if change is visible to the average user) — not applicable
- [x] Checked developer's documentation: Is the information available and up to date? If not, I outlined it in this pull request.
- [x] Checked documentation: Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CL9Fsi6kWV2LcmkAdA4VPY
