### PR TITLE
Reduce very big paddings and spacing, make the entry editor spacing more consistent across tabs

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
@@ -83,8 +83,7 @@ public final class GroupChangeDetailsView extends DatabaseChangeDetailsView {
         Label legendLabel = new Label(Localization.lang("Red: Removed, Blue: Changed, Green: Added"));
         legendLabel.getStyleClass().addAll(StyleClasses.CHANGE_VIEW_LEGEND);
 
-        VBox resultContainer = new VBox(splitPane, legendLabel);
-        resultContainer.setSpacing(5);
+        VBox resultContainer = new VBox(4, splitPane, legendLabel);
         VBox.setVgrow(splitPane, Priority.ALWAYS);
 
         return new SplitPane(resultContainer);

--- a/jabgui/src/main/java/org/jabref/gui/collab/metedatachange/MetadataChangeDetailsView.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/metedatachange/MetadataChangeDetailsView.java
@@ -23,7 +23,7 @@ public final class MetadataChangeDetailsView extends DatabaseChangeDetailsView {
                                      String leftLabelText,
                                      String rightLabelText,
                                      DiffHighlighter.BasicDiffMethod diffMethod) {
-        VBox container = new VBox(15);
+        VBox container = new VBox(12);
 
         Label header = new Label(Localization.lang("The following metadata changed:"));
         header.getStyleClass().addAll(StyleClasses.SECTION_HEADER);

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
@@ -132,8 +132,8 @@ public class LatexCitationsTab extends EntryEditorTab {
         Text notFoundText = new Text(Localization.lang("No LaTeX files containing this entry were found."));
         notFoundText.getStyleClass().add("italic");
 
-        VBox notFoundBox = new VBox(24, titleLabel, notFoundText);
-        notFoundBox.getStyleClass().add("padding-24");
+        VBox notFoundBox = new VBox(4, titleLabel, notFoundText);
+        notFoundBox.getStyleClass().add("padding-4");
         return notFoundBox;
     }
 
@@ -142,8 +142,8 @@ public class LatexCitationsTab extends EntryEditorTab {
         titleLabel.getStyleClass().addAll("text-danger", "h3", "bold");
         Text errorMessageText = new Text();
         errorMessageText.textProperty().bind(viewModel.searchErrorProperty());
-        VBox errorMessageBox = new VBox(24, titleLabel, errorMessageText);
-        errorMessageBox.getStyleClass().add("padding-24");
+        VBox errorMessageBox = new VBox(4, titleLabel, errorMessageText);
+        errorMessageBox.getStyleClass().add("padding-4");
         return errorMessageBox;
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
@@ -119,7 +119,7 @@ public class LatexCitationsTab extends EntryEditorTab {
     }
 
     private VBox getCitationsPane() {
-        VBox citationsBox = new VBox(24, citationsDisplay);
+        VBox citationsBox = new VBox(12, citationsDisplay);
         VBox.setVgrow(citationsDisplay, Priority.ALWAYS);
         citationsBox.getStyleClass().add("padding-0");
         return citationsBox;

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
@@ -112,8 +112,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
     private ScrollPane getRelatedArticleInfo(List<BibEntry> list, MrDLibFetcher fetcher) {
         ScrollPane scrollPane = new ScrollPane();
 
-        VBox vBox = new VBox();
-        vBox.setSpacing(4);
+        VBox vBox = new VBox(4);
 
         String heading = fetcher.getHeading();
         Text headingText = new Text(heading);
@@ -125,9 +124,8 @@ public class RelatedArticlesTab extends EntryEditorTab {
         vBox.getChildren().add(descriptionText);
 
         for (BibEntry entry : list) {
-            HBox hBox = new HBox();
-            hBox.setSpacing(4);
-            hBox.getStyleClass().add("padding-left-16");
+            HBox hBox = new HBox(4);
+            hBox.getStyleClass().add("padding-left-12");
 
             String title = entry.getTitle().orElse("");
             String journal = entry.getField(StandardField.JOURNAL).orElse("");

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
@@ -72,7 +72,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
     private StackPane getRelatedArticlesPane(BibEntry entry) {
         StackPane root = new StackPane();
         root.setId("related-articles-tab");
-        root.getStyleClass().add("padding-24");
+        root.getStyleClass().add("padding-4");
         ProgressIndicator progress = new ProgressIndicator();
         progress.setMaxSize(100, 100);
 
@@ -113,7 +113,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
         ScrollPane scrollPane = new ScrollPane();
 
         VBox vBox = new VBox();
-        vBox.setSpacing(20.0);
+        vBox.setSpacing(4);
 
         String heading = fetcher.getHeading();
         Text headingText = new Text(heading);
@@ -126,8 +126,8 @@ public class RelatedArticlesTab extends EntryEditorTab {
 
         for (BibEntry entry : list) {
             HBox hBox = new HBox();
-            hBox.setSpacing(5.0);
-            hBox.getStyleClass().add("padding-left-24");
+            hBox.setSpacing(4);
+            hBox.getStyleClass().add("padding-left-16");
 
             String title = entry.getTitle().orElse("");
             String journal = entry.getField(StandardField.JOURNAL).orElse("");
@@ -163,8 +163,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
     private ScrollPane getErrorInfo() {
         ScrollPane scrollPane = new ScrollPane();
 
-        VBox vBox = new VBox();
-        vBox.setSpacing(20.0);
+        VBox vBox = new VBox(16);
 
         Text descriptionText = new Text(Localization.lang("No recommendations received from Mr. DLib for this entry."));
         descriptionText.getStyleClass().add("italic");
@@ -181,13 +180,11 @@ public class RelatedArticlesTab extends EntryEditorTab {
     private ScrollPane getPrivacyDialog(BibEntry entry) {
         ScrollPane root = new ScrollPane();
         root.setId("related-articles-tab");
-        root.getStyleClass().add("padding-24");
-        VBox vbox = new VBox();
-        vbox.getStyleClass().addAll("gdpr-notice", "h4", "padding-12");
-        vbox.setSpacing(20.0);
+        root.getStyleClass().add("padding-4");
+        VBox vbox = new VBox(4);
+        vbox.getStyleClass().addAll("gdpr-notice", "h4", "padding-4");
 
-        HBox hbox = new HBox();
-        hbox.setSpacing(10.0);
+        HBox hbox = new HBox(4);
 
         Text title = new Text(Localization.lang("Mr. DLib Privacy settings"));
         title.getStyleClass().addAll("h3", "bold");
@@ -214,7 +211,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
                 dialogService.showErrorDialogAndWait(e);
             }
         });
-        VBox vb = new VBox();
+        VBox vb = new VBox(4);
         CheckBox cbTitle = new CheckBox(Localization.lang("Entry Title (Required to deliver recommendations.)"));
         cbTitle.setSelected(true);
         cbTitle.setDisable(true);
@@ -225,7 +222,6 @@ public class RelatedArticlesTab extends EntryEditorTab {
         CheckBox cbOS = new CheckBox(Localization.lang("Operating System (Provides for better recommendations by giving an indication of user's system set-up.)"));
         CheckBox cbTimezone = new CheckBox(Localization.lang("Timezone (Provides for better recommendations by indicating the time of day the request is being made.)"));
         vb.getChildren().addAll(cbTitle, cbVersion, cbLanguage, cbOS, cbTimezone);
-        vb.setSpacing(10);
 
         button.setOnAction(_ -> {
             MrDlibPreferences mrDlibPreferences = preferences.getMrDlibPreferences();

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/BibEntryView.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/BibEntryView.java
@@ -42,8 +42,8 @@ public class BibEntryView {
         journal.getStyleClass().add("h6");
 
         VBox entryContainer = new VBox(
-                new HBox(10, entryType, title),
-                new HBox(5, year, journal),
+                new HBox(4, entryType, title),
+                new HBox(4, year, journal),
                 authors
         );
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -310,8 +310,8 @@ public class CitationRelationsTab extends EntryEditorTab {
         Label titleLabel = new Label(Localization.lang("Error"));
         titleLabel.getStyleClass().addAll("h3", "bold", "text-danger");
         Text errorMessageText = new Text(citationsRelationsTabViewModel.searchErrorProperty().get());
-        VBox errorMessageBox = new VBox(24, titleLabel, errorMessageText);
-        errorMessageBox.getStyleClass().add("padding-24");
+        VBox errorMessageBox = new VBox(4, titleLabel, errorMessageText);
+        errorMessageBox.getStyleClass().add("padding-4");
         return errorMessageBox;
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/FileSelectionPage.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/FileSelectionPage.java
@@ -12,7 +12,6 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
-import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/FileSelectionPage.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/FileSelectionPage.java
@@ -126,8 +126,8 @@ public class FileSelectionPage extends WizardPane {
     private void setupUI() {
         BorderPane mainLayout = new BorderPane();
 
-        progressPane = new VBox(10);
-        progressPane.getStyleClass().addAll("align-center", "padding-24");
+        progressPane = new VBox(4);
+        progressPane.getStyleClass().addAll("align-center", "padding-4");
 
         ProgressIndicator progressIndicator = new ProgressIndicator();
         progressIndicator.progressProperty().bind(viewModel.progressValueProperty());
@@ -137,7 +137,7 @@ public class FileSelectionPage extends WizardPane {
 
         progressPane.getChildren().addAll(progressIndicator, progressLabel);
 
-        contentPane = new VBox(10);
+        contentPane = new VBox(4);
 
         fileCountLabel = new Label();
         fileCountLabel.getStyleClass().add("bold");
@@ -170,11 +170,11 @@ public class FileSelectionPage extends WizardPane {
         closePreviewButton.setTooltip(new Tooltip(Localization.lang("Close PDF preview")));
         closePreviewButton.setOnAction(_ -> hidePreviewPane());
 
-        HBox previewControls = new HBox(8, enablePreviewCheckBox, closePreviewButton);
+        HBox previewControls = new HBox(4, enablePreviewCheckBox, closePreviewButton);
         HBox.setHgrow(enablePreviewCheckBox, Priority.ALWAYS);
 
-        VBox previewContent = new VBox(8, previewControls, pdfPreview, metadataLabel, metadataPreview);
-        previewContent.setPadding(new Insets(8));
+        VBox previewContent = new VBox(4, previewControls, pdfPreview, metadataLabel, metadataPreview);
+        previewContent.getStyleClass().add("padding-4");
         previewPane = new TitledPane(Localization.lang("PDF preview"), previewContent);
         previewPane.setExpanded(true);
         previewPane.setCollapsible(false);
@@ -183,7 +183,7 @@ public class FileSelectionPage extends WizardPane {
         splitPane.setDividerPositions(0.58);
         VBox.setVgrow(splitPane, Priority.ALWAYS);
 
-        HBox buttonBar = new HBox(5);
+        HBox buttonBar = new HBox(4);
         selectAllButton = new Button(Localization.lang("Select all"));
         selectAllButton.setOnAction(e -> unlinkedFilesList.getCheckModel().checkAll());
 

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/ImportResultsPage.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/ImportResultsPage.java
@@ -51,9 +51,9 @@ public class ImportResultsPage extends WizardPane {
         mainLayout.setMaxWidth(Double.MAX_VALUE);
         mainLayout.setMaxHeight(Double.MAX_VALUE);
 
-        /// Progress pane
-        progressPane = new VBox(10);
-        progressPane.getStyleClass().addAll("align-center", "padding-24");
+        // Progress pane
+        progressPane = new VBox(4);
+        progressPane.getStyleClass().addAll("align-center", "padding-4");
         progressPane.setMaxWidth(Double.MAX_VALUE);
         progressPane.setMaxHeight(Double.MAX_VALUE);
 
@@ -65,8 +65,8 @@ public class ImportResultsPage extends WizardPane {
 
         progressPane.getChildren().addAll(progressIndicator, progressLabel);
 
-        /// Content pane with proper sizing
-        contentPane = new VBox(10);
+        // Content pane with proper sizing
+        contentPane = new VBox(4);
         contentPane.setMaxWidth(Double.MAX_VALUE);
         contentPane.setMaxHeight(Double.MAX_VALUE);
         contentPane.setFillWidth(true);
@@ -75,7 +75,7 @@ public class ImportResultsPage extends WizardPane {
         summaryLabel = new Label();
         summaryLabel.getStyleClass().add("bold");
 
-        /// TableView with explicit size constraints
+        // TableView with explicit size constraints
         resultsTable = new TableView<>();
         resultsTable.setItems(viewModel.resultTableItems());
         resultsTable.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/SearchConfigurationPage.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/SearchConfigurationPage.java
@@ -67,17 +67,15 @@ public class SearchConfigurationPage extends WizardPane {
     private void setupUI(BibDatabaseContext bibDatabaseContext, GuiPreferences preferences) {
         VBox wrapper = new VBox();
         wrapper.setFillWidth(true);
-        wrapper.setPadding(new Insets(10));
+        wrapper.setPadding(new Insets(8));
         wrapper.setMaxWidth(Double.MAX_VALUE);
         wrapper.setMaxHeight(Double.MAX_VALUE);
 
-        GridPane grid = new GridPane();
-        grid.setHgap(10);
-        grid.setVgap(10);
+        GridPane grid = new GridPane(8, 8);
         grid.setMaxWidth(Double.MAX_VALUE);
         VBox.setVgrow(grid, Priority.ALWAYS);
 
-        /// Column Constraints for proper alignment and resizing
+        // Column Constraints for proper alignment and resizing
         ColumnConstraints labelColumn = new ColumnConstraints();
         labelColumn.setHgrow(Priority.NEVER);
         labelColumn.setMinWidth(100);
@@ -92,11 +90,11 @@ public class SearchConfigurationPage extends WizardPane {
 
         int row = 0;
 
-        ///Directory selection
+        // Directory selection
         Label dirLabel = new Label(Localization.lang("Directory"));
         grid.add(dirLabel, 0, row);
 
-        HBox directoryBox = new HBox(5);
+        HBox directoryBox = new HBox(4);
         directoryBox.setAlignment(Pos.CENTER_LEFT);
         directoryBox.setMaxWidth(Double.MAX_VALUE);
         HBox.setHgrow(directoryBox, Priority.ALWAYS);

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -311,7 +311,7 @@ public class LinkedFilesEditor extends VBox implements FieldEditorFX {
         });
         parsePdfMetadata.getStyleClass().setAll("icon-button");
 
-        HBox container = new HBox(2);
+        HBox container = new HBox(4);
         container.setPrefHeight(Double.NEGATIVE_INFINITY);
         container.getChildren().addAll(acceptAutoLinkedFile, info, writeMetadataToPdf, parsePdfMetadata);
 
@@ -456,4 +456,3 @@ public class LinkedFilesEditor extends VBox implements FieldEditorFX {
         return 3;
     }
 }
-

--- a/jabgui/src/main/java/org/jabref/gui/git/GitEntryChangeDetailsView.java
+++ b/jabgui/src/main/java/org/jabref/gui/git/GitEntryChangeDetailsView.java
@@ -52,8 +52,7 @@ public final class GitEntryChangeDetailsView extends AnchorPane {
         Label legendLabel = new Label(Localization.lang("Red: Removed, Blue: Changed, Green: Added"));
         legendLabel.getStyleClass().addAll(StyleClasses.CHANGE_VIEW_LEGEND);
 
-        VBox resultContainer = new VBox(splitPane, legendLabel);
-        resultContainer.setSpacing(5);
+        VBox resultContainer = new VBox(4, splitPane, legendLabel);
         setAllAnchorsAndAttachChild(resultContainer);
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -208,10 +208,10 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
         Label noContentLabel = new Label(Localization.lang("No content in table"));
         noContentLabel.getStyleClass().addAll(StyleClasses.WELCOME_HEADER);
 
-        HBox buttonBox = new HBox(20, addExampleButton, importPdfsButton);
+        HBox buttonBox = new HBox(12, addExampleButton, importPdfsButton);
         buttonBox.setAlignment(Pos.CENTER);
 
-        VBox placeholderBox = new VBox(15, noContentLabel, buttonBox);
+        VBox placeholderBox = new VBox(12, noContentLabel, buttonBox);
         placeholderBox.setAlignment(Pos.CENTER);
 
         VBox loadingPlaceholder = new VBox(new ProgressIndicator(ProgressIndicator.INDETERMINATE_PROGRESS));

--- a/jabgui/src/main/java/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTab.java
@@ -43,7 +43,7 @@ public class CitationKeyPatternTab extends AbstractPreferenceTabView<CitationKey
                         .checkbox(Localization.lang("Overwrite existing keys"), viewModel.overwriteAllowProperty())
                         .checkbox(Localization.lang("Warn before overwriting existing keys"), viewModel.overwriteWarningProperty(),
                                 warn -> warn.disableWhen(viewModel.overwriteAllowProperty().not())
-                                            .styleClass("padding-left-16"))
+                                            .styleClass("padding-left-12"))
                         .checkbox(Localization.lang("Generate keys before saving (only for entries without a key)"), viewModel.generateOnSaveProperty())
                         .checkbox(Localization.lang("Generate new keys for imported entries (overwriting their default)"), viewModel.generateKeyOnImportProperty())
 
@@ -53,7 +53,7 @@ public class CitationKeyPatternTab extends AbstractPreferenceTabView<CitationKey
                                                 .radio(Localization.lang("Start on second duplicate key with letter A (a, b, ...)"), viewModel.letterStartAProperty())
                                                 .radio(Localization.lang("Start on second duplicate key with letter B (b, c, ...)"), viewModel.letterStartBProperty())
                                                 .radio(Localization.lang("Always add letter (a, b, ...) to generated keys"), viewModel.letterAlwaysAddProperty())),
-                                indent -> indent.styleClass("padding-left-16"))
+                                indent -> indent.styleClass("padding-left-12"))
 
                         // `[regex] by [replacement]` — one labelled field, so the two stay adjacent.
                         .stringField(Localization.lang("Replace (regular expression)"), viewModel.keyPatternRegexProperty(),

--- a/jabgui/src/main/java/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTab.java
@@ -43,7 +43,7 @@ public class CitationKeyPatternTab extends AbstractPreferenceTabView<CitationKey
                         .checkbox(Localization.lang("Overwrite existing keys"), viewModel.overwriteAllowProperty())
                         .checkbox(Localization.lang("Warn before overwriting existing keys"), viewModel.overwriteWarningProperty(),
                                 warn -> warn.disableWhen(viewModel.overwriteAllowProperty().not())
-                                            .styleClass("padding-left-24"))
+                                            .styleClass("padding-left-16"))
                         .checkbox(Localization.lang("Generate keys before saving (only for entries without a key)"), viewModel.generateOnSaveProperty())
                         .checkbox(Localization.lang("Generate new keys for imported entries (overwriting their default)"), viewModel.generateKeyOnImportProperty())
 
@@ -53,7 +53,7 @@ public class CitationKeyPatternTab extends AbstractPreferenceTabView<CitationKey
                                                 .radio(Localization.lang("Start on second duplicate key with letter A (a, b, ...)"), viewModel.letterStartAProperty())
                                                 .radio(Localization.lang("Start on second duplicate key with letter B (b, c, ...)"), viewModel.letterStartBProperty())
                                                 .radio(Localization.lang("Always add letter (a, b, ...) to generated keys"), viewModel.letterAlwaysAddProperty())),
-                                indent -> indent.styleClass("padding-left-24"))
+                                indent -> indent.styleClass("padding-left-16"))
 
                         // `[regex] by [replacement]` — one labelled field, so the two stay adjacent.
                         .stringField(Localization.lang("Replace (regular expression)"), viewModel.keyPatternRegexProperty(),

--- a/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
@@ -158,7 +158,7 @@ public class CustomEntryTypesTab extends AbstractPreferenceTabView<CustomEntryTy
 
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
-        HBox bottomRow = new HBox(GAP, new VBox(5.0, addFieldRow), spacer, resetButton);
+        HBox bottomRow = new HBox(GAP, new VBox(4, addFieldRow), spacer, resetButton);
         bottomRow.setAlignment(Pos.BASELINE_LEFT);
 
         VBox column = new VBox(GAP, header, fields, bottomRow);

--- a/jabgui/src/main/java/org/jabref/gui/preferences/forms/FormMetrics.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/forms/FormMetrics.java
@@ -9,7 +9,7 @@ import org.jspecify.annotations.NullMarked;
 public final class FormMetrics {
 
     /// Gap between elements, both between rows and between an element and what is attached to it.
-    public static final double GAP = 10.0;
+    public static final double GAP = 8.0;
 
     /// Width of a labelled button in a button row, so that the buttons in one row are uniform.
     public static final double BUTTON_WIDTH = 100.0;

--- a/jabgui/src/main/java/org/jabref/gui/preferences/table/TableTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/table/TableTab.java
@@ -63,7 +63,7 @@ public class TableTab extends AbstractPreferenceTabView<TableTabViewModel> {
                                                                 .radio(Localization.lang("Show names unchanged"), viewModel.nameAsIsProperty())
                                                                 .radio(Localization.lang("Show 'Firstname Lastname'"), viewModel.nameFirstLastProperty())
                                                                 .radio(Localization.lang("Show 'Lastname, Firstname'"), viewModel.nameLastFirstProperty())),
-                                                indent -> indent.styleClass("padding-left-16").spacing(4.0)))
+                                                indent -> indent.styleClass("padding-left-12").spacing(4.0)))
                                 .group(abbreviation -> abbreviation
                                         .label(Localization.lang("Abbreviations"))
                                         .group(choices -> choices
@@ -71,7 +71,7 @@ public class TableTab extends AbstractPreferenceTabView<TableTabViewModel> {
                                                                 .radio(Localization.lang("Do not abbreviate names"), viewModel.abbreviationDisabledProperty())
                                                                 .radio(Localization.lang("Abbreviate names"), viewModel.abbreviationEnabledProperty())
                                                                 .radio(Localization.lang("Show last names only"), viewModel.abbreviationLastNameOnlyProperty())),
-                                                indent -> indent.styleClass("padding-left-16")
+                                                indent -> indent.styleClass("padding-left-12")
                                                                 .spacing(4.0)
                                                                 // Natbib and "unchanged" render names verbatim,
                                                                 // so abbreviation does not apply.

--- a/jabgui/src/main/java/org/jabref/gui/preferences/table/TableTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/table/TableTab.java
@@ -63,7 +63,7 @@ public class TableTab extends AbstractPreferenceTabView<TableTabViewModel> {
                                                                 .radio(Localization.lang("Show names unchanged"), viewModel.nameAsIsProperty())
                                                                 .radio(Localization.lang("Show 'Firstname Lastname'"), viewModel.nameFirstLastProperty())
                                                                 .radio(Localization.lang("Show 'Lastname, Firstname'"), viewModel.nameLastFirstProperty())),
-                                                indent -> indent.styleClass("padding-left-24").spacing(4.0)))
+                                                indent -> indent.styleClass("padding-left-16").spacing(4.0)))
                                 .group(abbreviation -> abbreviation
                                         .label(Localization.lang("Abbreviations"))
                                         .group(choices -> choices
@@ -71,7 +71,7 @@ public class TableTab extends AbstractPreferenceTabView<TableTabViewModel> {
                                                                 .radio(Localization.lang("Do not abbreviate names"), viewModel.abbreviationDisabledProperty())
                                                                 .radio(Localization.lang("Abbreviate names"), viewModel.abbreviationEnabledProperty())
                                                                 .radio(Localization.lang("Show last names only"), viewModel.abbreviationLastNameOnlyProperty())),
-                                                indent -> indent.styleClass("padding-left-24")
+                                                indent -> indent.styleClass("padding-left-16")
                                                                 .spacing(4.0)
                                                                 // Natbib and "unchanged" render names verbatim,
                                                                 // so abbreviation does not apply.

--- a/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.java
@@ -86,7 +86,7 @@ public class WebSearchTab extends AbstractPreferenceTabView<WebSearchTabViewMode
                                         .checkbox(Localization.lang("Warn about duplicates on import"), viewModel.warnAboutDuplicatesOnImportProperty())
                                         .checkbox(Localization.lang("Download referenced files (PDFs, ...)"), viewModel.shouldDownloadLinkedOnlineFiles())
                                         .checkbox(Localization.lang("Store url for downloaded file"), viewModel.shouldKeepDownloadUrl()),
-                                toggleRow -> toggleRow.styleClass("gap-16"))
+                                toggleRow -> toggleRow.styleClass("gap-4"))
                         .checkWithField(Localization.lang("Add imported entries to group"), viewModel.getAddImportedEntries(), viewModel.getAddImportedEntriesGroupName(),
                                 PreferencesFormBuilder.InputElement::grow)
                         .combo(Localization.lang("Default plain citation parser"), viewModel.plainCitationParsers(), viewModel.defaultPlainCitationParserProperty(), PlainCitationParserChoice::getLocalizedName)

--- a/jabgui/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/jabgui/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -215,7 +215,7 @@ public class GlobalSearchBar extends HBox {
             this.getChildren().addAll(searchField, currentResults);
         }
 
-        this.setSpacing(4.0);
+        this.setSpacing(4);
         this.setAlignment(Pos.CENTER_LEFT);
 
         Timer searchTask = FxTimer.create(Duration.ofMillis(SEARCH_DELAY), this::updateSearchQuery);

--- a/jabgui/src/main/java/org/jabref/gui/texparser/CitationsDisplay.java
+++ b/jabgui/src/main/java/org/jabref/gui/texparser/CitationsDisplay.java
@@ -53,7 +53,7 @@ public class CitationsDisplay extends ListView<Citation> {
         fileNameLabel.setGraphic(IconTheme.JabRefIcons.LATEX_FILE.getGraphicNode());
         Label positionLabel = new Label("(%s:%s-%s)".formatted(item.line(), item.colStart(), item.colEnd()));
         positionLabel.setGraphic(IconTheme.JabRefIcons.LATEX_LINE.getGraphicNode());
-        HBox dataBox = new HBox(5, fileNameLabel, positionLabel);
+        HBox dataBox = new HBox(4, fileNameLabel, positionLabel);
 
         return new VBox(contextBox, dataBox);
     }

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
@@ -80,12 +80,12 @@ public class WalkthroughRenderer {
         boolean isVertical = step.position() == PanelPosition.LEFT || step.position() == PanelPosition.RIGHT;
 
         if (isVertical) {
-            panel.getStyleClass().addAll("walkthrough-side-panel-vertical", "padding-24");
+            panel.getStyleClass().addAll("walkthrough-side-panel-vertical", "padding-4");
             VBox.setVgrow(panel, Priority.ALWAYS);
             panel.setMaxHeight(Double.MAX_VALUE);
             step.maxWidth().ifPresent(panel::setMaxWidth);
         } else if (step.position() == PanelPosition.TOP || step.position() == PanelPosition.BOTTOM) {
-            panel.getStyleClass().addAll("walkthrough-side-panel-horizontal", "padding-24");
+            panel.getStyleClass().addAll("walkthrough-side-panel-horizontal", "padding-4");
             HBox.setHgrow(panel, Priority.ALWAYS);
             panel.setMaxWidth(Double.MAX_VALUE);
             step.maxHeight().ifPresent(panel::setMaxHeight);
@@ -126,7 +126,7 @@ public class WalkthroughRenderer {
     }
 
     private VBox makePanel() {
-        VBox container = new VBox(12);
+        VBox container = new VBox(4);
         container.getStyleClass().add("walkthrough-panel");
         return container;
     }
@@ -159,7 +159,7 @@ public class WalkthroughRenderer {
     }
 
     private VBox createContent(VisibleComponent component, Walkthrough walkthrough, Runnable beforeNavigate) {
-        VBox contentBox = new VBox(16);
+        VBox contentBox = new VBox(4);
         contentBox.getChildren().addAll(component.content().stream().map(block ->
                 switch (block) {
                     case TextBlock textBlock ->

--- a/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
@@ -114,8 +114,8 @@ public class WelcomeTab extends Tab {
         this.recentLibrariesBox = new VBox(8);
         recentLibrariesBox.getStyleClass().add("welcome-recent-libraries");
 
-        main = new VBox(24, createTopTitles(), new VBox(), createCommunityBox());
-        main.getStyleClass().addAll("welcome-main-container", "align-center", "padding-24");
+        main = new VBox(4, createTopTitles(), new VBox(), createCommunityBox());
+        main.getStyleClass().addAll("welcome-main-container", "align-center", "padding-4");
         initializeColumns();
 
         VBox container = new VBox(main);
@@ -135,14 +135,14 @@ public class WelcomeTab extends Tab {
         welcomeLabel.getStyleClass().addAll("h1", "text-accent");
         Label descriptionLabel = new Label(Localization.lang("Stay on top of your literature"));
         descriptionLabel.getStyleClass().add("h2");
-        VBox topTitles = new VBox(12, welcomeLabel, descriptionLabel);
-        topTitles.getStyleClass().addAll("align-top-left", "padding-bottom-24");
+        VBox topTitles = new VBox(4, welcomeLabel, descriptionLabel);
+        topTitles.getStyleClass().addAll("align-top-left", "padding-bottom-4");
         return topTitles;
     }
 
     private void initializeColumns() {
-        GridPane grid = new GridPane();
-        grid.getStyleClass().addAll("gap-16", "align-top-center");
+        GridPane grid = new GridPane(4, 4);
+        grid.getStyleClass().addAll( "align-top-center");
 
         VBox leftColumn = createLeftColumn();
         GridPane.setHgrow(leftColumn, Priority.ALWAYS);

--- a/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
@@ -353,7 +353,7 @@ public class WelcomeTab extends Tab {
     }
 
     private HBox createTextLinksContainer() {
-        HBox container = new HBox(16);
+        HBox container = new HBox(12);
         container.getStyleClass().addAll("align-center-left");
 
         Hyperlink devVersionLink = createFooterLink(Localization.lang("Download development version"), StandardActions.OPEN_DEV_VERSION_LINK, null);

--- a/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
@@ -142,7 +142,7 @@ public class WelcomeTab extends Tab {
 
     private void initializeColumns() {
         GridPane grid = new GridPane(4, 4);
-        grid.getStyleClass().addAll( "align-top-center");
+        grid.getStyleClass().add("align-top-center");
 
         VBox leftColumn = createLeftColumn();
         GridPane.setHgrow(leftColumn, Priority.ALWAYS);
@@ -171,7 +171,7 @@ public class WelcomeTab extends Tab {
     }
 
     private VBox createLeftColumn() {
-        VBox leftColumn = new VBox(24,
+        VBox leftColumn = new VBox(12,
                 createWelcomeStartBox(),
                 createWelcomeRecentBox()
         );
@@ -182,7 +182,7 @@ public class WelcomeTab extends Tab {
     private VBox createRightColumn() {
         this.quickSettings = new QuickSettings(preferences, dialogService, taskExecutor);
         this.walkthroughs = new Walkthroughs(stage, tabContainer, stateManager, preferences);
-        VBox rightColumn = new VBox(24, quickSettings, walkthroughs);
+        VBox rightColumn = new VBox(12, quickSettings, walkthroughs);
         rightColumn.getStyleClass().addAll("align-top-left");
         return rightColumn;
     }

--- a/jabgui/src/main/resources/org/jabref/gui/ai/AiPrivacyNotice.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/ai/AiPrivacyNotice.fxml
@@ -10,12 +10,12 @@
 <?import javafx.scene.text.Text?>
 <fx:root
         type="ScrollPane"
-        styleClass="ai-tab,padding-24"
+        styleClass="ai-tab,padding-4"
         xmlns="http://javafx.com/javafx/17.0.2-ea"
         xmlns:fx="http://javafx.com/fxml/1"
         fx:controller="org.jabref.gui.ai.AiPrivacyNoticeView">
-    <VBox spacing="20.0"
-          styleClass="gdpr-notice,h4,padding-12"
+    <VBox spacing="4.0"
+          styleClass="gdpr-notice,h4,padding-4"
           fx:id="text">
         <Label wrapText="true"
                text="%Privacy notice"
@@ -35,7 +35,7 @@
                 styleClass="embeddedHyperlink"
                 text="%You can find information about DJL privacy policy here."/>
 
-        <HBox spacing="10.0">
+        <HBox spacing="4.0">
             <Button onAction="#onPrivacyAgree"
                     text="%I agree"/>
             <Button onAction="#onPrivacyDisagree"

--- a/jabgui/src/main/resources/org/jabref/gui/ai/chat/AiChat.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/ai/chat/AiChat.fxml
@@ -74,19 +74,19 @@
         </center>
 
         <bottom>
-            <VBox spacing="10">
+            <VBox spacing="8">
                 <padding>
-                    <Insets top="10"/>
+                    <Insets top="8"/>
                 </padding>
 
                 <HBox fx:id="followUpQuestionsArea"
-                      spacing="5"
+                      spacing="4"
                       alignment="CENTER">
                     <Label text="%Follow-up questions"/>
 
                     <SimpleListView
                             fx:id="followUpQuestionsSimpleListView"
-                            spacing="10"/>
+                            spacing="8"/>
                 </HBox>
 
 

--- a/jabgui/src/main/resources/org/jabref/gui/ai/chat/AiChatMessage.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/ai/chat/AiChatMessage.fxml
@@ -39,7 +39,7 @@
 
     <VBox fx:id="buttons"
           alignment="TOP_CENTER"
-          spacing="5">
+          spacing="4">
         <Button fx:id="deleteButton"
                 onAction="#onDeleteClick"
                 styleClass="icon-button,narrow">

--- a/jabgui/src/main/resources/org/jabref/gui/auximport/FromAuxDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/auximport/FromAuxDialog.fxml
@@ -16,10 +16,10 @@
 <DialogPane xmlns:fx="http://javafx.com/fxml/1" prefHeight="650.0" prefWidth="500.0"
             xmlns="http://javafx.com/javafx/8.0.121" fx:controller="org.jabref.gui.auximport.FromAuxDialog">
     <content>
-        <VBox spacing="30">
-            <VBox spacing="5.0">
+        <VBox spacing="16">
+            <VBox spacing="4.0">
                 <Label text="%LaTeX AUX file:"/>
-                <HBox spacing="10" alignment="BASELINE_LEFT">
+                <HBox spacing="8" alignment="BASELINE_LEFT">
                     <TextField fx:id="auxFileField" HBox.hgrow="ALWAYS"/>
                     <Button onAction="#browseButtonClicked"
                             styleClass="icon-button,narrow"

--- a/jabgui/src/main/resources/org/jabref/gui/auximport/FromAuxDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/auximport/FromAuxDialog.fxml
@@ -16,7 +16,7 @@
 <DialogPane xmlns:fx="http://javafx.com/fxml/1" prefHeight="650.0" prefWidth="500.0"
             xmlns="http://javafx.com/javafx/8.0.121" fx:controller="org.jabref.gui.auximport.FromAuxDialog">
     <content>
-        <VBox spacing="16">
+        <VBox spacing="12">
             <VBox spacing="4.0">
                 <Label text="%LaTeX AUX file:"/>
                 <HBox spacing="8" alignment="BASELINE_LEFT">

--- a/jabgui/src/main/resources/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
@@ -15,24 +15,22 @@
 <?import org.controlsfx.control.MasterDetailPane?>
 <ScrollPane xmlns:fx="http://javafx.com/fxml/1" fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER"
             xmlns="http://javafx.com/javafx/8.0.112"
-            fx:controller="org.jabref.gui.entryeditor.fileannotationtab.FileAnnotationTabView" styleClass="editorPane,gap-8,padding-4">
+            fx:controller="org.jabref.gui.entryeditor.fileannotationtab.FileAnnotationTabView" styleClass="editorPane,padding-4">
     <MasterDetailPane dividerPosition="0.6">
         <masterNode>
-            <BorderPane>
-                <top>
-                    <HBox alignment="BASELINE_LEFT" spacing="10">
-                        <Label alignment="BASELINE_LEFT" text="%File"/>
+            <VBox spacing="4" styleClass="padding-4">
+                <children>
+                    <HBox alignment="BASELINE_LEFT" spacing="4">
+                        <Label minWidth="-Infinity" text="%File"/>
                         <ComboBox fx:id="files" maxWidth="Infinity" HBox.hgrow="ALWAYS"/>
                     </HBox>
-                </top>
-                <center>
-                    <ListView fx:id="annotationList"/>
-                </center>
-            </BorderPane>
+                    <ListView fx:id="annotationList" VBox.vgrow="ALWAYS"/>
+                </children>
+            </VBox>
         </masterNode>
         <detailNode>
-            <VBox fx:id="details">
-                <HBox>
+            <VBox fx:id="details" spacing="4" styleClass="padding-4">
+                <HBox spacing="4">
                     <Label fx:id="author"/>
                     <Pane HBox.hgrow="ALWAYS"/>
                     <Button onAction="#copy" styleClass="icon-button">

--- a/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
@@ -22,7 +22,7 @@
     <content>
         <VBox alignment="CENTER_LEFT" BorderPane.alignment="CENTER">
             <AnchorPane>
-                <VBox alignment="CENTER_LEFT" spacing="1.0" styleClass="padding-bottom-16"
+                <VBox alignment="CENTER_LEFT" spacing="4.0" styleClass="padding-bottom-12"
                       AnchorPane.leftAnchor="0" AnchorPane.topAnchor="0">
                     <Label alignment="CENTER" contentDisplay="CENTER" onMouseClicked="#copyVersionToClipboard" styleClass="h1,about-heading,text-accent" text="${controller.viewModel.heading}" wrapText="true">
                         <cursor>

--- a/jabgui/src/main/resources/org/jabref/gui/newentry/NewEntry.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/newentry/NewEntry.fxml
@@ -116,7 +116,7 @@
                                     StackPane.alignment="CENTER_RIGHT"
                                     text="%Jump to entry"
                                     visible="false"
-                                    styleClass="padding-right-16"/>
+                                    styleClass="padding-right-12"/>
                         </StackPane>
                     </HBox>
                     <VBox spacing="5.0">

--- a/jabgui/src/main/resources/org/jabref/gui/openoffice/StyleSelectDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/openoffice/StyleSelectDialog.fxml
@@ -96,7 +96,7 @@
                                 <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
                             </columnResizePolicy>
                         </TableView>
-                        <HBox alignment="CENTER_LEFT" spacing="16.0">
+                        <HBox alignment="CENTER_LEFT" spacing="12">
                             <Label text="%Citation format"/>
                             <RadioButton fx:id="numericFormatButton" text="%Numeric [1]"/>
                             <RadioButton fx:id="authorYearFormatButton" text="%Author-year"/>

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
@@ -22,7 +22,7 @@
                 </HBox>
             </bottom>
             <top>
-                <HBox spacing="16">
+                <HBox spacing="12">
                     <TextField fx:id="searchField" promptText="%Search"/>
                     <VBox alignment="CENTER">
                         <CheckBox fx:id="showOnlyDeviatingPreferenceOptions"

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
@@ -22,7 +22,7 @@
                 </HBox>
             </bottom>
             <top>
-                <HBox spacing="20">
+                <HBox spacing="16">
                     <TextField fx:id="searchField" promptText="%Search"/>
                     <VBox alignment="CENTER">
                         <CheckBox fx:id="showOnlyDeviatingPreferenceOptions"
@@ -40,7 +40,7 @@
                         <TableColumn fx:id="columnDefaultValue" text="%default"/>
                     </columns>
                     <padding>
-                        <Insets bottom="30.0"/>
+                        <Insets bottom="16.0"/>
                     </padding>
                 </TableView>
             </center>

--- a/jabgui/src/main/resources/org/jabref/gui/slr/ManageStudyDefinition.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/slr/ManageStudyDefinition.fxml
@@ -33,9 +33,9 @@
                                 fitToWidth="true"
                                 fitToHeight="true"
                                 styleClass="padding-12">
-                            <VBox spacing="20.0">
+                            <VBox spacing="16.0">
                                 <GridPane
-                                        hgap="10.0"
+                                        hgap="4.0"
                                         vgap="4.0">
                                     <columnConstraints>
                                         <ColumnConstraints
@@ -109,9 +109,9 @@
                                 fitToWidth="true"
                                 fitToHeight="true"
                                 styleClass="padding-12">
-                            <VBox spacing="20.0">
+                            <VBox spacing="16.0">
                                 <HBox alignment="CENTER_LEFT"
-                                      spacing="20.0">
+                                      spacing="16.0">
                                     <Label text="%Add Research Question:"/>
                                     <TextField
                                             fx:id="addResearchQuestion"
@@ -158,9 +158,9 @@
                                 fitToWidth="true"
                                 fitToHeight="true"
                                 styleClass="padding-12">
-                            <VBox spacing="20.0">
+                            <VBox spacing="16.0">
                                 <HBox alignment="CENTER_LEFT"
-                                      spacing="20.0">
+                                      spacing="16.0">
                                     <Label text="%Add Query:"/>
                                     <Label fx:id="helpIcon">
                                         <graphic>
@@ -213,7 +213,7 @@
                                 fitToWidth="true"
                                 fitToHeight="true"
                                 styleClass="padding-12">
-                            <VBox spacing="20.0">
+                            <VBox spacing="16.0">
                                 <Label text="%Select Catalogs:"/>
                                 <HBox alignment="CENTER_LEFT">
                                     <TableView
@@ -250,9 +250,9 @@
                                 fitToWidth="true"
                                 fitToHeight="true"
                                 styleClass="padding-12">
-                            <VBox spacing="20.0">
+                            <VBox spacing="16.0">
                                 <HBox alignment="CENTER_LEFT"
-                                      spacing="20.0">
+                                      spacing="16.0">
                                     <Label text="%Select the study directory:"/>
                                     <TextField
                                             fx:id="studyDirectory"

--- a/jabgui/src/main/resources/org/jabref/gui/slr/ManageStudyDefinition.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/slr/ManageStudyDefinition.fxml
@@ -33,7 +33,7 @@
                                 fitToWidth="true"
                                 fitToHeight="true"
                                 styleClass="padding-12">
-                            <VBox spacing="16.0">
+                            <VBox spacing="12">
                                 <GridPane
                                         hgap="4.0"
                                         vgap="4.0">
@@ -109,9 +109,9 @@
                                 fitToWidth="true"
                                 fitToHeight="true"
                                 styleClass="padding-12">
-                            <VBox spacing="16.0">
+                            <VBox spacing="12">
                                 <HBox alignment="CENTER_LEFT"
-                                      spacing="16.0">
+                                      spacing="12">
                                     <Label text="%Add Research Question:"/>
                                     <TextField
                                             fx:id="addResearchQuestion"
@@ -158,9 +158,9 @@
                                 fitToWidth="true"
                                 fitToHeight="true"
                                 styleClass="padding-12">
-                            <VBox spacing="16.0">
+                            <VBox spacing="12">
                                 <HBox alignment="CENTER_LEFT"
-                                      spacing="16.0">
+                                      spacing="12">
                                     <Label text="%Add Query:"/>
                                     <Label fx:id="helpIcon">
                                         <graphic>
@@ -213,7 +213,7 @@
                                 fitToWidth="true"
                                 fitToHeight="true"
                                 styleClass="padding-12">
-                            <VBox spacing="16.0">
+                            <VBox spacing="12">
                                 <Label text="%Select Catalogs:"/>
                                 <HBox alignment="CENTER_LEFT">
                                     <TableView
@@ -250,9 +250,9 @@
                                 fitToWidth="true"
                                 fitToHeight="true"
                                 styleClass="padding-12">
-                            <VBox spacing="16.0">
+                            <VBox spacing="12">
                                 <HBox alignment="CENTER_LEFT"
-                                      spacing="16.0">
+                                      spacing="12">
                                     <Label text="%Select the study directory:"/>
                                     <TextField
                                             fx:id="studyDirectory"

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -100,10 +100,8 @@
 .padding-top-12 { -fx-padding: 1em 0 0 0; }
 
 .padding-right-4 { -fx-padding: 0 0.333em 0 0; }
-.padding-right-16 { -fx-padding: 0 1.333em 0 0; }
 
 .padding-bottom-4 { -fx-padding: 0 0 0.333em 0; }
-.padding-bottom-16 { -fx-padding: 0 0 1.333em 0; }
 
 .padding-left-12 { -fx-padding: 0 0 0 1em; }
 

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -87,8 +87,6 @@
 .padding-4 { -fx-padding: 0.333em; }
 .padding-8 { -fx-padding: 0.667em; }
 .padding-12 { -fx-padding: 1em; }
-.padding-16 { -fx-padding: 1.333em; }
-.padding-24 { -fx-padding: 2em; }
 
 /* Padding: <vertical>-<horizontal>. Added on demand -- only the pairs in use exist. */
 .padding-0-4 { -fx-padding: 0 0.333em; }
@@ -106,16 +104,13 @@
 
 .padding-bottom-4 { -fx-padding: 0 0 0.333em 0; }
 .padding-bottom-16 { -fx-padding: 0 0 1.333em 0; }
-.padding-bottom-24 { -fx-padding: 0 0 2em 0; }
 
 .padding-left-12 { -fx-padding: 0 0 0 1em; }
-.padding-left-24 { -fx-padding: 0 0 0 2em; }
 
 /* Gap between the cells of a GridPane / FlowPane / TilePane */
 .gap-4 { -fx-hgap: 0.333em; -fx-vgap: 0.333em; }
 .gap-8 { -fx-hgap: 0.667em; -fx-vgap: 0.667em; }
 .gap-12 { -fx-hgap: 1em; -fx-vgap: 1em; }
-.gap-16 { -fx-hgap: 1.333em; -fx-vgap: 1.333em; }
 
 /* Alignment */
 .align-center { -fx-alignment: center; }

--- a/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/EntryTableConfigurationDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/EntryTableConfigurationDialog.fxml
@@ -10,7 +10,7 @@
 <DialogPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
             fx:controller="org.jabref.gui.welcome.quicksettings.EntryTableConfigurationDialog">
     <content>
-        <VBox spacing="16" styleClass="quick-settings-dialog-container,padding-16">
+        <VBox spacing="4" styleClass="quick-settings-dialog-container,padding-4">
             <HBox alignment="CENTER_LEFT" spacing="4">
                 <Label text="%Configure which columns are displayed in the entry table. The citation key column can be toggled to show or hide citation keys."
                        wrapText="true" HBox.hgrow="ALWAYS"/>

--- a/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/LargeLibraryOptimizationDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/LargeLibraryOptimizationDialog.fxml
@@ -10,14 +10,14 @@
 <DialogPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
             fx:controller="org.jabref.gui.welcome.quicksettings.LargeLibraryOptimizationDialog">
     <content>
-        <VBox spacing="16" styleClass="quick-settings-dialog-container,padding-16">
+        <VBox spacing="4" styleClass="quick-settings-dialog-container,padding-4">
             <HBox alignment="CENTER_LEFT" spacing="4">
                 <Label text="%Select features to disable. Disabling these features can significantly improve performance when working with large libraries."
                        wrapText="true" HBox.hgrow="ALWAYS"/>
                 <HelpButton fx:id="helpButton"/>
             </HBox>
 
-            <VBox spacing="16" styleClass="padding-left-12">
+            <VBox spacing="4">
                 <CheckBox fx:id="disableFulltextIndexing" text="%Fulltext indexing"
                           selected="true"/>
                 <CheckBox fx:id="disableCreationDate" text="%Creation date timestamps"

--- a/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/MainFileDirectoryDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/MainFileDirectoryDialog.fxml
@@ -13,7 +13,7 @@
 <DialogPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
             fx:controller="org.jabref.gui.welcome.quicksettings.MainFileDirectoryDialog">
     <content>
-        <VBox spacing="16" styleClass="quick-settings-dialog-container,padding-16">
+        <VBox spacing="4" styleClass="quick-settings-dialog-container,padding-4">
             <HBox alignment="CENTER_LEFT" spacing="4">
                 <Label text="%Set the default directory for storing attached files. Files will be stored relative to this directory unless specified otherwise."
                        wrapText="true" HBox.hgrow="ALWAYS"/>

--- a/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/OnlineServicesDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/OnlineServicesDialog.fxml
@@ -12,7 +12,7 @@
 <DialogPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
             fx:controller="org.jabref.gui.welcome.quicksettings.OnlineServicesDialog">
     <content>
-        <VBox spacing="16" styleClass="quick-settings-dialog-container,padding-16">
+        <VBox spacing="4" styleClass="quick-settings-dialog-container,padding-4">
             <HBox alignment="CENTER_LEFT" spacing="4">
                 <Label text="%Configure online catalogues and services for importing entries. Enable web search, update checking, and metadata extraction services."
                        wrapText="true" HBox.hgrow="ALWAYS"/>
@@ -39,7 +39,7 @@
 
             <ScrollPane fitToWidth="true" maxHeight="288"
                         hbarPolicy="NEVER">
-                <VBox fx:id="fetchersContainer" spacing="12" styleClass="padding-12"/>
+                <VBox fx:id="fetchersContainer" spacing="4" styleClass="padding-4"/>
             </ScrollPane>
         </VBox>
     </content>

--- a/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/PushApplicationDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/PushApplicationDialog.fxml
@@ -14,7 +14,7 @@
 <DialogPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
             fx:controller="org.jabref.gui.welcome.quicksettings.PushApplicationDialog">
     <content>
-        <VBox spacing="16" styleClass="quick-settings-dialog-container,padding-16">
+        <VBox spacing="4" styleClass="quick-settings-dialog-container,padding-4">
             <HBox alignment="CENTER_LEFT" spacing="4.0">
                 <Label text="%Configure external applications to push citations to. Detected applications are highlighted. Applications that are not detected can be set manually by specifying the path to the executable."
                        wrapText="true" HBox.hgrow="ALWAYS"/>

--- a/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/ThemeDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/welcome/quicksettings/ThemeDialog.fxml
@@ -17,10 +17,10 @@
 <DialogPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
             fx:controller="org.jabref.gui.welcome.quicksettings.ThemeDialog">
     <content>
-        <VBox spacing="16" styleClass="quick-settings-dialog-container,padding-16">
+        <VBox spacing="4" styleClass="quick-settings-dialog-container,padding-4">
             <Label text="%Choose between different themes, the color scheme or use a custom theme."
                    wrapText="true" HBox.hgrow="ALWAYS"/>
-            <GridPane hgap="10.0" vgap="4.0">
+            <GridPane hgap="4.0" vgap="4.0">
                 <columnConstraints>
                     <ColumnConstraints hgrow="SOMETIMES" percentWidth="30.0"/>
                     <ColumnConstraints hgrow="ALWAYS"/>

--- a/jabsrv/src/main/java/org/jabref/http/server/cayw/gui/SelectedItemsContainer.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/cayw/gui/SelectedItemsContainer.java
@@ -59,8 +59,8 @@ public class SelectedItemsContainer extends FlowPane {
             this.entry = entry;
 
             this.setAlignment(Pos.CENTER_LEFT);
-            this.setSpacing(5);
-            this.setPadding(new Insets(5, 10, 5, 10));
+            this.setSpacing(4);
+            this.setPadding(new Insets(4, 8, 4, 8));
 
             this.getStyleClass().add("chip-style");
 


### PR DESCRIPTION
### Summary

- Make the entry editor paddings more consistent, especially do not waste space so much
- Reduce very high paddings

### Steps to test

Use JabRef, especially the entry editor.

### Related issues and pull requests

Works towards: https://github.com/JabRef/jabref/issues/16787

### AI usage

Not used.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
