### PR TITLE
Fix 16808 recent libraries cutoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the "Connect to shared database" dialog froze while connecting. [#16800](https://github.com/JabRef/jabref/pull/16800)
 - We fixed an issue where the "entrytype" column header was shown in lower case; it now reads "Entry Type". [#16894](https://github.com/JabRef/jabref/pull/16894)
 - We fixed an issue where some buttons were not aligned in entry editor. [#16485](https://github.com/JabRef/jabref/issues/16485)
+- We fixed an issue where long recent library paths overflowed and were cut off in the Welcome tab. [#16808](https://github.com/JabRef/jabref/issues/16808)
 
 ### Removed
 

--- a/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
@@ -12,6 +12,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Tab;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.GridPane;
@@ -49,6 +50,7 @@ import org.jabref.logic.importer.fileformat.BibtexParser;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.BuildInfo;
 import org.jabref.logic.util.TaskExecutor;
+import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.util.FileUpdateMonitor;
@@ -59,6 +61,7 @@ import org.slf4j.LoggerFactory;
 
 public class WelcomeTab extends Tab {
     private static final Logger LOGGER = LoggerFactory.getLogger(WelcomeTab.class);
+    private static final int MAX_RECENT_FILE_PATH_LENGTH = 35;
 
     private final VBox recentLibrariesBox;
     private final LibraryTabContainer tabContainer;
@@ -309,8 +312,10 @@ public class WelcomeTab extends Tab {
         fileHistoryMenu.disableProperty().unbind();
         fileHistoryMenu.setDisable(false);
         for (MenuItem item : fileHistoryMenu.getItems()) {
-            Hyperlink recentLibraryLink = new Hyperlink(item.getText());
-            recentLibraryLink.getStyleClass().addAll("welcome-hyperlink", "h4");
+            String truncatedText = StringUtil.abbreviatePath(item.getText(), MAX_RECENT_FILE_PATH_LENGTH);
+            Hyperlink recentLibraryLink = new Hyperlink(truncatedText);
+            recentLibraryLink.setTooltip(new Tooltip(item.getText()));
+            recentLibraryLink.getStyleClass().add("welcome-hyperlink");
             recentLibraryLink.setOnAction(item.getOnAction());
             recentLibrariesBox.getChildren().add(recentLibraryLink);
         }

--- a/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
+++ b/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
@@ -805,7 +805,8 @@ public class StringUtil {
         int availableLengthForParent = maxLength - fileName.length() - 1;
 
         if (availableLengthForParent < MIN_PARENT_LENGTH) {
-            return ELLIPSIS + separator + fileName;
+            String fallback = ELLIPSIS + separator + fileName;
+            return fallback.length() <= maxLength ? fallback : fileName;
         }
 
         String parent = fullPath.substring(0, lastSeparator);

--- a/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
+++ b/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
@@ -775,9 +775,12 @@ public class StringUtil {
             return fullPath;
         }
 
-        int lastSeparator = Math.max(fullPath.lastIndexOf('/'), fullPath.lastIndexOf('\\'));
+        char primarySeparator = OS.WINDOWS ? '\\' : '/';
+        char fallbackSeparator = OS.WINDOWS ? '/' : '\\';
+
+        int lastSeparator = fullPath.lastIndexOf(primarySeparator);
         if (lastSeparator == -1) {
-            return limitStringLength(fullPath, maxLength);
+            lastSeparator = fullPath.lastIndexOf(fallbackSeparator);
         }
 
         String parent = fullPath.substring(0, lastSeparator);

--- a/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
+++ b/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
@@ -51,6 +51,10 @@ public class StringUtil {
     // A sentence ends with a .?!;, but not in the case of "Mr.", "Ms.", "Mrs.", "Dr.", "st.", "jr.", "co.", "inc.", and "ltd."
     private static final Pattern SPLIT_TEXT_PATTERN = Pattern.compile("(?<=[\\.!;\\?])(?<![Mm](([Rr]|[Rr][Ss])|[Ss])\\.|[Dd][Rr]\\.|[Ss][Tt]\\.|[Jj][Rr]\\.|[Cc][Oo]\\.|[Ii][Nn][Cc]\\.|[Ll][Tt][Dd]\\.)\\s+");
 
+    private static final String ELLIPSIS = "...";
+    private static final int MIN_TRUNCATED_FILENAME_LENGTH = 3;
+    private static final int MIN_PARENT_LENGTH = 5;
+
     public static String booleanToBinaryString(boolean expression) {
         return expression ? "1" : "0";
     }
@@ -783,21 +787,29 @@ public class StringUtil {
             lastSeparator = fullPath.lastIndexOf(fallbackSeparator);
         }
 
-        String parent = fullPath.substring(0, lastSeparator);
+        if (lastSeparator == -1) {
+            return maxLength > MIN_TRUNCATED_FILENAME_LENGTH
+                   ? fullPath.substring(0, maxLength - ELLIPSIS.length()) + ELLIPSIS
+                   : fullPath;
+        }
+
         String fileName = fullPath.substring(lastSeparator + 1);
         char separator = fullPath.charAt(lastSeparator);
 
         if (fileName.length() >= maxLength) {
-            return maxLength > 3 ? fileName.substring(0, maxLength - 3) + "..." : fileName;
+            return maxLength > MIN_TRUNCATED_FILENAME_LENGTH
+                   ? fileName.substring(0, maxLength - ELLIPSIS.length()) + ELLIPSIS
+                   : fileName;
         }
 
         int availableLengthForParent = maxLength - fileName.length() - 1;
 
-        if (availableLengthForParent < 5) {
-            return "..." + separator + fileName;
+        if (availableLengthForParent < MIN_PARENT_LENGTH) {
+            return ELLIPSIS + separator + fileName;
         }
 
-        String shortenedParent = abbreviateMiddle(parent, "...", availableLengthForParent);
+        String parent = fullPath.substring(0, lastSeparator);
+        String shortenedParent = abbreviateMiddle(parent, ELLIPSIS, availableLengthForParent);
         return shortenedParent + separator + fileName;
     }
 

--- a/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
+++ b/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
@@ -813,7 +813,6 @@ public class StringUtil {
         return shortenedParent + separator + fileName;
     }
 
-    @AllowedToUseApacheCommonsLang3("No Guava equivalent existing")
     public static String abbreviateMiddle(String str, String middle, int length) {
         return StringUtils.abbreviateMiddle(str, middle, length);
     }

--- a/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
+++ b/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
@@ -765,13 +765,11 @@ public class StringUtil {
         return Optional.ofNullable(string).orElse("");
     }
 
-    /**
-     * Abbreviates a file path by replacing middle directories with "...".
-     *
-     * @param fullPath  the full file path to abbreviate
-     * @param maxLength the maximum allowed length
-     * @return the abbreviated path, or {@code null} if {@code fullPath} is null
-     */
+    /// Abbreviates a file path by replacing middle directories with "...".
+    ///
+    /// @param fullPath  the full file path to abbreviate
+    /// @param maxLength the maximum allowed length
+    /// @return the abbreviated path, or null if fullPath is null
     public static String abbreviatePath(String fullPath, int maxLength) {
         if (fullPath == null || fullPath.length() <= maxLength) {
             return fullPath;

--- a/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
+++ b/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
@@ -766,11 +766,11 @@ public class StringUtil {
     }
 
     /**
-     * Abbreviates a file path to a maximum length while keeping the file name intact.
+     * Abbreviates a file path by replacing middle directories with "...".
      *
-     * @param fullPath  the full path of the file to abbreviate
-     * @param maxLength the maximum allowed length of the resulting string
-     * @return the abbreviated path, or the original path if within length
+     * @param fullPath  the full file path to abbreviate
+     * @param maxLength the maximum allowed length
+     * @return the abbreviated path, or {@code null} if {@code fullPath} is null
      */
     public static String abbreviatePath(String fullPath, int maxLength) {
         if (fullPath == null || fullPath.length() <= maxLength) {

--- a/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
+++ b/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
@@ -810,11 +810,7 @@ public class StringUtil {
         }
 
         String parent = fullPath.substring(0, lastSeparator);
-        String shortenedParent = abbreviateMiddle(parent, ELLIPSIS, availableLengthForParent);
+        String shortenedParent = StringUtils.abbreviateMiddle(parent, ELLIPSIS, availableLengthForParent);
         return shortenedParent + separator + fileName;
-    }
-
-    public static String abbreviateMiddle(String str, String middle, int length) {
-        return StringUtils.abbreviateMiddle(str, middle, length);
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
+++ b/jablib/src/main/java/org/jabref/logic/util/strings/StringUtil.java
@@ -764,4 +764,44 @@ public class StringUtil {
     public static String makeSafe(@Nullable String string) {
         return Optional.ofNullable(string).orElse("");
     }
+
+    /**
+     * Abbreviates a file path to a maximum length while keeping the file name intact.
+     *
+     * @param fullPath  the full path of the file to abbreviate
+     * @param maxLength the maximum allowed length of the resulting string
+     * @return the abbreviated path, or the original path if within length
+     */
+    public static String abbreviatePath(String fullPath, int maxLength) {
+        if (fullPath == null || fullPath.length() <= maxLength) {
+            return fullPath;
+        }
+
+        int lastSeparator = Math.max(fullPath.lastIndexOf('/'), fullPath.lastIndexOf('\\'));
+        if (lastSeparator == -1) {
+            return limitStringLength(fullPath, maxLength);
+        }
+
+        String parent = fullPath.substring(0, lastSeparator);
+        String fileName = fullPath.substring(lastSeparator + 1);
+        char separator = fullPath.charAt(lastSeparator);
+
+        if (fileName.length() >= maxLength) {
+            return maxLength > 3 ? fileName.substring(0, maxLength - 3) + "..." : fileName;
+        }
+
+        int availableLengthForParent = maxLength - fileName.length() - 1;
+
+        if (availableLengthForParent < 5) {
+            return "..." + separator + fileName;
+        }
+
+        String shortenedParent = abbreviateMiddle(parent, "...", availableLengthForParent);
+        return shortenedParent + separator + fileName;
+    }
+
+    @AllowedToUseApacheCommonsLang3("No Guava equivalent existing")
+    public static String abbreviateMiddle(String str, String middle, int length) {
+        return StringUtils.abbreviateMiddle(str, middle, length);
+    }
 }

--- a/jablib/src/test/java/org/jabref/logic/util/strings/StringUtilTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/strings/StringUtilTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -497,8 +498,30 @@ class StringUtilTest {
         String path = "very/long/directory/structure/file.bib";
         String result = StringUtil.abbreviatePath(path, 25);
 
+        assertNotNull(result);
         assertTrue(result.length() <= 25);
         assertTrue(result.endsWith("file.bib"));
         assertTrue(result.contains("..."));
+    }
+
+    @Test
+    void abbreviatePathReturnsFilenameOnlyWhenEllipsisWouldOverflow() {
+        String fileName = "a".repeat(29) + ".bib";
+        String path = "very/long/path/to/folder/" + fileName;
+        String result = StringUtil.abbreviatePath(path, 35);
+
+        assertNotNull(result);
+        assertTrue(result.length() <= 35);
+        assertEquals(fileName, result);
+    }
+
+    @Test
+    void abbreviatePathTruncatesFileNameWhenFilenameExceedsMaxLength() {
+        String path = "folder/extremely_long_file_name_exceeding_limit.bib";
+        String result = StringUtil.abbreviatePath(path, 20);
+
+        assertNotNull(result);
+        assertTrue(result.length() <= 20);
+        assertTrue(result.endsWith("..."));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/util/strings/StringUtilTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/strings/StringUtilTest.java
@@ -485,4 +485,20 @@ class StringUtilTest {
 
         assertEquals(expected, StringUtil.alignStringTable(given));
     }
+
+    @Test
+    void abbreviatePathReturnsOriginalWhenShorterThanMax() {
+        String path = "folder/file.bib";
+        assertEquals("folder/file.bib", StringUtil.abbreviatePath(path, 30));
+    }
+
+    @Test
+    void abbreviatePathShortensParentDirectory() {
+        String path = "very/long/directory/structure/file.bib";
+        String result = StringUtil.abbreviatePath(path, 25);
+
+        assertTrue(result.length() <= 25);
+        assertTrue(result.endsWith("file.bib"));
+        assertTrue(result.contains("..."));
+    }
 }


### PR DESCRIPTION
### Summary
Fixed long library paths overflowing in the Welcome tab by truncating the middle folders with `...` while keeping the drive root and the file name visible, and added a tooltip displaying the full original path on hover.

### Steps to test
1. Open JabRef.
2. In the "Recent libraries" section on the Welcome tab, observe entries with long paths; middle directories are truncated with `...`.
3. Hover over an abbreviated link to view the complete path in the tooltip.

### Related issues and pull requests
Closes #16808

### AI usage
AIL-1 (Used an AI tool for English grammar correction and formatting on the PR description. All code and tests were written and verified manually.)

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

### Visual changes
<img width="313" height="255" alt="image" src="https://github.com/user-attachments/assets/af93a921-e8ba-4f00-ae52-5e3ae100ef08" />
<img width="884" height="256" alt="image" src="https://github.com/user-attachments/assets/27ec8d92-f8ec-4985-bd82-5c5fd6b0eba0" />
