### PR TITLE
Parse "et al." in author lists as "and others"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where an author list ending with "et al." was parsed as a person named "et al." instead of "and others". [#TODO](https://github.com/JabRef/jabref/pull/TODO)
 - We fixed an issue where main table columns could not be resized while "Fit table horizontally on screen" was enabled. Resizing a column now adjusts only the columns to its right, and column widths keep their proportions when the window is resized. [#10516](https://github.com/JabRef/jabref/issues/10516)
 - We fixed an issue where entries imported in the background could not be selected or updated in the main table. [#16893](https://github.com/JabRef/jabref/pull/16893)
 - We fixed an issue where the entry editor kept showing an entry of another library after switching libraries. [#16892](https://github.com/JabRef/jabref/pull/16892)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where an author list ending with "et al." was parsed as a person named "et al." instead of "and others". [#TODO](https://github.com/JabRef/jabref/pull/TODO)
+- We fixed an issue where an author list ending with "et al." was parsed as a person named "et al." instead of "and others". [#16937](https://github.com/JabRef/jabref/pull/16937)
 - We fixed an issue where main table columns could not be resized while "Fit table horizontally on screen" was enabled. Resizing a column now adjusts only the columns to its right, and column widths keep their proportions when the window is resized. [#10516](https://github.com/JabRef/jabref/issues/10516)
 - We fixed an issue where entries imported in the background could not be selected or updated in the main table. [#16893](https://github.com/JabRef/jabref/pull/16893)
 - We fixed an issue where the entry editor kept showing an entry of another library after switching libraries. [#16892](https://github.com/JabRef/jabref/pull/16892)

--- a/jablib/src/main/java/org/jabref/logic/importer/AuthorListParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/AuthorListParser.java
@@ -43,7 +43,9 @@ public class AuthorListParser {
 
     private static final Pattern NEW_LINE_PATTERN = Pattern.compile("\\s*\\n\\s*");
 
-    private static final Pattern ET_AL_SUFFIX = Pattern.compile("[,;\\s]+et\\s+al\\.?$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ET_AL_SUFFIX = Pattern.compile("[,;\\s]++et\\s++al\\.?+$", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern COMMA_SEPARATOR = Pattern.compile("\\s*+,\\s*+");
 
     /// the raw bibtex author/editor field
     private String original;
@@ -110,7 +112,7 @@ public class AuthorListParser {
             andOthersPresent = true;
             listOfNames = listOfNames.substring(0, etAlMatcher.start());
             // "Z. Yao, D. S. Weld, et al.": without the "et al." nothing marks the commas as name separators
-            String[] names = listOfNames.split(", ");
+            String[] names = COMMA_SEPARATOR.split(listOfNames);
             if (!listOfNames.toUpperCase(Locale.ENGLISH).contains(" AND ")
                     && Arrays.stream(names).allMatch(name -> STARTS_WITH_CAPITAL_LETTER_DOT_OR_DASH.matcher(name).find())) {
                 listOfNames = String.join(" and ", names);

--- a/jablib/src/main/java/org/jabref/logic/importer/AuthorListParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/AuthorListParser.java
@@ -43,6 +43,8 @@ public class AuthorListParser {
 
     private static final Pattern NEW_LINE_PATTERN = Pattern.compile("\\s*\\n\\s*");
 
+    private static final Pattern ET_AL_SUFFIX = Pattern.compile("[,;\\s]+et\\s+al\\.?$", Pattern.CASE_INSENSITIVE);
+
     /// the raw bibtex author/editor field
     private String original;
     /// index of the start in original, for example to point to 'abc' in 'abc xyz', tokenStart=2
@@ -99,9 +101,20 @@ public class AuthorListParser {
         // Remove it from the list; it will be added at the very end of this method as special Author.OTHERS
         final String andOthersSuffix = " and others";
         final boolean andOthersPresent;
+        Matcher etAlMatcher = ET_AL_SUFFIX.matcher(listOfNames);
         if (StringUtil.endsWithIgnoreCase(listOfNames, andOthersSuffix)) {
             andOthersPresent = true;
             listOfNames = StringUtil.removeStringAtTheEnd(listOfNames, " and others");
+        } else if (etAlMatcher.find()) {
+            // Typeset bylines ("Smith, Doe, et al.") use "et al." where BibTeX expects "and others"
+            andOthersPresent = true;
+            listOfNames = listOfNames.substring(0, etAlMatcher.start());
+            // "Z. Yao, D. S. Weld, et al.": without the "et al." nothing marks the commas as name separators
+            String[] names = listOfNames.split(", ");
+            if (!listOfNames.toUpperCase(Locale.ENGLISH).contains(" AND ")
+                    && Arrays.stream(names).allMatch(name -> STARTS_WITH_CAPITAL_LETTER_DOT_OR_DASH.matcher(name).find())) {
+                listOfNames = String.join(" and ", names);
+            }
         } else {
             andOthersPresent = false;
         }

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/pdf/PdfContentImporter.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/pdf/PdfContentImporter.java
@@ -86,8 +86,12 @@ public class PdfContentImporter extends PdfImporter {
         return result;
     }
 
+    /// Converts an author line as found in a PDF into a BibTeX author list, mapping a trailing `et al.` to `others`.
+    ///
+    /// [org.jabref.logic.formatter.bibtexfields.NormalizeNamesFormatter] (via
+    /// [org.jabref.logic.importer.AuthorListParser#normalizeSimply]) covers the comma-separated cases including
+    /// `et al.`, but not the space-separated fallback below, so it cannot replace this method as is.
     private String streamlineNames(String names) {
-        // TODO: replace with NormalizeNamesFormatter?!
         String res;
         // supported formats:
         //   Matthias Schrepfer1, Johannes Wolf1, Jan Mendling1, and Hajo A. Reijers2

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/pdf/PdfContentImporter.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/pdf/PdfContentImporter.java
@@ -86,11 +86,24 @@ public class PdfContentImporter extends PdfImporter {
         return result;
     }
 
-    /// Converts an author line as found in a PDF into a BibTeX author list, mapping a trailing `et al.` to `others`.
+    /// Converts an author line as found in a PDF (a "byline") into a BibTeX author list, mapping a trailing `et al.` to `others`.
     ///
-    /// [org.jabref.logic.formatter.bibtexfields.NormalizeNamesFormatter] (via
-    /// [org.jabref.logic.importer.AuthorListParser#normalizeSimply]) covers the comma-separated cases including
-    /// `et al.`, but not the space-separated fallback below, so it cannot replace this method as is.
+    /// Neither [org.jabref.logic.importer.AuthorListParser] nor
+    /// [org.jabref.logic.formatter.bibtexfields.NormalizeNamesFormatter] (which delegates to
+    /// [org.jabref.logic.importer.AuthorListParser#normalizeSimply]) can take the byline directly. Both keep BibTeX
+    /// semantics, where a comma separates family and given names: `Smith, John and Doe, Jane` has the same shape as
+    /// `Karen Cooper, Jennifer Donovan and Gary Williamson`. Only this importer knows that its input is a byline and
+    /// thus in "Given Family" order. Measured on the raw bylines of the importer's tests:
+    ///
+    /// | Byline                                                                     | AuthorListParser result                                        |
+    /// |----------------------------------------------------------------------------|----------------------------------------------------------------|
+    /// | `Karen A. Cooper, Jennifer L. Donovan, Andrew L. Waterhouse and Gary Williamson` | 2 persons: "Andrew L. Waterhouse Karen A. Cooper, Jennifer L. Donovan" and "Gary Williamson" |
+    /// | `Karen A. Cooper1, Jennifer L. Donovan2 and Gary Williamson1*`            | 2 persons, affiliation markers kept as part of the family names |
+    /// | `Karen A. Cooper, Jennifer L. Donovan, et al.`                             | 1 garbled person plus `others` (the initials-first heuristic of `normalizeSimply` needs `K. A. Cooper`) |
+    /// | `Anke Lüdeling Merja Kytö` (separated by spaces only)                      | 1 person                                                       |
+    ///
+    /// Hence the byline is split heuristically here; the result is a plain BibTeX list that
+    /// [org.jabref.model.entry.AuthorList#parse] handles afterwards.
     private String streamlineNames(String names) {
         String res;
         // supported formats:

--- a/jablib/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -53,9 +54,14 @@ class AuthorListParserTest {
         assertEquals(Optional.of("Z. Yao and D. S. Weld and W-P. Chen and H. Sun"), AuthorListParser.normalizeSimply("Z. Yao, D. S. Weld, W-P. Chen, and H. Sun"));
     }
 
-    @Test
-    void etAlNormalizedToAndOthers() {
-        assertEquals(Optional.of("Z. Yao and D. S. Weld and others"), AuthorListParser.normalizeSimply("Z. Yao, D. S. Weld, et al."));
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "Z. Yao, D. S. Weld, et al.",
+            "Z. Yao,D. S. Weld, et al.",
+            "Z. Yao,   D. S. Weld, et al."
+    })
+    void etAlNormalizedToAndOthers(String input) {
+        assertEquals(Optional.of("Z. Yao and D. S. Weld and others"), AuthorListParser.normalizeSimply(input));
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
@@ -54,6 +54,11 @@ class AuthorListParserTest {
     }
 
     @Test
+    void etAlNormalizedToAndOthers() {
+        assertEquals(Optional.of("Z. Yao and D. S. Weld and others"), AuthorListParser.normalizeSimply("Z. Yao, D. S. Weld, et al."));
+    }
+
+    @Test
     void dashedNamesWithSpaceNormalized() {
         assertEquals(Optional.of("Z. Yao and D. S. Weld and W.-P. Chen and H. Sun"), AuthorListParser.normalizeSimply("Z. Yao, D. S. Weld, W.-P. Chen, and H. Sun"));
     }
@@ -66,6 +71,26 @@ class AuthorListParserTest {
                                 Author.OTHERS
                         ),
                         "Alexander Artemenko and others"),
+                Arguments.of(
+                        AuthorList.of(
+                                new Author("Alexander", "A.", null, "Artemenko", null),
+                                Author.OTHERS
+                        ),
+                        "Alexander Artemenko et al."),
+                Arguments.of(
+                        AuthorList.of(
+                                new Author("John", "J.", null, "Smith", null),
+                                new Author("Jane", "J.", null, "Doe", null),
+                                Author.OTHERS
+                        ),
+                        "Smith, John and Doe, Jane, et al"),
+                Arguments.of(
+                        AuthorList.of(
+                                new Author("J.", "J.", null, "Smith", null),
+                                new Author("A.", "A.", null, "Doe", null),
+                                Author.OTHERS
+                        ),
+                        "J. Smith and A. Doe ET AL."),
                 Arguments.of(
                         AuthorList.of(
                                 new Author("I.", "I.", null, "Podadera", null),


### PR DESCRIPTION
### Summary

🤖 An author list ending with "et al." (as printed in bylines and pasted from citations) was parsed as a person named "et al.". The parser now treats "et al." like BibTeX's "and others", and recognizes a preceding comma-separated list of initial-first names as separate persons.

**Analogies:** Like honey, this PR collects a scattered form and stores it in the standard cell; like chocolate, it removes a bitter after-taste from an otherwise sweet author list; and like the moon, "et al." now merely reflects the real authors instead of posing as one.

jabref-contrib-policy:4.2:reviewed​:ok

### Steps to test

1. Create an entry with author `Smith, John and Doe, Jane, et al.`
2. Open the entry preview: it shows "Smith, Doe, et al." instead of a person called "et al."

### Related issues and pull requests

Closes NA

Follow-up to https://github.com/JabRef/jabref/pull/16247, whose author cross-check found that `AuthorListParser` keeps "et al." as a literal person.

### AI usage

Claude Code (model claude-fable-5-1), AIL4: fully AI-generated, reviewed and owned by the author.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`).
- [x] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [x] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [x] No `catch (Exception e)` — only specific exceptions are caught.
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [x] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [/] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [x] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [x] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [/] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML).
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS).

### Tests

- [x] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [x] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions (let them propagate so JUnit reports setup/teardown failures directly), and use `@TempDir` instead of manual temp directories.
- [/] Fetcher tests hit the live endpoints — the remote API is not mocked or stubbed (automated-review suggestions to mock it are rejected on purpose).

## 2. Verification commands

- [x] `./gradlew :jablib:check` (or `./gradlew check` for all modules). — ran the affected test classes (AuthorListParserTest, AuthorListTest, PdfContent*, NormalizeNames*)
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [x] `./gradlew modernizer`.
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes (run `./gradlew rewriteRun` to fix).
- [/] `./gradlew javadoc`.
- [/] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` (only if Markdown changed).
- [/] `npm ci && npm run textlint` reports no misspellings (only if Markdown changed).
- [/] Only if formatting is still off after `rewriteRun`: `docker run -v $(pwd):/github/workspace ghcr.io/leventebajczi/intellij-format:master "*.java" "" ".idea/codeStyles/Project.xml"`.

## 3. Documentation

- [x] `CHANGELOG.md` entry added if the change is visible to the user.
- [x] Searched jabref/issues and jabref-koppor/issues for a related issue; none found.
- [/] Requirement added to `docs/requirements/<area>.md` if the change is a new feature or significant bug fix.
- [/] Developer documentation under `docs/` updated if behavior or architecture changed.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [/] "Steps to test" is a numbered list with a cropped screenshot of the result for every visible change.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>` (not `--body`).
- [x] `CHANGELOG.md` `TODO` placeholder replaced with the PR link after creation, then marked ready.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tGd88pEcjT2JUNBayRTc1
