### PR TITLE
remove styleProperty(), setStyle(..), getStyle(..). Simplify icon rendering

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -386,22 +386,6 @@ public class GroupTreeView extends BorderPane {
                 });
         text.getStyleClass().setAll("text");
 
-        text.styleProperty().bind(Bindings.createStringBinding(() -> {
-            double reducedFontSize;
-            double font_size = preferences.getWorkspacePreferences().getMainFontSize();
-            // For each breaking point, the font size is reduced 0.20 em to fix issue 8797
-            if (font_size > 26.0) {
-                reducedFontSize = 0.25;
-            } else if (font_size > 22.0) {
-                reducedFontSize = 0.35;
-            } else if (font_size > 18.0) {
-                reducedFontSize = 0.55;
-            } else {
-                reducedFontSize = 0.75;
-            }
-            return "-fx-font-size: %fem;".formatted(reducedFontSize);
-        }, preferences.getWorkspacePreferences().mainFontSizeProperty()));
-
         node.getChildren().add(text);
         node.setMaxWidth(Control.USE_PREF_SIZE);
         return node;

--- a/jabgui/src/main/java/org/jabref/gui/icon/IkonliIcon.java
+++ b/jabgui/src/main/java/org/jabref/gui/icon/IkonliIcon.java
@@ -16,8 +16,6 @@ import javafx.scene.Node;
 import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
 
-import org.jabref.gui.util.ColorUtil;
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.kordamp.ikonli.Ikon;
@@ -30,27 +28,30 @@ import org.kordamp.ikonli.javafx.FontIcon;
 @NullMarked
 public final class IkonliIcon implements JabRefIcon {
 
+    /// Ikonli's own default, so an icon that was never given a size renders as it always has.
+    private static final int DEFAULT_SIZE = 8;
+
     private final List<Ikon> icons;
     private final @Nullable Color color;
-    private final @Nullable Integer size;
+    private final int size;
 
     public IkonliIcon(Ikon... icons) {
-        this(List.of(icons), null, null);
+        this(List.of(icons), null, DEFAULT_SIZE);
     }
 
     public IkonliIcon(List<Ikon> icons) {
-        this(icons, null, null);
+        this(icons, null, DEFAULT_SIZE);
     }
 
     public IkonliIcon(Color color, Ikon... icons) {
-        this(List.of(icons), color, null);
+        this(List.of(icons), color, DEFAULT_SIZE);
     }
 
     IkonliIcon(Color color, List<Ikon> icons) {
-        this(icons, color, null);
+        this(icons, color, DEFAULT_SIZE);
     }
 
-    private IkonliIcon(List<Ikon> icons, @Nullable Color color, @Nullable Integer size) {
+    private IkonliIcon(List<Ikon> icons, @Nullable Color color, int size) {
         this.icons = List.copyOf(icons);
         this.color = color;
         this.size = size;
@@ -112,20 +113,10 @@ public final class IkonliIcon implements JabRefIcon {
     }
 
     private FontIcon buildFontIcon(Ikon ikon) {
-        FontIcon fontIcon = FontIcon.of(ikon);
+        // An explicit color (via withColor/disabled) has to survive the theme's .glyph-icon rules, which is what
+        // JabRefFontIcon takes care of. Without one, those rules are what colors the icon.
+        FontIcon fontIcon = color == null ? FontIcon.of(ikon, size) : new JabRefFontIcon(ikon, size, color);
         fontIcon.getStyleClass().add("glyph-icon");
-        if (size != null) {
-            fontIcon.setIconSize(size);
-        }
-
-        // Override the default color from the css files
-        // FIXME: Inline style should be removed eventually.
-        if (color != null) {
-            fontIcon.setStyle(fontIcon.getStyle() +
-                    "-fx-fill: %s;".formatted(ColorUtil.toRGBCode(color)) +
-                    "-fx-icon-color: %s;".formatted(ColorUtil.toRGBCode(color)));
-        }
-
         return fontIcon;
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/icon/JabRefFontIcon.java
+++ b/jabgui/src/main/java/org/jabref/gui/icon/JabRefFontIcon.java
@@ -1,0 +1,52 @@
+package org.jabref.gui.icon;
+
+import java.util.List;
+import java.util.Set;
+
+import javafx.css.CssMetaData;
+import javafx.css.Styleable;
+import javafx.scene.paint.Paint;
+
+import org.jspecify.annotations.NullMarked;
+import org.kordamp.ikonli.Ikon;
+import org.kordamp.ikonli.javafx.FontIcon;
+
+/// A [FontIcon] whose color is chosen in code rather than by the theme -- a group's color, or the gray of a
+/// disabled icon. The font-backed counterpart to [JabRefSvgIcon].
+///
+/// Plain [FontIcon#setIconColor(Paint)] is not enough for that: JavaFX lets a value from an author stylesheet
+/// win over one set programmatically, so the `.glyph-icon` and `.ikonli-font-icon` rules in jabref-base.css
+/// would paint the icon in the theme's text color again on the next CSS pass. The usual way out -- reporting
+/// the property as not settable -- is closed too, because Ikonli's `-fx-icon-color` metadata answers
+/// [CssMetaData#isSettable] with a constant `true`.
+///
+/// What is left is [#getCssMetaData()]: CSS only ever touches the properties a node lists there, so this node
+/// lists neither color property. Everything else -- sizes, bounds type -- stays under the theme's control.
+@NullMarked
+class JabRefFontIcon extends FontIcon {
+
+    /// The properties that color a [FontIcon]. `-fx-icon-color` feeds `-fx-fill` through Ikonli's own listener,
+    /// so both have to go for the color to survive.
+    private static final Set<String> COLOR_PROPERTIES = Set.of("-fx-fill", "-fx-icon-color");
+
+    private static final List<CssMetaData<? extends Styleable, ?>> CSS_META_DATA =
+            FontIcon.getClassCssMetaData()
+                    .stream()
+                    .filter(metaData -> !COLOR_PROPERTIES.contains(metaData.getProperty()))
+                    .toList();
+
+    JabRefFontIcon(Ikon ikon, int size, Paint color) {
+        setIconCode(ikon);
+        setIconSize(size);
+        setIconColor(color);
+    }
+
+    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
+        return CSS_META_DATA;
+    }
+
+    @Override
+    public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
+        return CSS_META_DATA;
+    }
+}

--- a/jabgui/src/main/java/org/jabref/gui/icon/JabRefIconView.java
+++ b/jabgui/src/main/java/org/jabref/gui/icon/JabRefIconView.java
@@ -16,12 +16,10 @@ import javafx.css.StyleableProperty;
 import javafx.css.converter.PaintConverter;
 import javafx.scene.Group;
 import javafx.scene.Node;
-import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
 import javafx.scene.text.Font;
 
 import org.jabref.gui.icon.IconTheme.JabRefIcons;
-import org.jabref.gui.util.ColorUtil;
 
 import com.tobiasdiez.easybind.EasyBind;
 import org.jspecify.annotations.NullMarked;
@@ -35,20 +33,20 @@ import org.jspecify.annotations.NullMarked;
 /// Theme coloring is handled by the hosted child itself (a `FontIcon` or [JabRefSvgIcon], both of
 /// which carry the icon style classes), so this view stays unclassed to avoid double-theming. The styleable
 /// `-fx-icon-color` here is an explicit override knob — e.g. an inline `style="-fx-icon-color: ..."`
-/// in FXML — and, when set, is forwarded to an SVG child as a user-origin color (overriding theme CSS).
+/// in FXML — and, when set, is forwarded to an SVG child as a color (overriding theme CSS).
 @NullMarked
 public class JabRefIconView extends Group {
 
-    private static final CssMetaData<JabRefIconView, Paint> ICON_COLOR =
+    private static final CssMetaData<JabRefIconView, Paint> COLOR =
             new CssMetaData<>("-fx-icon-color", PaintConverter.getInstance()) {
                 @Override
                 public boolean isSettable(JabRefIconView node) {
-                    return !node.iconColor.isBound();
+                    return !node.color.isBound();
                 }
 
                 @Override
                 public StyleableProperty<Paint> getStyleableProperty(JabRefIconView node) {
-                    return node.iconColor;
+                    return node.color;
                 }
             };
 
@@ -56,14 +54,14 @@ public class JabRefIconView extends Group {
 
     static {
         List<CssMetaData<? extends Styleable, ?>> metaData = new ArrayList<>(Group.getClassCssMetaData());
-        metaData.add(ICON_COLOR);
+        metaData.add(COLOR);
         CSS_META_DATA = Collections.unmodifiableList(metaData);
     }
 
     /// CSS-styleable color, fed by `-fx-icon-color` rules (e.g. an inline `style="-fx-icon-color: ..."`).
-    /// Forwarded to an SVG child as a user-origin color.
-    private final StyleableObjectProperty<Paint> iconColor =
-            new SimpleStyleableObjectProperty<>(ICON_COLOR, this, "iconColor");
+    /// Forwarded to an SVG child as a fixed color.
+    private final StyleableObjectProperty<Paint> color =
+            new SimpleStyleableObjectProperty<>(COLOR, this, "iconColor");
 
     /// This property is only needed to get proper IDE support in FXML files
     /// (e.g. validation that parameter passed to "icon" is indeed of type [IconTheme.JabRefIcons]).
@@ -90,7 +88,7 @@ public class JabRefIconView extends Group {
     private void initialize() {
         EasyBind.subscribe(glyph, _ -> updateGraphic());
         EasyBind.subscribe(glyphSize, _ -> updateGraphic());
-        EasyBind.subscribe(iconColor, _ -> applyColor());
+        EasyBind.subscribe(color, _ -> applyColor());
     }
 
     /// Rebuilds the hosted node from the current glyph, sized to the current glyph size. The icon applies the size
@@ -101,15 +99,16 @@ public class JabRefIconView extends Group {
         applyColor();
     }
 
-    /// Forwards an explicit [#iconColor] override to an SVG child. Applied as an inline style (INLINE origin)
-    /// rather than a programmatic set, so it beats the author `.glyph-icon { -fx-icon-color }` theme rule the child
-    /// also matches. When unset (the common case) the child colors itself from theme CSS, so it is left untouched.
+    /// Forwards an explicit [#color] override to an SVG child. [JabRefSvgIcon#setColor(Paint)] fixes the
+    /// color there, so it beats the author `.ikonli-font-icon { -fx-icon-color }` theme rule the child also matches.
+    /// When unset (the common case) the child colors itself from theme CSS, so it is left untouched.
     private void applyColor() {
-        Paint color = iconColor.get();
-        if ((color instanceof Color iconColorValue) && !getChildren().isEmpty()
+        Paint colorValue = color.get();
+        // Without an override the child colors itself from theme CSS. Pushing the null through would both paint
+        // nothing and pin the color to a code-set value, locking the theme out for good.
+        if ((colorValue != null) && !getChildren().isEmpty()
                 && (getChildren().getFirst() instanceof JabRefSvgIcon svgIcon)) {
-            // FIXME: Inline style should be removed eventually.
-            svgIcon.setStyle("-fx-icon-color: %s;".formatted(ColorUtil.toRGBCode(iconColorValue)));
+            svgIcon.setColor(colorValue);
         }
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/icon/JabRefSvgIcon.java
+++ b/jabgui/src/main/java/org/jabref/gui/icon/JabRefSvgIcon.java
@@ -5,13 +5,11 @@ import java.util.Collections;
 import java.util.List;
 
 import javafx.css.CssMetaData;
-import javafx.css.SimpleStyleableObjectProperty;
+import javafx.css.StyleOrigin;
 import javafx.css.Styleable;
-import javafx.css.StyleableObjectProperty;
 import javafx.css.StyleableProperty;
 import javafx.css.converter.PaintConverter;
 import javafx.css.converter.SizeConverter;
-import javafx.scene.Parent;
 import javafx.scene.paint.Paint;
 
 import tools.maran.svgnode.SvgNode;
@@ -34,14 +32,18 @@ public class JabRefSvgIcon extends SvgNode {
 
     private static final CssMetaData<JabRefSvgIcon, Paint> ICON_COLOR =
             new CssMetaData<>("-fx-icon-color", PaintConverter.getInstance()) {
+                /// A color set from code -- [SvgIcon#withColor], or an `-fx-icon-color` forwarded by
+                /// [JabRefIconView] -- has to outlive the next CSS pass. JavaFX lets an author stylesheet win
+                /// over a programmatic value, so the theme's `.ikonli-font-icon { -fx-icon-color }` rule would
+                /// otherwise repaint the icon; withholding the property is the way to keep it.
                 @Override
                 public boolean isSettable(JabRefSvgIcon node) {
-                    return !node.iconColor.isBound();
+                    return node.colorProperty().getStyleOrigin() != StyleOrigin.USER && !node.colorProperty().isBound();
                 }
 
                 @Override
                 public StyleableProperty<Paint> getStyleableProperty(JabRefSvgIcon node) {
-                    return node.iconColor;
+                    return node.colorProperty();
                 }
             };
 
@@ -49,12 +51,12 @@ public class JabRefSvgIcon extends SvgNode {
             new CssMetaData<>("-fx-icon-size", SizeConverter.getInstance()) {
                 @Override
                 public boolean isSettable(JabRefSvgIcon node) {
-                    return !node.iconSize.isBound();
+                    return !node.sizeProperty().isBound();
                 }
 
                 @Override
                 public StyleableProperty<Number> getStyleableProperty(JabRefSvgIcon node) {
-                    return node.iconSize;
+                    return node.sizeProperty();
                 }
             };
 
@@ -62,12 +64,12 @@ public class JabRefSvgIcon extends SvgNode {
             new CssMetaData<>("-glyph-size", SizeConverter.getInstance()) {
                 @Override
                 public boolean isSettable(JabRefSvgIcon node) {
-                    return !node.glyphSize.isBound();
+                    return !node.sizeProperty().isBound();
                 }
 
                 @Override
                 public StyleableProperty<Number> getStyleableProperty(JabRefSvgIcon node) {
-                    return node.glyphSize;
+                    return node.sizeProperty();
                 }
             };
 
@@ -75,19 +77,19 @@ public class JabRefSvgIcon extends SvgNode {
             new CssMetaData<>("-fx-font-size", SizeConverter.getInstance()) {
                 @Override
                 public boolean isSettable(JabRefSvgIcon node) {
-                    return !node.fontSize.isBound();
+                    return !node.sizeProperty().isBound();
                 }
 
                 @Override
                 public StyleableProperty<Number> getStyleableProperty(JabRefSvgIcon node) {
-                    return node.fontSize;
+                    return node.sizeProperty();
                 }
             };
 
     private static final List<CssMetaData<? extends Styleable, ?>> CSS_META_DATA;
 
     static {
-        List<CssMetaData<? extends Styleable, ?>> metaData = new ArrayList<>(Parent.getClassCssMetaData());
+        List<CssMetaData<? extends Styleable, ?>> metaData = new ArrayList<>(SvgNode.getClassCssMetaData());
         metaData.add(ICON_COLOR);
         metaData.add(GLYPH_SIZE);
         metaData.add(ICON_SIZE);
@@ -95,67 +97,9 @@ public class JabRefSvgIcon extends SvgNode {
         CSS_META_DATA = Collections.unmodifiableList(metaData);
     }
 
-    private final StyleableObjectProperty<Paint> iconColor =
-            new SimpleStyleableObjectProperty<>(ICON_COLOR, this, "iconColor") {
-                @Override
-                protected void invalidated() {
-                    Paint color = get();
-                    if (color != null) {
-                        setColor(color);
-                    }
-                }
-            };
-
-    private final StyleableObjectProperty<Number> iconSize =
-            new SimpleStyleableObjectProperty<>(ICON_SIZE, this, "iconSize") {
-                @Override
-                protected void invalidated() {
-                    updateSize();
-                }
-            };
-
-    private final StyleableObjectProperty<Number> glyphSize =
-            new SimpleStyleableObjectProperty<>(GLYPH_SIZE, this, "glyphSize") {
-                @Override
-                protected void invalidated() {
-                    updateSize();
-                }
-            };
-
-    private final StyleableObjectProperty<Number> fontSize =
-            new SimpleStyleableObjectProperty<>(FONT_SIZE, this, "fontSize") {
-                @Override
-                protected void invalidated() {
-                    updateSize();
-                }
-            };
-
     public JabRefSvgIcon(String path, double size) {
         super(path, size);
         getStyleClass().addAll("glyph-icon", "ikonli-font-icon");
-    }
-
-    /// Applies the CSS-resolved size, preferring an explicit `-fx-icon-size` over an em `-fx-font-size`.
-    /// When neither is set by CSS, the constructor/programmatic size is left untouched.
-    private void updateSize() {
-        Number size = iconSize.get() != null ? iconSize.get() : glyphSize.get() != null ? glyphSize.get() : fontSize.get();
-        if (size != null) {
-            setSize(size.doubleValue());
-        }
-    }
-
-    /// Sets the icon color directly (user origin). Overrides any color coming from a stylesheet, so it is the
-    /// right entry point for an explicit, programmatic color (e.g. [SvgIcon#withColor]).
-    public void setIconColor(Paint color) {
-        iconColor.set(color);
-    }
-
-    public Paint getIconColor() {
-        return iconColor.get();
-    }
-
-    public StyleableObjectProperty<Paint> iconColorProperty() {
-        return iconColor;
     }
 
     public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {

--- a/jabgui/src/main/java/org/jabref/gui/icon/SvgIcon.java
+++ b/jabgui/src/main/java/org/jabref/gui/icon/SvgIcon.java
@@ -30,10 +30,8 @@ public final class SvgIcon implements JabRefIcon {
     @Override
     public Node getGraphicNode() {
         JabRefSvgIcon node = new JabRefSvgIcon(svgPath, size);
-        // Explicit color (via withColor/disabled) is a user-origin value, so it wins over theme CSS. When absent,
-        // the node's `glyph-icon`/`ikonli-font-icon` classes let theme `-fx-icon-color` rules drive the color.
         if (color != null) {
-            node.setIconColor(color);
+            node.setColor(color);
         }
         return node;
     }

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogView.java
@@ -56,7 +56,8 @@ import org.controlsfx.control.textfield.CustomTextField;
 
 public class StyleSelectDialogView extends BaseDialog<OOStyle> {
 
-    private static final String PANDOC_WARNING_LABEL_STYLE = "-fx-text-fill: #c9a227;";
+    /// Turns [#bstPandocWarning] into a warning; without it the label reads as a plain hint.
+    private static final String WARNING_STYLE_CLASS = "text-warning";
 
     private final MenuItem edit = new MenuItem(Localization.lang("Edit"));
     private final MenuItem reload = new MenuItem(Localization.lang("Reload"));
@@ -334,13 +335,13 @@ public class StyleSelectDialogView extends BaseDialog<OOStyle> {
         if (StringUtil.isBlank(pandocPath)) {
             bstPandocWarning.setText(
                     Localization.lang("Pandoc path is required to be set. Please set it in your preferences."));
-            // FIXME: Inline style should be removed eventually.
-            bstPandocWarning.setStyle(PANDOC_WARNING_LABEL_STYLE);
+            if (!bstPandocWarning.getStyleClass().contains(WARNING_STYLE_CLASS)) {
+                bstPandocWarning.getStyleClass().add(WARNING_STYLE_CLASS);
+            }
         } else {
             bstPandocWarning.setText(
                     Localization.lang("Pandoc path: %0", pandocPath));
-            // FIXME: Inline style should be removed eventually.
-            bstPandocWarning.setStyle("");
+            bstPandocWarning.getStyleClass().remove(WARNING_STYLE_CLASS);
         }
 
         bstNameColumn.setCellValueFactory(cellData -> cellData.getValue().nameProperty());

--- a/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTab.java
@@ -127,7 +127,6 @@ public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> {
     private Spinner<Integer> buildFontSizeSpinner() {
         Spinner<Integer> fontSize = new Spinner<>();
         fontSize.setValueFactory(GeneralTabViewModel.fontSizeValueFactory);
-        fontSize.getStyleClass().add("fontsizeSpinner");
         fontSize.setEditable(true);
         fontSize.setMaxWidth(100.0);
         fontSize.getEditor().setAlignment(Pos.CENTER_RIGHT);

--- a/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTabViewModel.java
@@ -58,7 +58,7 @@ import de.saxsys.mvvmfx.utils.validation.Validator;
 public class GeneralTabViewModel implements PreferenceTabViewModel {
 
     protected static SpinnerValueFactory<Integer> fontSizeValueFactory =
-            new SpinnerValueFactory.IntegerSpinnerValueFactory(9, Integer.MAX_VALUE);
+            new SpinnerValueFactory.IntegerSpinnerValueFactory(8, 20);
 
     private final ReadOnlyListProperty<Language> languagesListProperty =
             new ReadOnlyListWrapper<>(FXCollections.observableArrayList(Language.getSorted()));
@@ -148,11 +148,13 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
         fontSizeValidator = new FunctionBasedValidator<>(
                 fontSizeProperty,
                 _ -> {
+                    int fontSize;
                     try {
-                        return Integer.parseInt(fontSizeProperty().getValue()) > 8;
+                        fontSize = Integer.parseInt(fontSizeProperty().get());
                     } catch (NumberFormatException ex) {
                         return false;
                     }
+                    return fontSize >= 8 && fontSize <= 20;
                 },
                 ValidationMessage.error("%s > %s %n %n %s".formatted(
                         Localization.lang("General"),

--- a/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
@@ -108,13 +108,10 @@ public class ThemeManager {
     }
 
     private void updateFontStyleForScene(@NonNull Scene scene) {
+        scene.getRoot().getStyleClass().removeIf(str -> str.startsWith("font-size-"));
         if (workspacePreferences.shouldOverrideDefaultFontSize()) {
             LOGGER.debug("Overriding font size with user preference to {}pt", workspacePreferences.getMainFontSize());
-            scene.getRoot().setStyle("-fx-font-size: " + workspacePreferences.getMainFontSize() + "pt;");
-        } else {
-            int mainFontSize = WorkspacePreferences.getDefault().getMainFontSize();
-            LOGGER.debug("Using default font size of {}pt", mainFontSize);
-            scene.getRoot().setStyle("-fx-font-size: " + mainFontSize + "pt;");
+            scene.getRoot().getStyleClass().add("font-size-" + workspacePreferences.getMainFontSize());
         }
     }
 

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -72,6 +72,20 @@
 .italic { -fx-font-style: italic; }
 .font-monospace { -fx-font-family: monospace; }
 
+.font-size-8 > * { -fx-font-size: 8pt; }
+.font-size-9 > * { -fx-font-size: 9pt; }
+.font-size-10 > * { -fx-font-size: 10pt; }
+.font-size-11 > * { -fx-font-size: 11pt; }
+.font-size-12 > * { -fx-font-size: 12pt; }
+.font-size-13 > * { -fx-font-size: 13pt; }
+.font-size-14 > * { -fx-font-size: 14pt; }
+.font-size-15 > * { -fx-font-size: 15pt; }
+.font-size-16 > * { -fx-font-size: 16pt; }
+.font-size-17 > * { -fx-font-size: 17pt; }
+.font-size-18 > * { -fx-font-size: 18pt; }
+.font-size-19 > * { -fx-font-size: 19pt; }
+.font-size-20 > * { -fx-font-size: 20pt; }
+
 /* Text color. Both properties are set so the same class works on a Label
    (-fx-text-fill), on a Text node inside a TextFlow and on an icon (-fx-fill). */
 .text-accent { -fx-text-fill: -color-accent; -fx-fill: -color-accent; }
@@ -121,6 +135,11 @@
 /* Surface */
 .bg-transparent { -fx-background-color: transparent; }
 .bordered { -fx-border-width: 1; -fx-border-color: -color-border-default; }
+
+.root {
+    /* Default JabRef font size. */
+    -fx-font-size: 9pt;
+}
 
 /* JavaFX with custom components */
 .tab-pane > .tab-header-area > .headers-region > .tab .glyph-icon,

--- a/jabgui/src/test/java/org/jabref/gui/theme/ThemeTokenContractTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/theme/ThemeTokenContractTest.java
@@ -5,11 +5,15 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import javafx.collections.ObservableList;
 import javafx.css.CssParser;
@@ -35,6 +39,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 /// 2. Every theme must declare every token that is used, otherwise JavaFX falls back to a default
 ///    and the control silently loses its color.
 /// 3. Every token a theme declares must be read by someone.
+///
+/// The fourth one is not about the stylesheets at all: nothing may set an inline style, because an inline
+/// style outranks every stylesheet and would put the color out of the theme's reach for good.
 @AllowedToUseClassGetResource("JavaFX internally handles the passed URLs properly.")
 class ThemeTokenContractTest {
 
@@ -74,6 +81,16 @@ class ThemeTokenContractTest {
 
     /// Primer's raw color ramps -- `-color-base-0` - `-color-base-9`.
     private static final Pattern PALETTE_RAMP = Pattern.compile("-color-(?:base|accent|success|warning|danger)-[0-9]|-color-(?:dark|light)");
+
+    /// All modules holding Java sources and FXML files that may build a scene graph.
+    private static final List<String> MODULES = List.of("jablib", "jabkit", "jabsrv", "jabgui", "jabls");
+
+    /// JavaFX's three entry points to a node's inline style.
+    private static final Pattern INLINE_STYLE_API = Pattern.compile(
+            "\\.(?:setStyle\\s*\\(|getStyle\\s*\\(\\s*\\)|styleProperty\\s*\\(\\s*\\))");
+
+    /// FXML's inline style, the same thing spelled declaratively.
+    private static final Pattern INLINE_STYLE_ATTRIBUTE = Pattern.compile("\\sstyle\\s*=\\s*\"");
 
     @BeforeEach
     void beforeEach() {
@@ -200,6 +217,50 @@ class ThemeTokenContractTest {
                     "%s declares -color- tokens for 'prefers-color-scheme: %s' that no stylesheet reads"
                             .formatted(themeCss, colorScheme));
         }
+    }
+
+    /// Walks `src/main/<sourceSet>` of every module and reports every line matching `forbidden`.
+    ///
+    /// @return `<module>/<path>:<line>: <line content>` for each hit, in file order
+    private static List<String> matchesInSources(String sourceSet, String extension, Pattern forbidden) throws IOException {
+        List<String> matches = new ArrayList<>();
+        for (String module : MODULES) {
+            Path root = Path.of("..", module, "src", "main", sourceSet).normalize();
+            if (!Files.isDirectory(root)) {
+                continue;
+            }
+            // Files.walk holds a directory handle, thus the stream needs to be closed
+            try (Stream<Path> paths = Files.walk(root)) {
+                for (Path path : paths.filter(candidate -> candidate.toString().endsWith(extension)).toList()) {
+                    List<String> lines = Files.readAllLines(path, StandardCharsets.UTF_8);
+                    for (int line = 0; line < lines.size(); line++) {
+                        if (forbidden.matcher(lines.get(line)).find()) {
+                            matches.add("%s:%d: %s".formatted(path, line + 1, lines.get(line).strip()));
+                        }
+                    }
+                }
+            }
+        }
+        return matches;
+    }
+
+    /// An inline style is applied with INLINE origin, which outranks the author stylesheets a theme is made of.
+    /// A control styled that way therefore keeps its hardcoded color in every theme and in both color schemes --
+    /// the failure this whole token set exists to prevent. Style classes and `-color-*` tokens are the way in.
+    ///
+    /// There is no exception: even the user's main font size goes through a `font-size-<n>` class.
+    @Test
+    void noSourceFileUsesTheInlineStyleApi() throws IOException {
+        assertEquals(List.of(), matchesInSources("java", ".java", INLINE_STYLE_API),
+                "an inline style cannot be themed: give the node a style class and let the stylesheets color it");
+    }
+
+    /// The declarative half of [#noSourceFileUsesTheInlineStyleApi]: `style="..."` in FXML is the same INLINE
+    /// origin, just written in the layout instead of in code.
+    @Test
+    void noFxmlFileUsesTheInlineStyleAttribute() throws IOException {
+        assertEquals(List.of(), matchesInSources("resources", ".fxml", INLINE_STYLE_ATTRIBUTE),
+                "an inline style cannot be themed: use styleClass and let the stylesheets color it");
     }
 
     @Test


### PR DESCRIPTION
### Summary

Removes all remaining `setStyle`, `styleProperty` and `getStyle` calls.
No inline styles anymore in JabRef.

Also replacing the way we apply the `font-size`. Should be a bit faster and bonus: we only add a styleClass when we are not the default.

Tests that nobody can add inline styles again.

### Steps to test

Open JabRef

### Related issues and pull requests

Works towards: https://github.com/JabRef/jabref/issues/16787
Really closed: https://github.com/JabRef/jabref/issues/15721 once and for all.

### AI usage

Not used.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
