### PR TITLE
Trim whitespaces from the field name in the Jump-to-field dialog

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/JumpToFieldDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/JumpToFieldDialog.java
@@ -83,7 +83,7 @@ public class JumpToFieldDialog extends BaseDialog<Void> {
         String selectedField = searchField.getText();
 
         if (selectedField != null && !selectedField.isEmpty()) {
-            String fieldToJumpTo = selectedField.toLowerCase();
+            String fieldToJumpTo = selectedField.toLowerCase().strip();
             entryEditor.selectField(fieldToJumpTo);
         }
     }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/JumpToFieldDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/JumpToFieldDialog.java
@@ -12,6 +12,7 @@ import javafx.scene.control.TextField;
 
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.util.strings.StringUtil;
 
 import com.airhacks.afterburner.views.ViewLoader;
 import org.controlsfx.control.textfield.AutoCompletionBinding;
@@ -82,7 +83,7 @@ public class JumpToFieldDialog extends BaseDialog<Void> {
     private void jumpToSelectedField() {
         String selectedField = searchField.getText();
 
-        if (selectedField != null && !selectedField.isEmpty()) {
+        if (StringUtil.isNotBlank(selectedField)) {
             String fieldToJumpTo = selectedField.toLowerCase().strip();
             entryEditor.selectField(fieldToJumpTo);
         }


### PR DESCRIPTION
### Summary

The dialog now normalizes the field name by stripping surrounding whitespace before passing it on.
This matters because the dialog accepts free text, and a name a user mistypes by adding an extra space (e.g., "author " or " title") would be built into an UnknownField whose name contains the whitespace

`jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

1. Open an entry in the entry editor.
2. Press Ctrl+J to open the "Jump to field" dialog.
3. Type a field name followed by a trailing space (e.g. author ), then press Enter.
4. Expected: focus lands on the author field.

### Related issues and pull requests

Follow-up to #16639 

### AI usage
NA
_____

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [ ] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
