### PR TITLE
Improve AboutDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
+- We redesigned the "About JabRef" dialog. [#16950](https://github.com/JabRef/jabref/pull/16950)
 - We removed the keystore fields, the server timezone, and the database type selection from the "Connect to shared database" dialog. [#16800](https://github.com/JabRef/jabref/pull/16800)
 - We changed remembered shared database passwords to use the operating system credential store. [#16800](https://github.com/JabRef/jabref/pull/16800)
 - We changed undo and redo to name the step they take back instead of only saying "Undo". [#16936](https://github.com/JabRef/jabref/pull/16936)
@@ -127,6 +128,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ### Fixed
 
 - We fixed an issue where an author list ending with "et al." was parsed as a person named "et al." instead of "and others". [#16937](https://github.com/JabRef/jabref/pull/16937)
+- We fixed an issue where dialog buttons cut off their text at a larger font size. [#16787](https://github.com/JabRef/jabref/issues/16787)
 - We fixed an issue where main table columns could not be resized while "Fit table horizontally on screen" was enabled. Resizing a column now adjusts only the columns to its right, and column widths keep their proportions when the window is resized. [#10516](https://github.com/JabRef/jabref/issues/10516)
 - We fixed an issue where entries imported in the background could not be selected or updated in the main table. [#16893](https://github.com/JabRef/jabref/pull/16893)
 - We fixed an issue where editing a library's string constants could not be undone. [#16936](https://github.com/JabRef/jabref/pull/16936)

--- a/jabgui/src/main/java/org/jabref/gui/FXDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/FXDialog.java
@@ -1,10 +1,12 @@
 package org.jabref.gui;
 
 import javafx.scene.control.Alert;
+import javafx.scene.control.DialogPane;
 import javafx.scene.image.Image;
 import javafx.scene.input.KeyEvent;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
 
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.BaseDialog;
@@ -42,22 +44,32 @@ public class FXDialog extends Alert {
     public FXDialog(AlertType type, boolean isModal) {
         super(type);
 
+        dialogPaneProperty().addListener((_, _, newPane) -> {
+            if (newPane != null) {
+                setupKeyBindings(newPane);
+            }
+        });
+        setupKeyBindings(getDialogPane());
+
         setDialogIcon(IconTheme.getJabRefIcon());
 
         Stage dialogWindow = getDialogWindow();
-        dialogWindow.setOnCloseRequest(evt -> this.close());
+        dialogWindow.addEventHandler(WindowEvent.WINDOW_SHOWN, _ -> BaseDialog.fitWindowToContent(this.getDialogPane()));
+        dialogWindow.setOnCloseRequest(_ -> this.close());
+
         if (isModal) {
             initModality(Modality.APPLICATION_MODAL);
         } else {
             initModality(Modality.NONE);
         }
-
-        getDialogPane().addEventHandler(KeyEvent.KEY_PRESSED, event -> BaseDialog.closeOnKeyBindingMatch(event, this));
-        setOnShown(_ -> BaseDialog.applyButtonFix(this.getDialogPane()));
     }
 
     public FXDialog(AlertType type) {
         this(type, true);
+    }
+
+    private void setupKeyBindings(DialogPane newPane) {
+        newPane.addEventHandler(KeyEvent.KEY_PRESSED, event -> BaseDialog.closeOnKeyBindingMatch(event, this));
     }
 
     private void setDialogIcon(Image image) {

--- a/jabgui/src/main/java/org/jabref/gui/backup/BackupResolverDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/backup/BackupResolverDialog.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Hyperlink;
+import javafx.scene.layout.StackPane;
 
 import org.jabref.gui.FXDialog;
 import org.jabref.gui.desktop.os.NativeDesktop;
@@ -59,6 +60,6 @@ public class BackupResolverDialog extends FXDialog {
                 }
             }
         });
-        getDialogPane().setContent(contentLabel);
+        getDialogPane().setContent(new StackPane(contentLabel));
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/help/AboutDialogViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/help/AboutDialogViewModel.java
@@ -29,7 +29,7 @@ public class AboutDialogViewModel extends AbstractViewModel {
     private final String versionInfo;
     private final ReadOnlyStringWrapper environmentInfo = new ReadOnlyStringWrapper();
     private final Logger logger = LoggerFactory.getLogger(AboutDialogViewModel.class);
-    private final ReadOnlyStringWrapper heading = new ReadOnlyStringWrapper();
+    private final ReadOnlyStringWrapper version = new ReadOnlyStringWrapper();
     private final ReadOnlyStringWrapper maintainers = new ReadOnlyStringWrapper();
     private final ReadOnlyStringWrapper license = new ReadOnlyStringWrapper();
     private final ReadOnlyBooleanWrapper isDevelopmentVersion = new ReadOnlyBooleanWrapper();
@@ -45,14 +45,14 @@ public class AboutDialogViewModel extends AbstractViewModel {
         this.dialogService = dialogService;
         this.preferences = preferences;
         this.clipBoardManager = clipBoardManager;
-        String[] version = buildInfo.version.getFullVersion().split("--");
-        heading.set("JabRef " + version[0]);
+        String[] versionParts = buildInfo.version.getFullVersion().split("--");
+        version.set(Localization.lang("Version") + " " + versionParts[0]);
 
-        if (version.length == 1) {
+        if (versionParts.length == 1) {
             isDevelopmentVersion.set(false);
         } else {
             isDevelopmentVersion.set(true);
-            String dev = new ArrayList<>(Arrays.asList(version)).stream().filter(string -> !string.equals(version[0])).collect(
+            String dev = new ArrayList<>(Arrays.asList(versionParts)).stream().filter(string -> !string.equals(versionParts[0])).collect(
                     Collectors.joining("--"));
             developmentVersion.set(dev);
         }
@@ -94,12 +94,12 @@ public class AboutDialogViewModel extends AbstractViewModel {
         return maintainers.get();
     }
 
-    public ReadOnlyStringProperty headingProperty() {
-        return heading.getReadOnlyProperty();
+    public ReadOnlyStringProperty versionProperty() {
+        return version.getReadOnlyProperty();
     }
 
-    public String getHeading() {
-        return heading.get();
+    public String getVersion() {
+        return version.get();
     }
 
     public ReadOnlyStringProperty licenseProperty() {

--- a/jabgui/src/main/java/org/jabref/gui/util/BaseDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/util/BaseDialog.java
@@ -2,9 +2,11 @@ package org.jabref.gui.util;
 
 import java.util.Optional;
 
+import javafx.application.Platform;
 import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
 import javafx.scene.control.Button;
-import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.DialogPane;
@@ -14,6 +16,7 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import javafx.stage.Stage;
 import javafx.stage.Window;
+import javafx.stage.WindowEvent;
 
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.keyboard.KeyBinding;
@@ -31,9 +34,11 @@ public class BaseDialog<T> extends Dialog<T> {
         });
         setupKeyBindings(getDialogPane());
 
-        setOnShown(_ -> applyButtonFix(this.getDialogPane()));
-
         setDialogIcon(IconTheme.getJabRefIcon());
+
+        Stage dialogWindow = getDialogWindow();
+        dialogWindow.addEventHandler(WindowEvent.WINDOW_SHOWN, _ -> fitWindowToContent(this.getDialogPane()));
+
         setResizable(true);
     }
 
@@ -49,27 +54,33 @@ public class BaseDialog<T> extends Dialog<T> {
         return false;
     }
 
-    private void setupKeyBindings(DialogPane dialogPane) {
-        dialogPane.addEventHandler(KeyEvent.KEY_PRESSED, event -> {
-            boolean closed = closeOnKeyBindingMatch(event, this);
-            if (closed) {
-                return;
-            }
+    private Stage getDialogWindow() {
+        return (Stage) getDialogPane().getScene().getWindow();
+    }
 
-            KeyBindingRepository keyBindingRepository = Injector.instantiateModelOrService(KeyBindingRepository.class);
-            if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.DEFAULT_DIALOG_ACTION, event)) {
-                getDefaultButton().ifPresent(Button::fire);
+    private void setupKeyBindings(DialogPane dialogPane) {
+        dialogPane.addEventHandler(KeyEvent.KEY_PRESSED, this::handleKeyEvent);
+    }
+
+    private void handleKeyEvent(KeyEvent event) {
+        boolean closed = closeOnKeyBindingMatch(event, this);
+        if (closed) {
+            return;
+        }
+
+        KeyBindingRepository keyBindingRepository = Injector.instantiateModelOrService(KeyBindingRepository.class);
+        if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.DEFAULT_DIALOG_ACTION, event)) {
+            getDefaultButton().ifPresent(Button::fire);
+            event.consume();
+        }
+
+        // all buttons in base dialogs react on enter
+        if (event.getCode() == KeyCode.ENTER) {
+            if (event.getTarget() instanceof Button button) {
+                button.fire();
                 event.consume();
             }
-
-            // all buttons in base dialogs react on enter
-            if (event.getCode() == KeyCode.ENTER) {
-                if (event.getTarget() instanceof Button button) {
-                    button.fire();
-                    event.consume();
-                }
-            }
-        });
+        }
     }
 
     private Optional<Button> getDefaultButton() {
@@ -88,34 +99,46 @@ public class BaseDialog<T> extends Dialog<T> {
         dialogWindow.getIcons().add(image);
     }
 
-    /// Applies a fix to prevent truncating ButtonBar buttons with larger font sizes
-    public static void applyButtonFix(DialogPane pane) {
-        // Force the window to fit the new font content bounds
-        if (pane.getScene() != null && pane.getScene().getWindow() != null) {
-            pane.getScene().getWindow().sizeToScene();
-        }
-
+    /// Fits the dialog window around its content.
+    public static void fitWindowToContent(DialogPane pane) {
         for (ButtonType type : pane.getButtonTypes()) {
-            Node node = pane.lookupButton(type);
-            if (node instanceof Button button) {
-                // Disabling uniform size prevents the ButtonBar from squeezing
-                // buttons into a width that is slightly too small for 10pt or larger text.
-
-                ButtonBar.setButtonUniformSize(button, false);
-                button.setMinWidth(Region.USE_PREF_SIZE);
-                button.setMaxWidth(Double.MAX_VALUE);
-
-                // Re-trigger CSS to ensure prefWidth is calculated using the new font metrics
-                button.applyCss();
+            if (pane.lookupButton(type) instanceof Button button) {
+                // The button bar squeezes buttons into a width that is too small for a raised font size.
+                button.setPrefWidth(Region.USE_COMPUTED_SIZE);
             }
         }
 
-        pane.requestLayout();
+        // The new sizes are only known after the pane has been laid out again.
+        Platform.runLater(() -> sizeDialog(pane));
+    }
+
+    /// Reapplies CSS and relayout the dialog again.
+    private static void sizeDialog(DialogPane pane) {
+        Scene scene = pane.getScene();
+        if (scene == null || !(scene.getWindow() instanceof Stage stage)) {
+            return;
+        }
+        clearSizeCache(pane);
+
+        pane.applyCss();
+        pane.layout();
+
+        // Now that the sizes are the ones of the font the dialog is rendered in, the window can be
+        // fitted around its content again.
+        stage.sizeToScene();
+    }
+
+    private static void clearSizeCache(Parent parent) {
+        parent.requestLayout();
+        for (Node child : parent.getChildrenUnmodifiable()) {
+            if (child instanceof Parent childParent) {
+                clearSizeCache(childParent);
+            }
+        }
     }
 
     public static void bringToFront(Dialog<?> dialog) {
         // Using answers from: <https://stackoverflow.com/a/43007782> and <https://stackoverflow.com/a/48798192>.
-
         Window window = dialog.getDialogPane().getScene().getWindow();
         if (window instanceof Stage stage) {
             stage.setAlwaysOnTop(true);

--- a/jabgui/src/main/java/org/jabref/gui/welcome/components/DonationProvider.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/components/DonationProvider.java
@@ -71,42 +71,40 @@ public class DonationProvider {
         VBox textBox = new VBox(4, title, subtitle);
 
         Node iconNode = IconTheme.JabRefIcons.DONATE.getGraphicNode();
-        HBox leftContent = new HBox(10, iconNode, textBox);
+        HBox leftContent = new HBox(4, iconNode, textBox);
         leftContent.setAlignment(Pos.CENTER_LEFT);
 
         Button neverButton = new Button(Localization.lang("Never show again"));
-        neverButton.getStyleClass().addAll("donation-btn-ghost", "padding-4-12");
+        neverButton.getStyleClass().addAll("btn-transparent");
         neverButton.setOnAction(_ -> {
             preferences.getDonationPreferences().setNeverShowAgain(true);
             hideToast();
         });
 
         Button cancelButton = new Button(Localization.lang("Cancel"));
-        cancelButton.getStyleClass().addAll("donation-btn-secondary", "padding-4-12");
+        cancelButton.getStyleClass().addAll("bg-secondary");
         cancelButton.setOnAction(_ -> hideToast());
 
         Button donateButton = new Button(Localization.lang("Donate"));
-        donateButton.getStyleClass().addAll("donation-btn-primary", "padding-4-12");
         donateButton.setDefaultButton(true);
         donateButton.setOnAction(_ -> {
             new OpenBrowserAction(DONATION_URL, dialogService, preferences.getExternalApplicationsPreferences()).execute();
             hideToast();
         });
 
-        HBox rightButtons = new HBox(8, neverButton, cancelButton, donateButton);
+        HBox rightButtons = new HBox(4, neverButton, cancelButton, donateButton);
         rightButtons.setAlignment(Pos.CENTER_RIGHT);
 
         Region textSpacer = new Region();
         HBox.setHgrow(textSpacer, Priority.ALWAYS);
 
-        donationToast = new HBox(12, leftContent, textSpacer, rightButtons);
+        donationToast = new HBox(4, leftContent, textSpacer, rightButtons);
         donationToast.getStyleClass().addAll("donation-toast", "padding-12", "align-center-left");
         donationToast.setMaxWidth(Region.USE_PREF_SIZE);
         donationToast.setMinWidth(Region.USE_PREF_SIZE);
-        donationToast.setTranslateY(-40);
 
         StackPane.setAlignment(donationToast, Pos.TOP_CENTER);
-        StackPane.setMargin(donationToast, new Insets(16));
+        StackPane.setMargin(donationToast, new Insets(8));
         rootPane.getChildren().add(donationToast);
 
         TranslateTransition slideDown = new TranslateTransition(Duration.millis(DONATION_POPUP_ANIM_MS), donationToast);

--- a/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
@@ -28,7 +28,7 @@
                 <RowConstraints vgrow="ALWAYS"/>
             </rowConstraints>
 
-            <VBox spacing="8" styleClass="bg-accent,padding-8" GridPane.columnIndex="0" GridPane.rowIndex="0">
+            <VBox spacing="8" styleClass="bg-accent,padding-8,corner-radius" GridPane.columnIndex="0" GridPane.rowIndex="0">
                 <Button onAction="#openJabrefWebsite" styleClass="btn-transparent,padding-4">
                     <cursor>
                         <Cursor fx:constant="HAND"/>

--- a/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
@@ -1,97 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ButtonType?>
 <?import javafx.scene.control.DialogPane?>
 <?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextArea?>
-<?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.Cursor?>
-<?import javafx.scene.effect.Reflection?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.shape.SVGPath?>
-<DialogPane prefWidth="530.0" prefHeight="510.0"
-            xmlns="http://javafx.com/javafx/8.0.212" xmlns:fx="http://javafx.com/fxml/1"
-            fx:controller="org.jabref.gui.help.AboutDialogView"
-            id="aboutDialog">
+<?import tools.maran.svgnode.SvgNode?>
+<DialogPane xmlns="http://javafx.com/javafx/8.0.212" xmlns:fx="http://javafx.com/fxml/1"
+            prefWidth="800" prefHeight="700"
+            fx:controller="org.jabref.gui.help.AboutDialogView">
     <content>
-        <VBox alignment="CENTER_LEFT" BorderPane.alignment="CENTER">
-            <AnchorPane>
-                <VBox alignment="CENTER_LEFT" spacing="4.0" styleClass="padding-bottom-12"
-                      AnchorPane.leftAnchor="0" AnchorPane.topAnchor="0">
-                    <Label alignment="CENTER" contentDisplay="CENTER" onMouseClicked="#copyVersionToClipboard" styleClass="h1,about-heading,text-accent" text="${controller.viewModel.heading}" wrapText="true">
-                        <cursor>
-                            <Cursor fx:constant="HAND"/>
-                        </cursor>
-                        <tooltip>
-                            <Tooltip text="%Copy Version"/>
-                        </tooltip>
-                    </Label>
-                    <Label managed="${controller.viewModel.isDevelopmentVersion}" styleClass="dev-heading,h3"
-                           text="${controller.viewModel.developmentVersion}"
-                           visible="${controller.viewModel.isDevelopmentVersion}"/>
-                    <Hyperlink onAction="#openChangeLog" styleClass="padding-top-4" text="%What's new in this version?"/>
-                    <Label styleClass="filler"/>
-                    <HBox alignment="CENTER_LEFT">
-                        <Label styleClass="padding-right-4" text="${controller.viewModel.license}" wrapText="true"/>
-                        <Hyperlink onAction="#openLicense" text="MIT"/>
-                    </HBox>
-                    <Hyperlink onAction="#openPrivacyPolicy" text="Privacy Policy"/>
-                    <Hyperlink onAction="#openExternalLibrariesWebsite" text="%Used libraries"/>
-                    <HBox alignment="CENTER_LEFT">
-                        <Label styleClass="padding-right-4" text="%Want to help?" wrapText="true"/>
-                        <Hyperlink onAction="#openDonation" text="%Make a donation"/>
-                        <Label styleClass="padding-0-4" text="%or" wrapText="true"/>
-                        <Hyperlink onAction="#openGithub" text="%get involved"/>
-                        <Label text="."/>
-                    </HBox>
-                </VBox>
+        <GridPane vgap="4" hgap="4">
+            <columnConstraints>
+                <ColumnConstraints percentWidth="30"/>
+                <ColumnConstraints percentWidth="70"/>
+            </columnConstraints>
+            <rowConstraints>
+                <RowConstraints vgrow="ALWAYS"/>
+            </rowConstraints>
 
-                <StackPane onMouseClicked="#openJabrefWebsite"
-                           scaleX="0.6" scaleY="0.6" translateX="-26" translateY="-30" prefWidth="120" prefHeight="120"
-                           AnchorPane.rightAnchor="0" AnchorPane.topAnchor="0">
-                    <!-- SVGPaths need to be wrapped in a Pane to get them to the same size -->
-                    <Pane styleClass="logo-pane">
-                        <SVGPath content="M97.2 87.1C93.2 33.8 18.4 14.6 18.2 15.6c-0.1 6.7-0.3 13.3-0.4 20 17.8 3.6 61.7 20.1 79.4 51.5"/>
-                    </Pane>
-                    <Pane styleClass="logo-pane">
-                        <SVGPath content="M96.2 61.2C92.8 19.2 35.1 0.4 35 1c0 3.5-0.1 7-0.1 10.6 18.1 7.5 47.7 24.7 61.3 49.6"/>
-                    </Pane>
-                    <Pane styleClass="logo-pane">
-                        <SVGPath content="M67.1 65.2c-25.9-17.6-58.5-22.1-58.6-21.4-0.3 12.4-0.6 24.8-0.9 37.2 37.9 2.2 40.2 25.7 37.9 40.8l-39.1 12.6-1.9 69.5 68.7-26.6c8-3.3 16-6.4 24.1-9.3v-47.9c0-21.4-10.9-41.8-30.1-54.9"/>
-                    </Pane>
-                    <Pane styleClass="logo-pane">
-                        <SVGPath content="M107.8 87.1c3.9-53.2 78.8-72.5 78.9-71.5 0.1 6.7 0.3 13.3 0.4 20-17.8 3.6-61.7 20.1-79.4 51.5"/>
-                    </Pane>
-                    <Pane styleClass="logo-pane">
-                        <SVGPath content="M108.8 61.2c3.4-42.1 61.1-60.8 61.2-60.2 0 3.5 0.1 7 0.1 10.6-18.1 7.5-47.7 24.7-61.3 49.6"/>
-                    </Pane>
-                    <Pane styleClass="logo-pane">
-                        <SVGPath content="M137.9 65.2c25.9-17.6 58.5-22.1 58.6-21.4 0.3 12.4 0.6 24.8 0.9 37.2-37.9 2.2-40.2 25.7-37.9 40.8l39.1 12.6 1.9 69.5-68.7-26.6c-8-3.3-16-6.4-24.1-9.3v-47.9c0-21.4 10.9-41.8 30.1-54.9"/>
-                    </Pane>
-
+            <VBox spacing="8" styleClass="bg-accent,padding-8" GridPane.columnIndex="0" GridPane.rowIndex="0">
+                <Button onAction="#openJabrefWebsite" styleClass="btn-transparent,padding-4">
                     <cursor>
                         <Cursor fx:constant="HAND"/>
                     </cursor>
-                    <effect>
-                        <Reflection fraction="0.15"/>
-                    </effect>
-                </StackPane>
-            </AnchorPane>
-            <Label styleClass="h3,padding-4" text="%Maintainers"/>
-            <Label alignment="CENTER" styleClass="padding-4" prefHeight="100.0" text="${controller.viewModel.maintainers}" textAlignment="JUSTIFY" wrapText="true"/>
-            <Label styleClass="h3,padding-4" text="%Contributors"/>
-            <HBox alignment="CENTER_LEFT">
-                <Hyperlink styleClass="padding-4" onAction="#openContributors" text="%JabRef would not have been possible without the help of our contributors." wrapText="true"/>
-            </HBox>
-            <TextArea fx:id="textAreaVersions" editable="false" prefHeight="100.0" prefWidth="200.0" styleClass="padding-4"/>
-        </VBox>
+                    <graphic>
+                        <StackPane styleClass="bg-secondary,corner-radius,padding-4">
+                            <SvgNode size="80" styleClass="jabref-logo"
+                                     path="M97.2 87.1C93.2 33.8 18.4 14.6 18.2 15.6c-0.1 6.7-0.3 13.3-0.4 20 17.8 3.6 61.7 20.1 79.4 51.5 M96.2 61.2C92.8 19.2 35.1 0.4 35 1c0 3.5-0.1 7-0.1 10.6 18.1 7.5 47.7 24.7 61.3 49.6 M67.1 65.2c-25.9-17.6-58.5-22.1-58.6-21.4-0.3 12.4-0.6 24.8-0.9 37.2 37.9 2.2 40.2 25.7 37.9 40.8l-39.1 12.6-1.9 69.5 68.7-26.6c8-3.3 16-6.4 24.1-9.3v-47.9c0-21.4-10.9-41.8-30.1-54.9 M107.8 87.1c3.9-53.2 78.8-72.5 78.9-71.5 0.1 6.7 0.3 13.3 0.4 20-17.8 3.6-61.7 20.1-79.4 51.5 M108.8 61.2c3.4-42.1 61.1-60.8 61.2-60.2 0 3.5 0.1 7 0.1 10.6-18.1 7.5-47.7 24.7-61.3 49.6 M137.9 65.2c25.9-17.6 58.5-22.1 58.6-21.4 0.3 12.4 0.6 24.8 0.9 37.2-37.9 2.2-40.2 25.7-37.9 40.8l39.1 12.6 1.9 69.5-68.7-26.6c-8-3.3-16-6.4-24.1-9.3v-47.9c0-21.4 10.9-41.8 30.1-54.9"/>
+                        </StackPane>
+                    </graphic>
+                </Button>
+                <VBox spacing="4">
+                    <Label styleClass="h1,bold,text-emphasis" text="JabRef"/>
+                    <VBox spacing="4">
+                        <Label styleClass="text-emphasis,font-monospace" text="${controller.viewModel.version}"/>
+                        <Label managed="${controller.viewModel.isDevelopmentVersion}"
+                               styleClass="text-emphasis,font-monospace"
+                               text="${controller.viewModel.developmentVersion}"
+                               visible="${controller.viewModel.isDevelopmentVersion}"/>
+                    </VBox>
+                </VBox>
+                <VBox spacing="4">
+                    <Hyperlink onAction="#openChangeLog" styleClass="text-emphasis" text="%What's new in this version?"/>
+                    <HBox alignment="CENTER_LEFT" spacing="4">
+                        <Label styleClass="text-emphasis" text="${controller.viewModel.license}"/>
+                        <Hyperlink onAction="#openLicense" styleClass="text-emphasis" text="MIT"/>
+                    </HBox>
+                    <Hyperlink onAction="#openPrivacyPolicy" styleClass="text-emphasis" text="Privacy Policy"/>
+                    <Hyperlink onAction="#openExternalLibrariesWebsite" styleClass="text-emphasis" text="%Used libraries"/>
+                </VBox>
+                <Region VBox.vgrow="ALWAYS"/>
+                <VBox spacing="4">
+                    <Button maxWidth="Infinity" onAction="#openDonation" styleClass="text-emphasis" text="%Make a donation">
+                        <cursor>
+                            <Cursor fx:constant="HAND"/>
+                        </cursor>
+                    </Button>
+                    <Button maxWidth="Infinity" onAction="#openGithub" styleClass="text-emphasis" text="%Get involved">
+                        <cursor>
+                            <Cursor fx:constant="HAND"/>
+                        </cursor>
+                    </Button>
+                </VBox>
+            </VBox>
+
+            <VBox spacing="4" styleClass="bg-secondary,padding-8" GridPane.columnIndex="1" GridPane.rowIndex="0">
+                <VBox spacing="4">
+                    <Label styleClass="bold,text-accent" text="%Maintainers"/>
+                    <Label text="${controller.viewModel.maintainers}" wrapText="true"/>
+                </VBox>
+                <VBox spacing="4">
+                    <Label styleClass="bold,text-accent" text="%Contributors"/>
+                    <Hyperlink onAction="#openContributors" wrapText="true"
+                               text="%JabRef would not have been possible without the help of our contributors."/>
+                    <Label text="%Founded by Morten O. Alver and Nizar Batada."/>
+                </VBox>
+                <VBox spacing="4" VBox.vgrow="ALWAYS">
+                    <Label styleClass="bold,text-accent" text="%System"/>
+                    <TextArea fx:id="textAreaVersions" editable="false" styleClass="font-monospace" VBox.vgrow="ALWAYS"/>
+                </VBox>
+            </VBox>
+        </GridPane>
     </content>
-    <ButtonType fx:id="copyVersionButton" text="Copy Version" buttonData="LEFT"/>
+    <ButtonType fx:id="copyVersionButton" text="%Copy Version" buttonData="OTHER"/>
     <ButtonType fx:constant="CLOSE"/>
 </DialogPane>

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -96,6 +96,9 @@
 .text-warning { -fx-text-fill: -color-warning; -fx-fill: -color-warning; }
 .text-success { -fx-text-fill: -color-success; -fx-fill: -color-success; }
 
+.bg-accent { -fx-background: -color-accent; -fx-background-color: -color-accent; }
+.bg-secondary { -fx-background: -color-bg-secondary; -fx-background-color: -color-bg-secondary; }
+
 /* Padding: all sides */
 .padding-0 { -fx-padding: 0; }
 .padding-4 { -fx-padding: 0.333em; }
@@ -133,12 +136,21 @@
 .align-baseline-left { -fx-alignment: baseline-left; }
 
 /* Surface */
-.bg-transparent { -fx-background-color: transparent; }
+.bg-transparent { -fx-background: transparent; -fx-background-color: transparent; }
 .bordered { -fx-border-width: 1; -fx-border-color: -color-border-default; }
+.corner-radius { -fx-background-radius: 0.25em; }
 
 .root {
     /* Default JabRef font size. */
     -fx-font-size: 9pt;
+}
+
+.btn-transparent {
+    -fx-background: transparent;
+    -fx-background-color: -fx-background;
+    -fx-border-width: 0;
+    -fx-background-insets: 0;
+    -fx-background-radius: 0.25em;
 }
 
 /* JavaFX with custom components */
@@ -342,7 +354,6 @@
     -fx-background-color: transparent;
     -fx-fill: -color-selection;
 }
-
 
 .icon-button.no-space-bottom {
     -fx-padding: 0.5em 0.5em -0.1em 0.5em;
@@ -870,53 +881,9 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-max-height: 4em;
 }
 
-.donation-toast .label {
-    -fx-text-fill: -fx-text-base-color;
-}
-
-.donation-btn-primary,
-.donation-btn-secondary,
-.donation-btn-ghost {
-    -fx-background-radius: 0.5em;
-    -fx-border-radius: 0.5em;
-}
-
-.donation-btn-primary {
-    -fx-background-color: -color-accent;
-}
-
-.donation-btn-secondary {
-    -fx-background-color: derive(-color-bg-secondary, -6%);
-}
-
-.donation-btn-ghost {
-    -fx-background-color: transparent;
-    -fx-text-fill: -color-border-default;
-    -fx-stroke-width: 0;
-    -fx-border-width: 0
-}
-
-.donation-btn-ghost:hover {
-    -fx-background-color: transparent;
-    -fx-text-fill: -color-fg-subtle;
-}
-
-/* AboutDialog */
-#aboutDialog .about-heading:pressed {
-    -fx-text-fill: -color-selection;
-}
-
-/* Pulls the developer list up against its heading -- the spacing scale has no negative steps. */
-#aboutDialog .dev-heading {
-    -fx-padding: -0.833em 0 0 0;
-}
-
-#aboutDialog .logo-pane {
-    -fx-fill: transparent;
-}
-
-#aboutDialog .logo-pane SVGPath {
-    -fx-fill: -color-accent;
+/* The logo is a single SvgNode; its shape is filled with -fx-color, not -fx-fill. */
+.jabref-logo {
+    -fx-color: -color-accent;
 }
 
 /* DocumentViewer */
@@ -1431,10 +1398,6 @@ We want to have a look that matches our icons in the tool-bar */
 
 .exampleQuestionStyle:hover {
     -fx-background-color: -color-button-hover;
-}
-
-.refresh {
-    -fx-background-color: transparent;
 }
 
 .text-button-blue {

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -147,7 +147,7 @@
 
 .btn-transparent {
     -fx-background: transparent;
-    -fx-background-color: -fx-background;
+    -fx-background-color: transparent;
     -fx-border-width: 0;
     -fx-background-insets: 0;
     -fx-background-radius: 0.25em;

--- a/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
@@ -253,7 +253,7 @@
 /* JavaFX Button */
 .button {
     -fx-border-color: -color-button-border;
-    -fx-border-width: 0.062em;
+    -fx-border-width: 0.0625em;
     -fx-padding: 0.5em 1em 0.5em 1em;
 }
 

--- a/jabgui/src/test/java/org/jabref/gui/backup/BackupResolverDialogTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/backup/BackupResolverDialogTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.mock;
 @AllowedToUseClassGetResource("JavaFX internally handles the passed URLs properly.")
 class BackupResolverDialogTest extends ApplicationTest {
 
-    /// The class [org.jabref.gui.theme.ThemeManager] puts on a scene root for a user who raised the font size from the default 9pt.
     private static final String FONT_SIZE_CLASS = "font-size-12";
 
     private BackupResolverDialog backupResolverDialog;
@@ -93,17 +92,6 @@ class BackupResolverDialogTest extends ApplicationTest {
         double windowWidth = pane.getScene().getWindow().getWidth();
         assertTrue(windowWidth >= pane.prefWidth(-1),
                 "Window is %.1fpx wide, but its content needs %.1fpx".formatted(windowWidth, pane.prefWidth(-1)));
-    }
-
-    /// Without a minimum size, the window could be resized until its buttons are cut off again.
-    @Test
-    void windowCannotBeShrunkBelowItsContent() {
-        WaitForAsyncUtils.waitForFxEvents();
-
-        DialogPane pane = backupResolverDialog.getDialogPane();
-        Stage window = (Stage) pane.getScene().getWindow();
-        assertTrue(window.getMinWidth() >= pane.minWidth(-1),
-                "Window can be shrunk to %.1fpx, but its content needs %.1fpx".formatted(window.getMinWidth(), pane.minWidth(-1)));
     }
 
     private static String stylesheet(String path) {

--- a/jabgui/src/test/java/org/jabref/gui/backup/BackupResolverDialogTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/backup/BackupResolverDialogTest.java
@@ -1,0 +1,112 @@
+package org.jabref.gui.backup;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+import javafx.collections.ListChangeListener;
+import javafx.scene.Scene;
+import javafx.scene.control.DialogPane;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+
+import org.jabref.architecture.AllowedToUseClassGetResource;
+import org.jabref.gui.frame.ExternalApplicationsPreferences;
+import org.jabref.gui.keyboard.KeyBindingRepository;
+import org.jabref.gui.util.DialogButtonAssertions;
+import org.jabref.logic.l10n.Language;
+import org.jabref.logic.l10n.Localization;
+
+import com.airhacks.afterburner.injection.Injector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testfx.framework.junit5.ApplicationTest;
+import org.testfx.util.WaitForAsyncUtils;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@AllowedToUseClassGetResource("JavaFX internally handles the passed URLs properly.")
+class BackupResolverDialogTest extends ApplicationTest {
+
+    /// The class [org.jabref.gui.theme.ThemeManager] puts on a scene root for a user who raised the font size from the default 9pt.
+    private static final String FONT_SIZE_CLASS = "font-size-12";
+
+    private BackupResolverDialog backupResolverDialog;
+
+    private ListChangeListener<Window> raisedFontSizeListener;
+
+    @BeforeEach
+    void initLocalization() {
+        Localization.setLanguage(Language.ENGLISH);
+    }
+
+    @Override
+    public void start(Stage stage) {
+        Injector.setModelOrService(KeyBindingRepository.class, mock(KeyBindingRepository.class));
+
+        Scene mainWindowScene = new Scene(new StackPane(), 1024, 768);
+        mainWindowScene.getStylesheets().addAll(
+                stylesheet("/org/jabref/gui/theme/jabref-theme.css"),
+                stylesheet("/org/jabref/gui/theme/internal/jabref-base.css"));
+        stage.setScene(mainWindowScene);
+
+        raisedFontSizeListener = change -> {
+            while (change.next()) {
+                change.getAddedSubList().stream()
+                      .map(Window::getScene)
+                      .filter(Objects::nonNull)
+                      .forEach(scene -> scene.getRoot().getStyleClass().add(FONT_SIZE_CLASS));
+            }
+        };
+        Window.getWindows().addListener(raisedFontSizeListener);
+
+        backupResolverDialog = new BackupResolverDialog(
+                Path.of("library.bib"), Path.of("backups"), mock(ExternalApplicationsPreferences.class));
+        backupResolverDialog.initOwner(stage);
+        interact(backupResolverDialog::show);
+    }
+
+    @AfterEach
+    void removeRaisedFontSizeListener() {
+        if (raisedFontSizeListener != null) {
+            Window.getWindows().removeListener(raisedFontSizeListener);
+            raisedFontSizeListener = null;
+        }
+    }
+
+    /// The dialog has three buttons with long captions, so they only fit when the window grows to the
+    /// size the raised font needs.
+    @Test
+    void buttonCaptionsAreNotTruncatedAtARaisedFontSize() {
+        WaitForAsyncUtils.waitForFxEvents();
+
+        DialogButtonAssertions.assertCaptionsAreNotTruncated(backupResolverDialog.getDialogPane());
+    }
+
+    @Test
+    void windowIsAsWideAsItsContentNeeds() {
+        WaitForAsyncUtils.waitForFxEvents();
+
+        DialogPane pane = backupResolverDialog.getDialogPane();
+        double windowWidth = pane.getScene().getWindow().getWidth();
+        assertTrue(windowWidth >= pane.prefWidth(-1),
+                "Window is %.1fpx wide, but its content needs %.1fpx".formatted(windowWidth, pane.prefWidth(-1)));
+    }
+
+    /// Without a minimum size, the window could be resized until its buttons are cut off again.
+    @Test
+    void windowCannotBeShrunkBelowItsContent() {
+        WaitForAsyncUtils.waitForFxEvents();
+
+        DialogPane pane = backupResolverDialog.getDialogPane();
+        Stage window = (Stage) pane.getScene().getWindow();
+        assertTrue(window.getMinWidth() >= pane.minWidth(-1),
+                "Window can be shrunk to %.1fpx, but its content needs %.1fpx".formatted(window.getMinWidth(), pane.minWidth(-1)));
+    }
+
+    private static String stylesheet(String path) {
+        return Objects.requireNonNull(BackupResolverDialogTest.class.getResource(path)).toExternalForm();
+    }
+}

--- a/jabgui/src/test/java/org/jabref/gui/dialogs/BackupUIManagerTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/dialogs/BackupUIManagerTest.java
@@ -7,6 +7,8 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javafx.scene.layout.StackPane;
+
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.backup.BackupResolverDialog;
@@ -84,8 +86,9 @@ class BackupUIManagerTest extends ApplicationTest {
         AtomicReference<@Nullable String> dialogContent = new AtomicReference<>();
         interact(() -> {
             BackupResolverDialog dialog = new BackupResolverDialog(originalFile, backupFile.getParent(), mock(ExternalApplicationsPreferences.class));
-            HyperlinkLabel content = (HyperlinkLabel) dialog.getDialogPane().getContent();
-            dialogContent.set(content.getText());
+            StackPane content = (StackPane) dialog.getDialogPane().getContent();
+            HyperlinkLabel hyperlink = (HyperlinkLabel) content.getChildren().getFirst();
+            dialogContent.set(hyperlink.getText());
         });
 
         assertEquals("""

--- a/jabgui/src/test/java/org/jabref/gui/help/AboutDialogViewTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/help/AboutDialogViewTest.java
@@ -41,7 +41,6 @@ import static org.testfx.matcher.base.NodeMatchers.isVisible;
 @AllowedToUseClassGetResource("JavaFX internally handles the passed URLs properly.")
 class AboutDialogViewTest extends ApplicationTest {
 
-    /// The class [ThemeManager] puts on a scene root for a user who raised the font size from the default 9pt.
     private static final String FONT_SIZE_CLASS = "font-size-12";
 
     private AboutDialogView aboutDialogView;
@@ -99,11 +98,6 @@ class AboutDialogViewTest extends ApplicationTest {
             Window.getWindows().removeListener(raisedFontSizeListener);
             raisedFontSizeListener = null;
         }
-    }
-
-    @Test
-    void aboutDialogHeading() {
-        verifyThat(".about-heading", isVisible());
     }
 
     @Test

--- a/jabgui/src/test/java/org/jabref/gui/help/AboutDialogViewTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/help/AboutDialogViewTest.java
@@ -1,36 +1,53 @@
 package org.jabref.gui.help;
 
-import javafx.scene.control.Button;
-import javafx.scene.control.ButtonType;
-import javafx.scene.control.DialogPane;
-import javafx.stage.Stage;
+import java.util.List;
+import java.util.Objects;
 
+import javafx.collections.ListChangeListener;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.DialogPane;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+
+import org.jabref.architecture.AllowedToUseClassGetResource;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.clipboard.ClipBoardManager;
 import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.theme.ThemeManager;
+import org.jabref.gui.util.DialogButtonAssertions;
 import org.jabref.logic.l10n.Language;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.BuildInfo;
 
 import com.airhacks.afterburner.injection.Injector;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testfx.framework.junit5.ApplicationTest;
+import org.testfx.util.WaitForAsyncUtils;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.matcher.base.NodeMatchers.isVisible;
 
+@AllowedToUseClassGetResource("JavaFX internally handles the passed URLs properly.")
 class AboutDialogViewTest extends ApplicationTest {
+
+    /// The class [ThemeManager] puts on a scene root for a user who raised the font size from the default 9pt.
+    private static final String FONT_SIZE_CLASS = "font-size-12";
 
     private AboutDialogView aboutDialogView;
     private ClipBoardManager clipBoardManager;
+
+    private ListChangeListener<Window> raisedFontSizeListener;
 
     @BeforeEach
     void initLocalization() {
@@ -38,7 +55,7 @@ class AboutDialogViewTest extends ApplicationTest {
     }
 
     @Override
-    public void start(Stage stage) throws Exception {
+    public void start(Stage stage) {
         GuiPreferences preferences = mock(GuiPreferences.class);
         DialogService dialogService = mock(DialogService.class);
         clipBoardManager = mock(ClipBoardManager.class);
@@ -55,18 +72,33 @@ class AboutDialogViewTest extends ApplicationTest {
         Injector.setModelOrService(KeyBindingRepository.class, keyBindingRepository);
         Injector.setModelOrService(StateManager.class, stateManager);
 
-        aboutDialogView = new AboutDialogView();
+        Scene mainWindowScene = new Scene(new StackPane(), 1024, 768);
+        mainWindowScene.getStylesheets().addAll(
+                stylesheet("/org/jabref/gui/theme/jabref-theme.css"),
+                stylesheet("/org/jabref/gui/theme/internal/jabref-base.css"));
+        stage.setScene(mainWindowScene);
+
+        raisedFontSizeListener = change -> {
+            while (change.next()) {
+                change.getAddedSubList().stream()
+                      .map(Window::getScene)
+                      .filter(Objects::nonNull)
+                      .forEach(scene -> scene.getRoot().getStyleClass().add(FONT_SIZE_CLASS));
+            }
+        };
+        Window.getWindows().addListener(raisedFontSizeListener);
 
         aboutDialogView = new AboutDialogView();
+        aboutDialogView.initOwner(stage);
+        interact(aboutDialogView::show);
+    }
 
-        DialogPane pane = aboutDialogView.getDialogPane();
-
-        // 1. Load the CSS into the DialogPane
-        pane.getStylesheets().add(AboutDialogView.class.getResource("/org/jabref/gui/theme/jabref-theme.css").toExternalForm());
-        // 2. Force the 10pt font style
-        pane.setStyle("-fx-font-size: 10pt;");
-        // 3. Show the dialog (this triggers BaseDialog's DIALOG_SHOWING listener)
-        interact(() -> aboutDialogView.show());
+    @AfterEach
+    void removeRaisedFontSizeListener() {
+        if (raisedFontSizeListener != null) {
+            Window.getWindows().removeListener(raisedFontSizeListener);
+            raisedFontSizeListener = null;
+        }
     }
 
     @Test
@@ -77,37 +109,41 @@ class AboutDialogViewTest extends ApplicationTest {
     @Test
     void copyVersionButton() {
         verifyThat("Copy Version", isVisible());
-        clickOn("Copy Version");
+
+        interact(() -> buttonOf("Copy Version").fire());
+
         verify(clipBoardManager).setContent(anyString());
     }
 
     @Test
     void closeButton() {
         verifyThat("Close", isVisible());
-        clickOn("Close");
+
+        interact(() -> buttonOf("Close").fire());
+
+        assertFalse(aboutDialogView.isShowing());
     }
 
     @Test
-    void buttonsAreNotTruncatedAt10ptFont() throws InterruptedException {
+    void buttonCaptionsAreNotTruncatedAtARaisedFontSize() {
+        WaitForAsyncUtils.waitForFxEvents();
         DialogPane pane = aboutDialogView.getDialogPane();
-        for (ButtonType type : pane.getButtonTypes()) {
-            Button button = (Button) pane.lookupButton(type);
 
-            // We need to wait for a layout pulse to ensure CSS is applied
-            interact(() -> {
-                button.applyCss();
-                double prefWidth = button.prefWidth(-1);
-                double actualWidth = button.getWidth();
+        assertEquals(List.of("Copy Version", "Close"),
+                DialogButtonAssertions.buttonsOf(pane).stream().map(Button::getText).toList());
+        DialogButtonAssertions.assertCaptionsAreNotTruncated(pane);
+    }
 
-                // Assert that the actual rendered width is at least as large
-                // as the width required by the 10pt text.
-                // If actualWidth < prefWidth, JavaFX will truncate the text.
-                assertTrue(actualWidth >= prefWidth,
-                        "Button [%s] is truncated! Actual: %.2f, Pref: %.2f".formatted(
-                                button.getText(), actualWidth, prefWidth));
-            });
-            // for debugging purpises
-            // Thread.sleep(4000);
-        }
+    /// The buttons are fired rather than clicked: a robot click needs the window manager to let the
+    /// application move the pointer, which is not the case on every desktop the tests run on.
+    private Button buttonOf(String caption) {
+        return DialogButtonAssertions.buttonsOf(aboutDialogView.getDialogPane()).stream()
+                                     .filter(button -> caption.equals(button.getText()))
+                                     .findFirst()
+                                     .orElseThrow(() -> new AssertionError("No button '%s' on the dialog".formatted(caption)));
+    }
+
+    private static String stylesheet(String path) {
+        return Objects.requireNonNull(AboutDialogViewTest.class.getResource(path)).toExternalForm();
     }
 }

--- a/jabgui/src/test/java/org/jabref/gui/util/DialogButtonAssertions.java
+++ b/jabgui/src/test/java/org/jabref/gui/util/DialogButtonAssertions.java
@@ -1,0 +1,47 @@
+package org.jabref.gui.util;
+
+import java.util.List;
+
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.DialogPane;
+import javafx.scene.text.Text;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// Assertions on the buttons of a [DialogPane], to be used from a JavaFX thread.
+public class DialogButtonAssertions {
+
+    private DialogButtonAssertions() {
+    }
+
+    public static List<Button> buttonsOf(DialogPane pane) {
+        return pane.getButtonTypes().stream()
+                   .map(pane::lookupButton)
+                   .map(Button.class::cast)
+                   .toList();
+    }
+
+    /// Asserts that every button of the pane shows its whole caption.
+    public static void assertCaptionsAreNotTruncated(DialogPane pane) {
+        for (Button button : buttonsOf(pane)) {
+            // A caption that does not fit is rendered with an ellipsis instead of the caption itself.
+            assertEquals(button.getText(), ((Text) button.lookup(".text")).getText(),
+                    "Caption of button '%s' is truncated".formatted(button.getText()));
+
+            // Even without an ellipsis, the button must be wide enough for the caption in the font it is rendered in.
+            double requiredWidth = requiredWidth(button);
+            assertTrue(button.getWidth() >= requiredWidth,
+                    "Button '%s' is %.1fpx wide, but its caption needs %.1fpx".formatted(button.getText(), button.getWidth(), requiredWidth));
+        }
+    }
+
+    /// The width the button needs to show its whole caption: the caption measured in the font of the button plus the space its background and padding take.
+    private static double requiredWidth(Button button) {
+        Text caption = new Text(button.getText());
+        caption.setFont(button.getFont());
+        Insets insets = button.getInsets();
+        return caption.getLayoutBounds().getWidth() + insets.getLeft() + insets.getRight();
+    }
+}

--- a/jabgui/src/test/java/org/jabref/gui/util/component/MarkdownTextFlowTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/util/component/MarkdownTextFlowTest.java
@@ -2,12 +2,16 @@ package org.jabref.gui.util.component;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import javafx.event.Event;
+import javafx.event.EventType;
 import javafx.geometry.BoundingBox;
 import javafx.geometry.Bounds;
+import javafx.geometry.Point2D;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
 import javafx.stage.Stage;
@@ -225,18 +229,29 @@ class MarkdownTextFlowTest {
         Bounds bounds = firstTextBounds(robot, textFlow);
         double centerY = bounds.getMinY() + (bounds.getHeight() / 2);
 
-        robot.moveTo(bounds.getMinX() + 1, centerY)
-             .press(MouseButton.PRIMARY)
-             .moveTo(bounds.getMaxX() - 1, centerY)
-             .release(MouseButton.PRIMARY);
+        robot.interact(() -> {
+            fireMouseEvent(textFlow, MouseEvent.MOUSE_PRESSED, bounds.getMinX() + 1, centerY, true);
+            fireMouseEvent(textFlow, MouseEvent.MOUSE_DRAGGED, bounds.getMaxX() - 1, centerY, true);
+            fireMouseEvent(textFlow, MouseEvent.MOUSE_RELEASED, bounds.getMaxX() - 1, centerY, false);
+        });
     }
 
+    private static void fireMouseEvent(MarkdownTextFlow textFlow, EventType<MouseEvent> type, double x, double y, boolean buttonDown) {
+        Point2D onScreen = textFlow.localToScreen(x, y);
+        Event.fireEvent(textFlow, new MouseEvent(
+                type, x, y, onScreen.getX(), onScreen.getY(), MouseButton.PRIMARY, 1,
+                false, false, false, false,
+                buttonDown, false, false,
+                false, false, false, null));
+    }
+
+    /// The bounds of the first rendered line, in the coordinate space of the text flow.
     private static Bounds firstTextBounds(FxRobot robot, MarkdownTextFlow textFlow) {
         AtomicReference<Bounds> boundsReference = new AtomicReference<>();
         robot.interact(() -> {
             for (Node child : textFlow.getChildren()) {
-                Bounds childBounds = child.localToScreen(child.getBoundsInLocal());
-                if (childBounds != null && childBounds.getWidth() > 2) {
+                Bounds childBounds = child.getBoundsInParent();
+                if (childBounds.getWidth() > 2) {
                     boundsReference.set(childBounds);
                     return;
                 }

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -1977,9 +1977,8 @@ edition\ of\ book\ reported\ as\ just\ 1=edition of book reported as just 1
 no\ integer\ as\ values\ for\ edition\ allowed=no integer as values for edition allowed
 Tools=Tools
 What\'s\ new\ in\ this\ version?=What\'s new in this version?
-Want\ to\ help?=Want to help?
 Make\ a\ donation=Make a donation
-get\ involved=get involved
+Get\ involved=Get involved
 Used\ libraries=Used libraries
 Existing\ file=Existing file
 
@@ -3720,3 +3719,4 @@ Modify\ group=Modify group
 Move\ group=Move group
 Sort\ subgroups=Sort subgroups
 Change\ string\ constants=Change string constants
+Founded\ by\ Morten\ O.\ Alver\ and\ Nizar\ Batada.=Founded by Morten O. Alver and Nizar Batada.


### PR DESCRIPTION
### Summary

- Improve `Dialog` sizing which can be broken for a bigger font-size.
- Improve overall `AboutDialog` layout
  - Use better spacing, do not use weird padding

cc @Siedlerchr since you could also reproduce on macOS. 

### Steps to test

Run JabRef, Open About.

Font Size 9:

<img width="902" height="762" alt="image" src="https://github.com/user-attachments/assets/a221fdfc-9d5c-4a67-82e3-1cbbbc9149b6" />

Font Size 12:

<img width="902" height="762" alt="image" src="https://github.com/user-attachments/assets/36e7798a-3af3-42c3-9450-d9ca03aef72b" />

### Related issues and pull requests

Works towards: https://github.com/JabRef/jabref/issues/16787

### AI usage

Not used.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
