### PR TITLE
Request focus after selecting entry in main table

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -348,6 +348,7 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                 if (index >= 0) {
                     getSelectionModel().clearAndSelect(index);
                     scrollTo(index);
+                    requestFocus();
                 }
             });
         }


### PR DESCRIPTION
PR description:

Adds a call to requestFocus() on the main table right after selecting and scrolling to a newly added entry, in MainTable.clearAndSelect(BibEntry). Previously the new entry was selected and scrolled into view but the table itself never received keyboard focus, so pressing arrow keys, Enter, or Delete right after adding an entry had no effect until the user clicked into the table first. This fixes that gap so the newly added entry is immediately keyboard-navigable.

Steps to test

Open JabRef with any library loaded.
Go to Library → New entry (or press the toolbar "+" button) and add a new entry of any type (e.g. Article).
Without clicking anywhere else, immediately press the ↓ (down arrow) key.
Expected result: the selection moves to the next row in the table. Before this fix, nothing happened until you clicked the table once.
Related issues and pull requests

Closes #16035