### PR TITLE
Improve Entry editor button ergonomics

### DIFF
--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/CitationCountEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/CitationCountEditor.fxml
@@ -8,12 +8,12 @@
 <?import org.jabref.gui.fieldeditors.EditorTextField?>
 <?import org.jabref.gui.icon.JabRefIconView?>
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
-         spacing="4"
+         spacing="4.0"
          alignment="CENTER_LEFT"
          fx:controller="org.jabref.gui.fieldeditors.CitationCountEditor">
     <EditorTextField fx:id="textField" prefHeight="0.0" HBox.hgrow="ALWAYS"/>
     <ComboBox fx:id="fetcherComboBox"/>
-    <Button fx:id="fetchCitationCountButton" onAction="#fetchCitationCount" styleClass="icon-button">
+    <Button fx:id="fetchCitationCountButton" onAction="#fetchCitationCount" styleClass="icon-button, entry-editor-field-button">
         <graphic>
             <StackPane>
                 <JabRefIconView glyph="LOOKUP_IDENTIFIER"

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/CitationKeyEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/CitationKeyEditor.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import org.jabref.gui.fieldeditors.EditorTextField?>
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
-         spacing="4"
+         spacing="4.0"
          alignment="CENTER_LEFT"
          fx:controller="org.jabref.gui.fieldeditors.CitationKeyEditor">
     <EditorTextField fx:id="textField"/>

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/CitationKeyEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/CitationKeyEditor.fxml
@@ -8,5 +8,5 @@
          alignment="CENTER_LEFT"
          fx:controller="org.jabref.gui.fieldeditors.CitationKeyEditor">
     <EditorTextField fx:id="textField"/>
-    <Button fx:id="generateCitationKeyButton" text="%Generate" styleClass="icon-button"/>
+    <Button fx:id="generateCitationKeyButton" text="%Generate" styleClass="icon-button, entry-editor-field-button"/>
 </fx:root>

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/ICORERankingEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/ICORERankingEditor.fxml
@@ -11,14 +11,14 @@
     <EditorTextField fx:id="textField"/>
         <Button fx:id="lookupICORERankButton"
                 onAction="#lookupRank"
-                styleClass="icon-button">
+                styleClass="icon-button, entry-editor-field-button">
             <graphic>
                 <JabRefIconView glyph="LOOKUP_IDENTIFIER"/>
             </graphic>
         </Button>
         <Button fx:id="visitICOREConferencePageButton"
                 onAction="#openExternalLink"
-                styleClass="icon-button">
+                styleClass="icon-button, entry-editor-field-button">
             <graphic>
                 <JabRefIconView glyph="OPEN_LINK"/>
             </graphic>

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/ICORERankingEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/ICORERankingEditor.fxml
@@ -5,6 +5,8 @@
 <?import org.jabref.gui.fieldeditors.EditorTextField?>
 <?import org.jabref.gui.icon.JabRefIconView?>
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
+         spacing="4.0"
+         alignment="CENTER_LEFT"
          fx:controller="org.jabref.gui.fieldeditors.ICORERankingEditor">
     <EditorTextField fx:id="textField"/>
         <Button fx:id="lookupICORERankButton"

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/ISSNEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/ISSNEditor.fxml
@@ -6,6 +6,8 @@
 <?import org.jabref.gui.fieldeditors.EditorTextField?>
 <?import org.jabref.gui.icon.JabRefIconView?>
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
+         spacing="4.0"
+         alignment="CENTER_LEFT"
          fx:controller="org.jabref.gui.fieldeditors.ISSNEditor">
     <EditorTextField fx:id="textField"/>
         <Button fx:id="journalInfoButton"

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/ISSNEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/ISSNEditor.fxml
@@ -12,7 +12,7 @@
     <EditorTextField fx:id="textField"/>
         <Button fx:id="journalInfoButton"
                 onAction="#showJournalInfo"
-                styleClass="icon-button">
+                styleClass="icon-button, entry-editor-field-button">
             <graphic>
                 <JabRefIconView glyph="VIEW_JOURNAL_INFO"/>
             </graphic>
@@ -22,7 +22,7 @@
         </Button>
         <Button fx:id="fetchInformationByIdentifierButton"
                 onAction="#fetchInformationByIdentifier"
-                styleClass="icon-button">
+                styleClass="icon-button, entry-editor-field-button">
             <graphic>
                 <JabRefIconView glyph="FETCH_BY_IDENTIFIER"/>
             </graphic>

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/JournalEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/JournalEditor.fxml
@@ -13,7 +13,7 @@
     <HBox>
         <Button fx:id="journalInfoButton"
                 onAction="#showJournalInfo"
-                styleClass="icon-button">
+                styleClass="icon-button, entry-editor-field-button">
             <graphic>
                 <JabRefIconView glyph="VIEW_JOURNAL_INFO"/>
             </graphic>
@@ -22,7 +22,7 @@
             </tooltip>
         </Button>
         <Button onAction="#toggleAbbreviation"
-                styleClass="icon-button">
+                styleClass="icon-button, entry-editor-field-button">
             <graphic>
                 <JabRefIconView glyph="TOGGLE_ABBREVIATION"/>
             </graphic>

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/JournalEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/JournalEditor.fxml
@@ -6,7 +6,7 @@
 <?import org.jabref.gui.fieldeditors.EditorTextField?>
 <?import org.jabref.gui.icon.JabRefIconView?>
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
-         spacing="4"
+         spacing="4.0"
          alignment="CENTER_LEFT"
          fx:controller="org.jabref.gui.fieldeditors.JournalEditor">
     <EditorTextField fx:id="textField"/>

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/OwnerEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/OwnerEditor.fxml
@@ -11,7 +11,7 @@
          fx:controller="org.jabref.gui.fieldeditors.OwnerEditor">
     <EditorTextField fx:id="textField" prefHeight="0.0" HBox.hgrow="ALWAYS"/>
     <Button onAction="#setOwner"
-            styleClass="icon-button">
+            styleClass="icon-button, entry-editor-field-button">
         <graphic>
             <JabRefIconView glyph="OWNER"/>
         </graphic>

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/OwnerEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/OwnerEditor.fxml
@@ -6,6 +6,8 @@
 <?import org.jabref.gui.fieldeditors.EditorTextField?>
 <?import org.jabref.gui.icon.JabRefIconView?>
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
+         spacing="4.0"
+         alignment="CENTER_LEFT"
          fx:controller="org.jabref.gui.fieldeditors.OwnerEditor">
     <EditorTextField fx:id="textField" prefHeight="0.0" HBox.hgrow="ALWAYS"/>
     <Button onAction="#setOwner"

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/UrlEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/UrlEditor.fxml
@@ -6,6 +6,8 @@
 <?import org.jabref.gui.fieldeditors.EditorTextField?>
 <?import org.jabref.gui.icon.JabRefIconView?>
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
+         spacing="4.0"
+         alignment="CENTER_LEFT"
          fx:controller="org.jabref.gui.fieldeditors.UrlEditor">
     <EditorTextField fx:id="textField" prefHeight="0.0" HBox.hgrow="ALWAYS"/>
     <Button disable="${controller.viewModel.validUrlIsNotPresent}" onAction="#openExternalLink"

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/UrlEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/UrlEditor.fxml
@@ -11,7 +11,7 @@
          fx:controller="org.jabref.gui.fieldeditors.UrlEditor">
     <EditorTextField fx:id="textField" prefHeight="0.0" HBox.hgrow="ALWAYS"/>
     <Button disable="${controller.viewModel.validUrlIsNotPresent}" onAction="#openExternalLink"
-            styleClass="icon-button">
+            styleClass="icon-button, entry-editor-field-button">
         <graphic>
             <JabRefIconView glyph="OPEN_LINK"/>
         </graphic>

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/identifier/IdentifierEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/identifier/IdentifierEditor.fxml
@@ -9,6 +9,7 @@
 <?import org.jabref.gui.fieldeditors.EditorTextField?>
 <?import org.jabref.gui.icon.JabRefIconView?>
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
+         spacing="4.0"
          alignment="CENTER_LEFT"
          fx:controller="org.jabref.gui.fieldeditors.identifier.IdentifierEditor">
     <EditorTextField fx:id="textField" HBox.hgrow="ALWAYS"/>

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/identifier/IdentifierEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/identifier/IdentifierEditor.fxml
@@ -16,7 +16,7 @@
 
     <Button fx:id="shortenDOIButton"
             onAction="#shortenID"
-            styleClass="icon-button"
+            styleClass="icon-button, entry-editor-field-button"
             disable="${controller.viewModel.isInvalidIdentifier}"
             managed="${controller.viewModel.canShortenIdentifier}"
             visible="${controller.viewModel.canShortenIdentifier}">
@@ -27,7 +27,7 @@
 
     <Button disable="${controller.viewModel.isInvalidIdentifier}"
             onAction="#openExternalLink"
-            styleClass="icon-button">
+            styleClass="icon-button, entry-editor-field-button">
         <graphic>
             <JabRefIconView glyph="OPEN_LINK"/>
         </graphic>
@@ -38,7 +38,7 @@
 
     <Button fx:id="lookupIdentifierButton"
             onAction="#lookupIdentifier"
-            styleClass="icon-button"
+            styleClass="icon-button, entry-editor-field-button"
             visible="${controller.viewModel.canLookupIdentifier}"
             managed="${controller.viewModel.canLookupIdentifier}">
         <graphic>
@@ -53,7 +53,7 @@
 
     <Button fx:id="fetchInformationByIdentifierButton"
             onAction="#fetchInformationByIdentifier"
-            styleClass="icon-button"
+            styleClass="icon-button, entry-editor-field-button"
             disable="${controller.viewModel.isInvalidIdentifier}"
             managed="${controller.viewModel.canFetchBibliographyInformationById}"
             visible="${controller.viewModel.canFetchBibliographyInformationById}">

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -337,6 +337,10 @@
     -fx-opacity: 0.4;
 }
 
+.entry-editor-field-button {
+    -fx-padding: 0.333em 0.5em;
+}
+
 /* Selected state is signalled by the icon color alone (set in code), not by a background. */
 .addEntryButton:selected {
     -fx-background-color: transparent;


### PR DESCRIPTION
### Summary

Follow-up #16928, add spaces for more fields
<img width="550" height="88" alt="image" src="https://github.com/user-attachments/assets/31682618-46b7-4f11-950e-29ae113006ce" />

Implement https://github.com/JabRef/jabref/pull/16928#issuecomment-5584673012
<img width="319" height="126" alt="image" src="https://github.com/user-attachments/assets/df3bd4a6-6910-4446-a826-d74f35f9571e" />


### Steps to test

Open entry editor and check

### Related issues and pull requests

Closes NA

### AI usage
codex 5.4 + brain
_____

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
