### PR TITLE
Document Windows Defender exclusions for the workspace

### DIFF
--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-03-code.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-03-code.md
@@ -67,6 +67,26 @@ git fetch --all
 >
 > Note that putting the JabRef repository directly on `C:\` or any other drive letter on Windows causes compile errors (**negative example**: `C:\jabref`).
 
+#### Exclude the workspace from Windows Defender
+
+Windows Defender's real-time protection scans every file the build touches.
+JabRef's resources contain more than 10,000 citation style files, and `:jablib:processResources` copies about 3,000 of them - each copy triggers a scan.
+
+Measured on a developer machine, excluding the workspace and the Gradle caches cut `:jablib:processResources` from **3 minutes 21 seconds to 51 seconds**.
+
+Open "Windows PowerShell" **as administrator** and run (adjust the paths to your setup):
+
+```powershell
+Add-MpPreference -ExclusionPath 'C:\git-repositories\jabref', "$env:USERPROFILE\.gradle"
+```
+
+Check the result with `(Get-MpPreference).ExclusionPath`.
+
+{: .warning }
+> Files below these paths are no longer scanned in real time.
+> This includes everything Gradle downloads into `~/.gradle`.
+> Exclude the directory you actually work in - an exclusion for an old checkout path silently does nothing.
+
 ### Background
 
 Initial cloning of your fork might be very slow (`27.00 KiB/s`).


### PR DESCRIPTION
Adds a Windows-specific step to "Set up a local workspace": exclude the workspace and the Gradle caches from Windows Defender.

Defender's real-time protection scans every file the build touches. `jablib/src/main/resources/csl-styles` alone holds 10,873 files, of which ~2,900 are copied into `build/resources/main` by `:jablib:processResources` - each copy triggers a scan.

Measured on a developer machine (`gradlew :jablib:processResources --rerun --profile`):

| | before | after |
|---|---|---|
| `:jablib:processResources` | 3m21s | **51s** |

The note warns about the trade-off (those paths are no longer scanned in real time, including everything Gradle downloads into `~/.gradle`) and points out that an exclusion for an old checkout path silently does nothing - which is exactly how this went unnoticed.

### Mandatory checks

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable) - documentation only, not user facing
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required) - n/a, documentation only
- [x] Screenshots added in PR description (for UI changes) - n/a
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaJC7hwXcn7T9kf1M6TREf
