### PR TITLE
Unify button corner radius and color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We moved the Git settings into their own preferences tab. [#12630](https://github.com/JabRef/jabref/issues/12630)
 - "Get fulltext", groups "Attach file", "Attach file from URL", "Open folder(s)" and "Open file" commands in right click menu have been moved into a "More file operations..." submenu. [#16829](https://github.com/JabRef/jabref/pull/16829)
 - We changed the logging during full-text search indexing to identify which linked files cause errors. [#15680](https://github.com/JabRef/jabref/issues/15680)
+- We unified the Button style. All Buttons have rounded corners, a hover, pressed and focused color. [#16980](https://github.com/JabRef/jabref/pull/16980)
 
 ### Fixed
 

--- a/jabgui/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/jabgui/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -371,8 +371,7 @@ public class JabRefDialogService implements DialogService {
 
         CustomPasswordField passwordField = new CustomPasswordField();
 
-        HBox box = new HBox();
-        box.setSpacing(10);
+        HBox box = new HBox(8);
         box.getChildren().addAll(new Label(content), passwordField);
         dialog.setTitle(title);
         dialog.getDialogPane().setContent(box);

--- a/jabgui/src/main/java/org/jabref/gui/actions/ActionFactory.java
+++ b/jabgui/src/main/java/org/jabref/gui/actions/ActionFactory.java
@@ -164,14 +164,7 @@ public class ActionFactory {
     public Button createIconButton(Action action, Command command) {
         Button button = ActionUtils.createButton(new JabRefAction(action, command, keyBindingRepository), ActionUtils.ActionTextBehavior.HIDE);
 
-        button.getStyleClass().setAll("icon-button");
-
-        // For some reason the graphic is not set correctly, so let's fix this
-        button.graphicProperty().unbind();
-        action.getIcon().ifPresent(icon -> button.setGraphic(icon.getGraphicNode()));
-
-        // Prevent the buttons from stealing the focus
-        button.setFocusTraversable(false);
+        initButton(action, button);
 
         return button;
     }
@@ -183,13 +176,15 @@ public class ActionFactory {
                 button,
                 ActionUtils.ActionTextBehavior.HIDE);
 
-        button.getStyleClass().add("icon-button");
-
-        // For some reason the graphic is not set correctly, so let's fix this
-        // ToDO: Find a way to reuse JabRefIconView
-        button.graphicProperty().unbind();
-        action.getIcon().ifPresent(icon -> button.setGraphic(icon.getGraphicNode()));
+        initButton(action, button);
 
         return button;
+    }
+
+    private static void initButton(Action action, ButtonBase button) {
+        button.setFocusTraversable(true);
+        button.getStyleClass().add("icon-button");
+        button.graphicProperty().unbind();
+        action.getIcon().ifPresent(icon -> button.setGraphic(icon.getGraphicNode()));
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/ai/chat/AiChatStatusView.java
+++ b/jabgui/src/main/java/org/jabref/gui/ai/chat/AiChatStatusView.java
@@ -153,7 +153,6 @@ public class AiChatStatusView extends VBox {
 
     private Button constructErrorButton(AiChatStatusViewModel.IngestionStatusRow row) {
         Button errorButton = new Button(Localization.lang("Show Error"));
-        errorButton.getStyleClass().add("text-button");
         errorButton.setOnAction(event ->
                 dialogService.showErrorDialogAndWait(
                         Localization.lang("Ingestion Error"),

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -227,10 +227,9 @@ public class CitationRelationsTab extends EntryEditorTab {
 
         Label label = new Label(Localization.lang("Looking up DOI..."));
 
-        VBox vBox = new VBox();
+        VBox vBox = new VBox(4);
         vBox.getChildren().add(progressIndicator);
         vBox.getChildren().add(label);
-        vBox.setSpacing(2d);
         vBox.getStyleClass().add("align-center");
 
         sciteResultsPane.add(vBox, 0, 0);
@@ -250,10 +249,9 @@ public class CitationRelationsTab extends EntryEditorTab {
         Hyperlink link = new Hyperlink(Localization.lang("Look up a DOI and try again."));
         link.setOnAction(_ -> triggerDoiLookup());
 
-        HBox hBox = new HBox();
+        HBox hBox = new HBox(4);
         hBox.getChildren().add(label);
         hBox.getChildren().add(link);
-        hBox.setSpacing(2d);
         hBox.getStyleClass().add("align-center");
 
         sciteResultsPane.add(hBox, 0, 0);
@@ -833,7 +831,7 @@ public class CitationRelationsTab extends EntryEditorTab {
         hideNodes(citationComponents.abortButton(), citationComponents.progress());
         showNodes(citationComponents.refreshButton());
 
-        HBox hBox = new HBox();
+        HBox hBox = new HBox(4);
         Label label = new Label(Localization.lang("The selected entry doesn't have a DOI linked to it."));
         Hyperlink link = new Hyperlink(Localization.lang("Look up a DOI and try again."));
 
@@ -841,7 +839,6 @@ public class CitationRelationsTab extends EntryEditorTab {
 
         hBox.getChildren().add(label);
         hBox.getChildren().add(link);
-        hBox.setSpacing(2d);
         hBox.getStyleClass().add("align-center");
         hBox.setFillHeight(true);
 

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesCellFactory.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesCellFactory.java
@@ -32,9 +32,9 @@ public class UnlinkedFilesCellFactory extends CheckBoxTreeCell<FileNodeViewModel
                                     UnlinkedFilesDialogViewModel viewModel) {
         this.stateManager = stateManager;
         this.viewModel = viewModel;
-        cellContent.setSpacing(10);
-        leftSide.setSpacing(5);
-        jumpIcon.setSpacing(5);
+        cellContent.setSpacing(8);
+        leftSide.setSpacing(4);
+        jumpIcon.setSpacing(4);
 
         new ViewModelListCellFactory<BibEntry>()
                 .withText(entry -> entry.getCitationKey().orElse(Localization.lang("new")))

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/SpecialFieldEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/SpecialFieldEditor.java
@@ -61,7 +61,7 @@ public class SpecialFieldEditor extends HBox implements FieldEditorFX {
         this.viewModel = new SpecialFieldViewModel(specialField, preferences, undoManager);
 
         setAlignment(Pos.CENTER_LEFT);
-        setSpacing(2);
+        setSpacing(4);
 
         if (specialField == SpecialField.RANKING) {
             Rating rating = createRatingControl();

--- a/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -254,8 +254,7 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
                 journalAbbreviationRepository
         );
 
-        VBox head = new VBox(mainMenu, mainToolBar);
-        head.setSpacing(0d);
+        VBox head = new VBox(0, mainMenu, mainToolBar);
         setTop(head);
 
         verticalSplit.getItems().addAll(tabbedPane);

--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -253,8 +253,7 @@ public class MainTableColumnFactory {
                                                                               .stream())
                                                    .toList();
         if (!groupIcons.isEmpty()) {
-            HBox container = new HBox();
-            container.setSpacing(2);
+            HBox container = new HBox(4);
             container.setMinWidth(10);
             container.setAlignment(Pos.CENTER_LEFT);
             container.setPadding(new Insets(0, 2, 0, 2));

--- a/jabgui/src/main/resources/org/jabref/gui/texparser/ParseLatexDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/texparser/ParseLatexDialog.fxml
@@ -28,8 +28,8 @@
             </VBox>
             <VBox spacing="5.0">
                 <HBox spacing="10.0">
-                    <Button fx:id="selectAllButton" text="%Select all" styleClass="text-button" onAction="#selectAll"/>
-                    <Button fx:id="unselectAllButton" text="%Unselect all" styleClass="text-button"
+                    <Button fx:id="selectAllButton" text="%Select all" onAction="#selectAll"/>
+                    <Button fx:id="unselectAllButton" text="%Unselect all"
                             onAction="#unselectAll"/>
                 </HBox>
             </VBox>

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -54,9 +54,10 @@
  * default root font (9pt = 12px, see ThemeManager). The value itself is
  * written in `em`, so all spacing scales with the user's font size setting:
  *
- *     0 -> 0          12 -> 1em
- *     4 -> 0.333em    16 -> 1.333em
- *     8 -> 0.667em    24 -> 2em
+ * 0 -> 0
+ * 4 -> 0.333em
+ * 8 -> 0.667em
+ * 12 -> 1em
  * ========================================================================== */
 
 /* Type scale */
@@ -310,10 +311,6 @@
 
 .ikonli-font-icon {
     -fx-icon-color: -fx-text-base-color;
-}
-
-.text-button {
-    -fx-border-width: 0;
 }
 
 .icon-button {
@@ -1373,7 +1370,7 @@ We want to have a look that matches our icons in the tool-bar */
 
 .three-way-merge .field-name .glyph-icon,
 .three-way-merge .field-name .ikonli-font-icon {
-    -fx-icon-size: 17;
+    -fx-icon-size: 18;
     -fx-icon-color: -color-accent;
 }
 
@@ -1413,8 +1410,8 @@ We want to have a look that matches our icons in the tool-bar */
 }
 
 .add-certificate {
-    -fx-pref-width: 17em;
-    -fx-min-width: 17em;
+    -fx-pref-width: 18em;
+    -fx-min-width: 18em;
 }
 
 /* Quick Settings */

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -149,9 +149,6 @@
 .btn-transparent {
     -fx-background: transparent;
     -fx-background-color: transparent;
-    -fx-border-width: 0;
-    -fx-background-insets: 0;
-    -fx-background-radius: 0.25em;
 }
 
 /* JavaFX with custom components */
@@ -314,12 +311,12 @@
 }
 
 .icon-button {
-    -fx-border-width: 0;
     -fx-background: transparent;
     -fx-background-color: transparent;
     -fx-padding: 0.5em;
-    -fx-background-radius: 0.25em;
     -fx-border-radius: 0.25em;
+    -fx-border-width: 0.0625em;
+    -fx-border-color: transparent;
 }
 
 .icon-button:hover {
@@ -337,6 +334,10 @@
     -fx-background-color: -color-overlay-hover;
     -fx-text-fill: -color-fg-emphasis;
     -fx-fill: -color-fg-emphasis;
+}
+
+.icon-button:focused {
+    -fx-border-color: -color-accent;
 }
 
 .icon-button:disabled {
@@ -460,7 +461,7 @@
 .mainToolbar .glyph-icon,
 .mainToolbar .ikonli-font-icon {
     /* `!important` is override library's default font size */
-    -fx-font-size: 1.7em!important;
+    -fx-font-size: 1.8em!important;
     -fx-fill: -color-accent;
     -fx-text-fill: -color-accent;
     -fx-icon-color: -color-accent;

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -1403,6 +1403,14 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-background-color: -color-button-hover;
 }
 
+.exampleQuestionStyle:armed {
+    -fx-background-color: -color-button-pressed;
+}
+
+.refresh {
+    -fx-background-color: transparent;
+}
+
 .text-button-blue {
     -fx-background-color: transparent;
     -fx-text-fill: -color-accent;
@@ -1428,6 +1436,10 @@ We want to have a look that matches our icons in the tool-bar */
 
 .quick-settings-button:hover {
     -fx-border-color: -color-accent-subtle;
+}
+
+.quick-settings-button:armed {
+    -fx-background-color: -color-bg-alt, -color-button-pressed;
 }
 
 .quick-settings-button .glyph-icon,
@@ -1541,6 +1553,14 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-background-radius: 0.25em;
 }
 
+.walkthrough-continue-button:hover {
+    -fx-background-color: -color-accent, -color-button-hover;
+}
+
+.walkthrough-continue-button:armed {
+    -fx-background-color: -color-accent, -color-button-pressed;
+}
+
 .walkthrough-skip-button {
     -fx-background-color: transparent;
     -fx-text-fill: -color-accent;
@@ -1550,11 +1570,27 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-background-radius: 0.25em;
 }
 
+.walkthrough-skip-button:hover {
+    -fx-background-color: -color-button-hover;
+}
+
+.walkthrough-skip-button:armed {
+    -fx-background-color: -color-button-pressed;
+}
+
 .walkthrough-back-button {
     -fx-background-color: transparent;
     -fx-text-fill: -color-accent;
     -fx-border-radius: 0.25em;
     -fx-background-radius: 0.25em;
+}
+
+.walkthrough-back-button:hover {
+    -fx-background-color: -color-button-hover;
+}
+
+.walkthrough-back-button:armed {
+    -fx-background-color: -color-button-pressed;
 }
 
 .walkthrough-quit-button {
@@ -1573,7 +1609,7 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-background-color: derive(-color-bg-tertiary, -20%);
 }
 
-.walkthrough-quit-button:pressed {
+.walkthrough-quit-button:armed {
     -fx-background-color: derive(-color-bg-tertiary, 30%);
 }
 
@@ -1665,6 +1701,14 @@ We want to have a look that matches our icons in the tool-bar */
 .info-center-view .notification-view > .content > .text-container > .actions-box .button {
     -fx-background: -color-button-default;
     -fx-background-color: -color-button-default;
+}
+
+.info-center-view .notification-view > .content > .text-container > .actions-box .button:hover {
+    -fx-background-color: -color-button-default, -color-button-hover;
+}
+
+.info-center-view .notification-view > .content > .text-container > .actions-box .button:armed {
+    -fx-background-color: -color-button-default, -color-button-pressed;
 }
 
 /* Row height for the linked-files ListView. Expressed in em so theming and font scaling adjust it;

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -316,11 +316,6 @@
     -fx-border-width: 0;
 }
 
-.contained-button {
-    -fx-background-color: -color-accent-subtle;
-    -fx-border-color: -color-accent-subtle;
-}
-
 .icon-button {
     -fx-border-width: 0;
     -fx-background: transparent;

--- a/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/internal/jabref-base.css
@@ -326,6 +326,8 @@
     -fx-background: transparent;
     -fx-background-color: transparent;
     -fx-padding: 0.5em;
+    -fx-background-radius: 0.25em;
+    -fx-border-radius: 0.25em;
 }
 
 .icon-button:hover {
@@ -924,8 +926,8 @@ We want to have a look that matches our icons in the tool-bar */
 }
 
 #entryEditor .all-fields-add-chip {
-    -fx-background-radius: 3;
-    -fx-border-radius: 3;
+    -fx-background-radius: 0.25em;
+    -fx-border-radius: 0.25em;
 }
 
 #entryEditor Text {
@@ -1085,7 +1087,8 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-border-insets: 0;
     -fx-background-insets: 0;
     -fx-border-image-insets: 0;
-    -fx-background-radius: 0;
+    -fx-background-radius: 0.25em;
+    -fx-border-radius: 0.25em;
 }
 
 /* ParseLatexResult */
@@ -1387,8 +1390,8 @@ We want to have a look that matches our icons in the tool-bar */
 
 .exampleQuestionStyle {
     -fx-background-color: transparent;
-    -fx-background-radius: 20px;
-    -fx-border-radius: 20px;
+    -fx-background-radius: 0.25em;
+    -fx-border-radius: 0.25em;
     -fx-border-width: 0.062em;
     -fx-border-color: -color-border-default;
     -fx-font-weight: bold;
@@ -1416,8 +1419,8 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-background-color: -color-bg-alt;
     -fx-border-color: -color-border-default;
     -fx-border-width: 0.08333em;
-    -fx-border-radius: 0.333em;
-    -fx-background-radius: 0.333em;
+    -fx-border-radius: 0.25em;
+    -fx-background-radius: 0.25em;
     -fx-graphic-text-gap: 0.667em;
     -fx-text-fill: -fx-text-base-color;
     -fx-cursor: hand;

--- a/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
@@ -237,7 +237,7 @@
     -fx-background-color: -color-bg-primary;
 }
 
-/* JavaFX Button-like */
+/* JavaFX Button-like. */
 .button,
 .toggle-button,
 .menu-button,
@@ -248,6 +248,7 @@
     -fx-background-color: -fx-background;
     -fx-background-insets: 0;
     -fx-background-radius: 0.25em;
+    -fx-border-radius: 0.25em;
 }
 
 /* JavaFX Button */
@@ -416,7 +417,7 @@ TextFlow > .tooltip-text-monospaced {
 .color-picker:focused,
 .color-picker {
     -fx-background-color: transparent;
-    -fx-background-radius: 0;
+    -fx-background-radius: 0.25em;
     -fx-background-insets: 0;
     -fx-effect: null;
 }
@@ -464,7 +465,7 @@ TextFlow > .tooltip-text-monospaced {
 .menu-bar .menu-button {
     -fx-border-color: transparent;
     -fx-border-width: 0;
-    -fx-border-radius: 0;
+    -fx-border-radius: 0.25em;
 }
 
 
@@ -587,7 +588,7 @@ TextFlow > .tooltip-text-monospaced {
 .combo-box-base {
     -fx-background-color: -color-border-default, -color-bg-secondary;
     -fx-background-insets: 0, 1;
-    -fx-background-radius: 0;
+    -fx-background-radius: 0.25em;
 }
 
 .combo-box > .list-cell {
@@ -626,7 +627,7 @@ TextFlow > .tooltip-text-monospaced {
 .date-picker > .text-field {
     -fx-background-color: -color-border-default, -color-bg-secondary;
     -fx-background-insets: 0, 1;
-    -fx-background-radius: 0;
+    -fx-background-radius: 0.25em;
 }
 
 .combo-box-base:editable:focused > .text-field,
@@ -634,7 +635,7 @@ TextFlow > .tooltip-text-monospaced {
 .date-picker > .text-field:focused {
     -fx-background-color: -color-accent-subtle, -color-bg-secondary;
     -fx-background-insets: 0, 2;
-    -fx-background-radius: 0;
+    -fx-background-radius: 0.25em;
 }
 
 .date-picker:focused > .text-field {

--- a/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
@@ -276,13 +276,11 @@
 }
 
 .button:default:hover {
-    -fx-background: -color-button-default;
-    -fx-background-color: -fx-background, -color-button-hover;
+    -fx-background-color: -color-button-default, -color-button-hover;
 }
 
 .button:default:armed {
-    -fx-background: -color-button-default;
-    -fx-background-color: -fx-background, -color-button-pressed;
+    -fx-background-color: -color-button-default, -color-button-pressed;
 }
 
 /* JavaFX ToggleButton */

--- a/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
@@ -482,7 +482,6 @@ TextFlow > .tooltip-text-monospaced {
     -fx-border-radius: 0.25em;
 }
 
-
 .menu-bar > .container {
     -fx-border-width: 0;
 }

--- a/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
@@ -262,22 +262,38 @@
     -fx-background: -color-button-hover;
 }
 
-.button:focused,
-.button:pressed {
+.button:armed {
     -fx-background: -color-button-pressed;
 }
 
-.button:default,
-.button:default:hover,
-.button:default:focused,
-.button:default:pressed {
+.button:focused {
+    -fx-border-color: -color-accent;
+}
+
+.button:default {
     -fx-background: -color-button-default;
+    -fx-background-color: -fx-background;
+}
+
+.button:default:hover {
+    -fx-background: -color-button-default;
+    -fx-background-color: -fx-background, -color-button-hover;
+}
+
+.button:default:armed {
+    -fx-background: -color-button-default;
+    -fx-background-color: -fx-background, -color-button-pressed;
 }
 
 /* JavaFX ToggleButton */
 .toggle-button:hover,
 .toggle-button:selected:hover {
     -fx-background-color: -color-overlay-hover;
+}
+
+.toggle-button:armed,
+.toggle-button:selected:armed {
+    -fx-background-color: -color-overlay-armed;
 }
 
 .toggle-button:selected {

--- a/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
@@ -943,8 +943,3 @@ TextFlow > .tooltip-text-monospaced {
     -fx-alignment: center-left;
     -fx-text-fill: -fx-text-inner-color;
 }
-
-/* JavaFX WebView */
-.web-view {
-    -fx-page-fill: -color-fg-emphasis;
-}

--- a/jabgui/src/test/resources/org/jabref/testutils/interactive/styletester/StyleTester.fxml
+++ b/jabgui/src/test/resources/org/jabref/testutils/interactive/styletester/StyleTester.fxml
@@ -385,42 +385,42 @@
                         </graphic>
                     </Button>
                     <Label GridPane.columnIndex="0" GridPane.columnSpan="6" GridPane.rowIndex="4">Contained buttons:</Label>
-                    <Button styleClass="contained-button" text="Normal" GridPane.columnIndex="0" GridPane.rowIndex="5">
+                    <Button text="Normal" GridPane.columnIndex="0" GridPane.rowIndex="5">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>
                         </graphic>
                     </Button>
-                    <Button fx:id="containedButtonHover" styleClass="contained-button" text="Hover" GridPane.columnIndex="1"
+                    <Button fx:id="containedButtonHover" text="Hover" GridPane.columnIndex="1"
                             GridPane.rowIndex="5">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>
                         </graphic>
                     </Button>
-                    <Button fx:id="containedButtonPressed" styleClass="contained-button" text="Pressed"
+                    <Button fx:id="containedButtonPressed" text="Pressed"
                             GridPane.columnIndex="2" GridPane.rowIndex="5">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>
                         </graphic>
                     </Button>
-                    <Button fx:id="containedButtonFocused" styleClass="contained-button" text="Focused"
+                    <Button fx:id="containedButtonFocused" text="Focused"
                             GridPane.columnIndex="3" GridPane.rowIndex="5">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>
                         </graphic>
                     </Button>
-                    <Button disable="true" styleClass="contained-button" text="Disabled" GridPane.columnIndex="4"
+                    <Button disable="true" text="Disabled" GridPane.columnIndex="4"
                             GridPane.rowIndex="5">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>
                         </graphic>
                     </Button>
-                    <Button defaultButton="true" styleClass="contained-button" text="Default" GridPane.columnIndex="5"
+                    <Button defaultButton="true" text="Default" GridPane.columnIndex="5"
                             GridPane.rowIndex="5">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>
                         </graphic>
                     </Button>
-                    <Button cancelButton="true" styleClass="contained-button" text="Cancel" GridPane.columnIndex="6"
+                    <Button cancelButton="true" text="Cancel" GridPane.columnIndex="6"
                             GridPane.rowIndex="5">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>

--- a/jabgui/src/test/resources/org/jabref/testutils/interactive/styletester/StyleTester.fxml
+++ b/jabgui/src/test/resources/org/jabref/testutils/interactive/styletester/StyleTester.fxml
@@ -343,42 +343,42 @@
                         </graphic>
                     </Button>
                     <Label GridPane.columnIndex="0" GridPane.columnSpan="6" GridPane.rowIndex="2">Text buttons:</Label>
-                    <Button styleClass="text-button" text="Normal" GridPane.columnIndex="0" GridPane.rowIndex="3">
+                    <Button text="Normal" GridPane.columnIndex="0" GridPane.rowIndex="3">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>
                         </graphic>
                     </Button>
-                    <Button fx:id="textButtonHover" styleClass="text-button" text="Hover" GridPane.columnIndex="1"
+                    <Button fx:id="textButtonHover" text="Hover" GridPane.columnIndex="1"
                             GridPane.rowIndex="3">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>
                         </graphic>
                     </Button>
-                    <Button fx:id="textButtonPressed" styleClass="text-button" text="Pressed" GridPane.columnIndex="2"
+                    <Button fx:id="textButtonPressed"text="Pressed" GridPane.columnIndex="2"
                             GridPane.rowIndex="3">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>
                         </graphic>
                     </Button>
-                    <Button fx:id="textButtonFocused" styleClass="text-button" text="Focused" GridPane.columnIndex="3"
+                    <Button fx:id="textButtonFocused"text="Focused" GridPane.columnIndex="3"
                             GridPane.rowIndex="3">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>
                         </graphic>
                     </Button>
-                    <Button disable="true" styleClass="text-button" text="Disabled" GridPane.columnIndex="4"
+                    <Button disable="true"text="Disabled" GridPane.columnIndex="4"
                             GridPane.rowIndex="3">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>
                         </graphic>
                     </Button>
-                    <Button defaultButton="true" styleClass="text-button" text="Default" GridPane.columnIndex="5"
+                    <Button defaultButton="true"text="Default" GridPane.columnIndex="5"
                             GridPane.rowIndex="3">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>
                         </graphic>
                     </Button>
-                    <Button cancelButton="true" styleClass="text-button" text="Cancel" GridPane.columnIndex="6"
+                    <Button cancelButton="true"text="Cancel" GridPane.columnIndex="6"
                             GridPane.rowIndex="3">
                         <graphic>
                             <JabRefIconView glyph="ADD_NOBOX"/>


### PR DESCRIPTION
### Summary

All `Button`s have:
- a corner radius now
- hover color
- pressed (armed) color
- focused border when navigating with TAB 

### Steps to test

Open JabRef, check the Toolbar and Dialog `Button`s.

<img width="671" height="371" alt="image" src="https://github.com/user-attachments/assets/a8c9034a-52e8-46e8-92eb-ca5eff8e71ee" />

<img width="218" height="115" alt="image" src="https://github.com/user-attachments/assets/9ab49a53-52b6-4685-8fea-2793a0d730f5" />

### Related issues and pull requests

Closes: https://github.com/JabRef/jabref/issues/16974

### AI usage

Nope.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
