### PR TITLE
Use pattern matching for switch in several classes

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/AllFieldsTab.java
@@ -680,13 +680,18 @@ public class AllFieldsTab extends FieldsEditorTab {
     /// natural-height list that blows up the rows' preferred heights, so reset text fields to
     /// their computed size and cap text areas at a few visible rows.
     private static void normalizeInputHeights(Node node) {
-        if (node instanceof TextArea textArea) {
-            textArea.setPrefRowCount(MULTILINE_ROWS);
-            textArea.setPrefHeight(Region.USE_COMPUTED_SIZE);
-        } else if (node instanceof TextField textField) {
-            textField.setPrefHeight(Region.USE_COMPUTED_SIZE);
-        } else if (node instanceof Parent parent) {
-            parent.getChildrenUnmodifiable().forEach(AllFieldsTab::normalizeInputHeights);
+        switch (node) {
+            case TextArea textArea -> {
+                textArea.setPrefRowCount(MULTILINE_ROWS);
+                textArea.setPrefHeight(Region.USE_COMPUTED_SIZE);
+            }
+            case TextField textField ->
+                    textField.setPrefHeight(Region.USE_COMPUTED_SIZE);
+            case Parent parent ->
+                    parent.getChildrenUnmodifiable().forEach(AllFieldsTab::normalizeInputHeights);
+            case null,
+                 default -> {
+            }
         }
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
@@ -529,37 +529,33 @@ public class GroupNodeViewModel {
 
     public boolean canAddEntriesIn() {
         AbstractGroup group = groupNode.getGroup();
-        if (group instanceof AllEntriesGroup) {
-            return false;
-        } else if (group instanceof ExplicitGroup) {
-            return true;
-        } else if (group instanceof LastNameGroup || group instanceof RegexKeywordGroup) {
-            return groupNode.getParent()
-                            .map(GroupTreeNode::getGroup)
-                            .map(groupParent -> groupParent instanceof AutomaticKeywordGroup || groupParent instanceof AutomaticPersonsGroup)
-                            .orElse(false);
-        } else if (group instanceof KeywordGroup) {
-            // also covers WordKeywordGroup
-            return true;
-        } else if (group instanceof SearchGroup) {
-            return false;
-        } else if (group instanceof AutomaticKeywordGroup) {
-            return false;
-        } else if (group instanceof AutomaticPersonsGroup) {
-            return false;
-        } else if (group instanceof TexGroup) {
-            return false;
-        } else if (group instanceof AutomaticDateGroup) {
-            return false;
-        } else if (group instanceof DateGroup) {
-            return false;
-        } else if (group instanceof AutomaticEntryTypeGroup) {
-            return false;
-        } else if (group instanceof EntryTypeGroup) {
-            return false;
-        } else {
-            throw new UnsupportedOperationException("canAddEntriesIn method not yet implemented in group: " + group.getClass().getName());
-        }
+        return switch (group) {
+            case AllEntriesGroup _,
+                 SearchGroup _,
+                 AutomaticKeywordGroup _,
+                 AutomaticPersonsGroup _,
+                 AutomaticDateGroup _,
+                 DateGroup _,
+                 AutomaticEntryTypeGroup _,
+                 EntryTypeGroup _,
+                 TexGroup _ ->
+                    false;
+            case ExplicitGroup _ ->
+                    true;
+            case LastNameGroup _,
+                 RegexKeywordGroup _ ->
+                    groupNode.getParent()
+                             .map(GroupTreeNode::getGroup)
+                             .map(groupParent -> groupParent instanceof AutomaticKeywordGroup || groupParent instanceof AutomaticPersonsGroup)
+                             .orElse(false);
+            case KeywordGroup _ ->
+                // also covers WordKeywordGroup
+                    true;
+            case null ->
+                    throw new IllegalArgumentException("Group cannot be null");
+            default ->
+                    throw new UnsupportedOperationException("canAddEntriesIn method not yet implemented in group: " + group.getClass().getName());
+        };
     }
 
     public boolean canBeDragged() {

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -624,33 +624,33 @@ public class OOBibBase {
         try {
 
             UnoUndo.enterUndoContext(doc, "Insert citation");
-            OOVoidResult<OOError> result = OOVoidResult.ok();
-            if (style instanceof CitationStyle citationStyle) {
-                // Handle insertion of CSL Style citations
-                result = insertCSLCitation(entries,
-                        doc,
-                        citationType,
-                        citationStyle,
-                        bibDatabaseContext,
-                        selectedDatabases,
-                        cursor,
-                        syncOptions);
-            } else if (style instanceof BstStyle bstStyle) {
-                // Handle insertion of BST citations
-                result = insertBstCitation(entries, doc, bstStyle, bibDatabaseContext, cursor);
-            } else if (style instanceof JStyle jStyle) {
-                // Handle insertion of JStyle citations
-                result = insertJStyleCitation(entries,
-                        doc,
-                        citationType,
-                        jStyle,
-                        frontend,
-                        cursor,
-                        bibDatabaseContext,
-                        syncOptions,
-                        pageInfo,
-                        fcursor);
-            }
+            OOVoidResult<OOError> result = switch (style) {
+                case CitationStyle citationStyle ->
+                        insertCSLCitation(entries,
+                                doc,
+                                citationType,
+                                citationStyle,
+                                bibDatabaseContext,
+                                selectedDatabases,
+                                cursor,
+                                syncOptions);
+                case BstStyle bstStyle ->
+                        insertBstCitation(entries, doc, bstStyle, bibDatabaseContext, cursor);
+                case JStyle jStyle ->
+                        insertJStyleCitation(entries,
+                                doc,
+                                citationType,
+                                jStyle,
+                                frontend,
+                                cursor,
+                                bibDatabaseContext,
+                                syncOptions,
+                                pageInfo,
+                                fcursor);
+                case null,
+                     default ->
+                        OOVoidResult.ok();
+            };
             testDialog(errorTitle, result);
         } finally {
             UnoUndo.leaveUndoContext(doc);
@@ -940,14 +940,15 @@ public class OOBibBase {
         ExportCited.GenerateDatabaseResult result = null;
         try {
             UnoUndo.enterUndoContext(doc, "Changes during \"Export cited\"");
-            OOResult<ExportCited.GenerateDatabaseResult, JabRefException> generateResult;
-            if (style instanceof CitationStyle) {
-                generateResult = exportCitedForCSL(databases);
-            } else if (style instanceof BstStyle) {
-                generateResult = exportCitedForBST(databases);
-            } else {
-                generateResult = ExportCited.generateDatabase(doc, databases);
-            }
+            OOResult<ExportCited.GenerateDatabaseResult, JabRefException> generateResult = switch (style) {
+                case CitationStyle _ ->
+                        exportCitedForCSL(databases);
+                case BstStyle _ ->
+                        exportCitedForBST(databases);
+                case null,
+                     default ->
+                        ExportCited.generateDatabase(doc, databases);
+            };
             if (testDialog(errorTitle, generateResult.asVoidResult().mapError(OOError::from))) {
                 return FAIL;
             }

--- a/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesFilter.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesFilter.java
@@ -61,21 +61,23 @@ public class PreferencesFilter {
         }
 
         private PreferenceType getType(Object value) {
-            if (value instanceof Boolean) {
-                return PreferenceType.BOOLEAN;
-            } else if (value instanceof Integer) {
-                return PreferenceType.INTEGER;
-            } else if (value instanceof Double) {
-                return PreferenceType.DOUBLE;
-            } else if (value instanceof Map) {
-                return PreferenceType.MAP;
-            } else if (value instanceof Set) {
-                return PreferenceType.SET;
-            } else if (value instanceof List) {
-                return PreferenceType.LIST;
-            } else {
-                return PreferenceType.STRING;
-            }
+            return switch (value) {
+                case Boolean _ ->
+                        PreferenceType.BOOLEAN;
+                case Integer _ ->
+                        PreferenceType.INTEGER;
+                case Double _ ->
+                        PreferenceType.DOUBLE;
+                case Map<?, ?> _ ->
+                        PreferenceType.MAP;
+                case Set<?> _ ->
+                        PreferenceType.SET;
+                case List<?> _ ->
+                        PreferenceType.LIST;
+                case null,
+                     default ->
+                        PreferenceType.STRING;
+            };
         }
 
         public boolean isUnchanged() {

--- a/jabgui/src/main/java/org/jabref/gui/util/component/MarkdownTextFlow.java
+++ b/jabgui/src/main/java/org/jabref/gui/util/component/MarkdownTextFlow.java
@@ -210,45 +210,54 @@ public class MarkdownTextFlow extends SelectableTextFlow {
     private String getMarkdownRepresentation(Node astNode, String renderedText) {
         if ("\n".equals(renderedText) || "\n\n".equals(renderedText)) {
             return renderedText;
-        } else if (astNode instanceof Heading heading) {
-            return "#".repeat(heading.getLevel()) + " " + heading.getText().toString().trim();
-        } else if (astNode instanceof Code) {
-            return "`" + astNode.getChildChars() + "`";
-        } else if (astNode instanceof Emphasis) {
-            return "*" + astNode.getChildChars() + "*";
-        } else if (astNode instanceof StrongEmphasis) {
-            return "**" + astNode.getChildChars() + "**";
-        } else if (astNode instanceof Link link) {
-            String linkText = link.getText().toString();
-            String url = link.getUrl().toString();
-            String title = link.getTitle().toString();
-            if (title.isEmpty()) {
-                return "[" + linkText + "](" + url + ")";
-            } else {
-                return "[" + linkText + "](" + url + " \"" + title + "\")";
-            }
-        } else if (astNode instanceof LinkRef linkRef) {
-            String linkText = linkRef.getText().toString();
-            String reference = linkRef.getReference().toString();
-            return "[" + linkText + "][" + reference + "]";
-        } else if (astNode instanceof FencedCodeBlock fencedCodeBlock) {
-            String info = fencedCodeBlock.getInfo().toString();
-            String openingFence = fencedCodeBlock.getOpeningFence().toString();
-            String closingFence = fencedCodeBlock.getClosingFence().toString();
-            // NOTE: Hack. Flexmark always add \n at beginning, \n\n at end.
-            String content = fencedCodeBlock.getContentChars().toString();
-            return openingFence + info + content.substring(0, content.length() - 1) + closingFence;
-        } else if (astNode instanceof IndentedCodeBlock) {
-            return astNode.getChars().toString();
-        } else if (astNode instanceof BlockQuote) {
-            return renderedText;
-        } else if (renderedText.matches(BULLET_LIST_PATTERN)) {
-            return renderedText.replace(UNICODE_BULLET, "-");
-        } else if (renderedText.matches(NUMBERED_LIST_PATTERN)) {
-            return renderedText;
-        } else {
-            return renderedText;
         }
+        return switch (astNode) {
+            case Heading heading ->
+                    "#".repeat(heading.getLevel()) + " " + heading.getText().toString().trim();
+            case Code code ->
+                    "`" + code.getChildChars() + "`";
+            case Emphasis emphasis ->
+                    "*" + emphasis.getChildChars() + "*";
+            case StrongEmphasis strongEmphasis ->
+                    "**" + strongEmphasis.getChildChars() + "**";
+            case Link link -> {
+                String linkText = link.getText().toString();
+                String url = link.getUrl().toString();
+                String title = link.getTitle().toString();
+                if (title.isEmpty()) {
+                    yield "[" + linkText + "](" + url + ")";
+                } else {
+                    yield "[" + linkText + "](" + url + " \"" + title + "\")";
+                }
+            }
+            case LinkRef linkRef -> {
+                String linkText = linkRef.getText().toString();
+                String reference = linkRef.getReference().toString();
+                yield "[" + linkText + "][" + reference + "]";
+            }
+            case FencedCodeBlock fencedCodeBlock -> {
+                String info = fencedCodeBlock.getInfo().toString();
+                String openingFence = fencedCodeBlock.getOpeningFence().toString();
+                String closingFence = fencedCodeBlock.getClosingFence().toString();
+                // NOTE: Hack. Flexmark always add \n at beginning, \n\n at end.
+                String content = fencedCodeBlock.getContentChars().toString();
+                yield openingFence + info + content.substring(0, content.length() - 1) + closingFence;
+            }
+            case IndentedCodeBlock indentedCodeBlock ->
+                    indentedCodeBlock.getChars().toString();
+            case BlockQuote _ ->
+                    renderedText;
+            case null,
+                 default -> {
+                if (renderedText.matches(BULLET_LIST_PATTERN)) {
+                    yield renderedText.replace(UNICODE_BULLET, "-");
+                } else if (renderedText.matches(NUMBERED_LIST_PATTERN)) {
+                    yield renderedText;
+                } else {
+                    yield renderedText;
+                }
+            }
+        };
     }
 
     private class MarkdownRenderer {

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/MathSciNet.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/MathSciNet.java
@@ -231,13 +231,15 @@ public class MathSciNet implements SearchBasedParserFetcher, EntryBasedParserFet
             }
         }
 
-        if (value instanceof String stringValue) {
-            return Optional.of(fixStringEncoding(stringValue));
-        } else if (value instanceof Integer intValue) {
-            return Optional.of(intValue.toString());
-        }
-
-        return Optional.empty();
+        return switch (value) {
+            case String stringValue ->
+                    Optional.of(fixStringEncoding(stringValue));
+            case Integer intValue ->
+                    Optional.of(intValue.toString());
+            case null,
+                 default ->
+                    Optional.empty();
+        };
     }
 
     /// Method to change character set, to fix output string encoding

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -1006,25 +1006,27 @@ public class JabRefCliPreferences implements CliPreferences {
     }
 
     private Object getObject(Observable observable) {
-        if (observable instanceof BooleanProperty booleanProperty) {
-            return booleanProperty.get();
-        } else if (observable instanceof IntegerProperty integerProperty) {
-            return integerProperty.get();
-        } else if (observable instanceof DoubleProperty doubleProperty) {
-            return doubleProperty.get();
-        } else if (observable instanceof StringProperty stringProperty) {
-            return stringProperty.get();
-        } else if (observable instanceof ObservableList<?> observableList) {
-            return observableList;
-        } else if (observable instanceof ObservableSet<?> observableSet) {
-            return observableSet;
-        } else if (observable instanceof ObservableMap<?, ?> observableMap) {
-            return observableMap;
-        } else if (observable instanceof ObjectProperty<?> objectProperty) {
-            return objectProperty.get();
-        }
-
-        return null;
+        return switch (observable) {
+            case BooleanProperty booleanProperty ->
+                    booleanProperty.get();
+            case IntegerProperty integerProperty ->
+                    integerProperty.get();
+            case DoubleProperty doubleProperty ->
+                    doubleProperty.get();
+            case StringProperty stringProperty ->
+                    stringProperty.get();
+            case ObservableList<?> observableList ->
+                    observableList;
+            case ObservableSet<?> observableSet ->
+                    observableSet;
+            case ObservableMap<?, ?> observableMap ->
+                    observableMap;
+            case ObjectProperty<?> objectProperty ->
+                    objectProperty.get();
+            case null,
+                 default ->
+                    null;
+        };
     }
 
     @Override


### PR DESCRIPTION
Combines several small refactorings that convert traditional `switch` statements to Java pattern-matching `switch` expressions, improving readability and exhaustiveness checking. No behavior changes.

### Related issues and pull requests

Triggered by github.com/JabRef/jabref-koppor/pull/751, github.com/JabRef/jabref-koppor/pull/752, github.com/JabRef/jabref-koppor/pull/753, github.com/JabRef/jabref-koppor/pull/754, github.com/JabRef/jabref-koppor/pull/756, github.com/JabRef/jabref-koppor/pull/757, github.com/JabRef/jabref-koppor/pull/758

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvTi9rK3SapsH2vVS8tSp5