### PR TITLE
Fix truncated validation icons in entry types and box border

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
@@ -89,7 +89,7 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
             tabTitle.setText(tab.getTitle());
             Node content = tab.getContent();
             preferencesContainer.setContent(content);
-            content.getStyleClass().add("padding-4");
+            content.getStyleClass().addAll("padding-4", "preferences-tab-content");
         });
 
         if (this.preferencesTabToSelectClass != null) {

--- a/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/theme/jabref-theme.css
@@ -311,7 +311,7 @@
     -fx-background-insets: 0;
     -fx-background-radius: 0;
     -fx-text-fill: -fx-text-base-color;
-    -fx-border-color: -color-border-default;
+    -fx-border-color: -color-fg-muted;
     -fx-border-width: 0.125em;
     -fx-border-radius: 0.062em;
     -fx-padding: 0.1em 0.1em 0.2em 0.2em;
@@ -368,6 +368,10 @@
 .dialog-pane {
     -fx-font-size: 1em;
     -fx-background-color: -color-bg-overlay;
+}
+
+.preferences-dialog .preferences-tab-content {
+    -fx-padding: 0.333em 0.333em 0.333em 0.667em;
 }
 
 /* JavaFX TextFlow / HyperLink */


### PR DESCRIPTION
## Summary
- fixed clipped validation icons in entry type preferences.
- The checkbox border was also adjusted to see the box easily 

## Steps to test

1. Open JabRef.
2. Open Preferences and go to the Entry Types tab.
3. Enter an invalid entry type or field containing spaces.
4. Check that the validation warning icon is fully visible.
5. Check that the Required and Multiline checkbox borders are clearly visible.

## Related issues and pull requests

Closes #16997

## AI usage

So I take help from ChatGPT (GPT-5.6 Luna) to investigate and understand the UI issue and review the changes. The changes were manually reviewed, understood, and tested.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

- [x] I reviewed the changes and understand the submitted code.
- [x] I manually tested the changes in running JabRef.
- [/] I did not add JUnit tests because this is a UI/CSS layout change.
- [x] I added screenshots showing the visible UI changes.
- [x] I added a CHANGELOG entry.
- [/] I checked the user documentation and determined that no documentation update is needed.

</details>

Screenshot
<img width="662" height="589" alt="Image" src="https://github.com/user-attachments/assets/9e929396-e6ec-4c7a-a3b9-f14361467d24" />

<img width="701" height="202" alt="Image" src="https://github.com/user-attachments/assets/555aa2bd-addb-4234-bd97-1749b6fc4a5d" />

<img width="671" height="259" alt="Image" src="https://github.com/user-attachments/assets/a849ef1e-fafa-456a-8a7e-085e791e56dd" />

## Checklist

- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added one sentence (max 20 words) to CHANGELOG.md describing the change from the user's point of view
- [/] I checked the user documentation for up to dateness and determined that no update is needed

jabref-contrib-policy:4.2:reviewed:ok