### PR TITLE
Fix duplicate detection across entry types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where newly added entries could not be found in search. [#15719](https://github.com/JabRef/jabref/issues/15719)
 - We fixed a performance issue with the duplicate resolving when copying and pasting many entries. [#15780](https://github.com/JabRef/jabref/pull/15780)
 - We fixed an issue where the duplicate finder progress counter displayed incorrect values, not reflecting the actual number of duplicate pairs reviewed by the user. [#11848](https://github.com/JabRef/jabref/issues/11848)
+- We fixed duplicate detection for matching publications stored under different entry types. [#16580](https://github.com/JabRef/jabref/issues/16580)
 - We fixed an issue where non latin caseless author names being parsed as nameprefix instead of familyname. [#15813](https://github.com/JabRef/jabref/issues/15813)
 - We fixed an issue where `Quality-> Cleanup -> Rename PDF` together with `Moved linked files to file directory` would lead to an exception. [#15833](https://github.com/JabRef/jabref/issues/15833)
 - We fixed an issue where renaming a linked file with a very long title showed a misleading "file is being used by another process" error instead of renaming successfully. [#14771](https://github.com/JabRef/jabref/issues/14771)

--- a/docs/requirements/duplicate-detection.md
+++ b/docs/requirements/duplicate-detection.md
@@ -1,0 +1,30 @@
+---
+parent: Requirements
+---
+# Duplicate detection
+
+## Match publications independently of entry type
+`req~duplicates.type-independent-matching~1`
+
+Entries describing the same publication can be detected as duplicates even when their entry types differ.
+Changing an entry's type or swapping the order of the entries does not change the duplicate decision.
+For example, the Article and Misc entries in [issue #16580](https://github.com/JabRef/jabref/issues/16580) are duplicates.
+
+A shared unique publication identifier, such as a DOI, continues to identify a duplicate directly.
+Otherwise, a matching title and at least one matching author, editor, date, year, or ISBN are required before evaluating weighted field similarity.
+A shared author alone does not identify a publication.
+Conflicting editions and different chapters or pages of the same publication retain their existing exclusions.
+Citation keys, group memberships, and linked-file locations do not affect the publication comparison.
+
+Needs: impl, utest
+
+### Implementation notes
+
+`DuplicateCheck.isDuplicate` compares the union of populated bibliographic fields with the existing field comparison helpers and a threshold of 0.75.
+Core publication fields receive the previous factor of three consistently across all entry types; the required and optional fields of an entry type no longer determine the score.
+The constructor and database-mode argument remain available for existing callers.
+
+`compareEntriesStrictly` continues to compare complete records, including their entry types.
+Finding a possible duplicate across types therefore does not make it an exact duplicate for automatic removal.
+
+<!-- markdownlint-disable-file MD022 -->

--- a/jablib/src/main/java/org/jabref/logic/database/DuplicateCheck.java
+++ b/jablib/src/main/java/org/jabref/logic/database/DuplicateCheck.java
@@ -5,11 +5,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jabref.logic.os.OS;
 import org.jabref.logic.util.strings.StringSimilarity;
@@ -18,25 +18,18 @@ import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.AuthorList;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.BibEntryType;
 import org.jabref.model.entry.BibEntryTypesManager;
-import org.jabref.model.entry.field.BibField;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldProperty;
-import org.jabref.model.entry.field.OrFields;
+import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.entry.field.StandardField;
-import org.jabref.model.entry.identifier.ISBN;
-import org.jabref.model.entry.types.StandardEntryType;
 
 import com.google.common.collect.Sets;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /// This class contains utility method for duplicate checking of entries.
 public class DuplicateCheck {
     private static final double DUPLICATE_THRESHOLD = 0.75; // The overall threshold to signal a duplicate pair
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DuplicateCheck.class);
     /*
      * Integer values for indicating result of duplicate check (for entries):
      */
@@ -46,32 +39,28 @@ public class DuplicateCheck {
     private static final int EMPTY_IN_TWO = 3;
 
     private static final int EMPTY_IN_BOTH = 4;
-    // Non-required fields are investigated only if the required fields give a value within
-    // the doubt range of the threshold:
-    private static final double DOUBT_RANGE = 0.05;
-
-    private static final double REQUIRED_WEIGHT = 3; // Weighting of all required fields
-
     // Extra weighting of those fields that are most likely to provide correct duplicate detection:
+    private static final double CORE_FIELD_WEIGHT = 3;
+    private static final Set<Field> CORE_FIELDS = Set.of(
+            StandardField.AUTHOR, StandardField.EDITOR, StandardField.TITLE,
+            StandardField.JOURNAL, StandardField.JOURNALTITLE, StandardField.BOOKTITLE,
+            StandardField.PUBLISHER, StandardField.DATE, StandardField.YEAR);
     private static final Map<Field, Double> FIELD_WEIGHTS = new HashMap<>();
     private static final Pattern PAGE_SEPARATOR_PATTERN = Pattern.compile("[\\p{Pd} ]+");
-
-    private static final Set<StandardEntryType> STANDARD_ENTRY_TYPES = Set.of(StandardEntryType.Article, StandardEntryType.InBook, StandardEntryType.InCollection);
 
     static {
         DuplicateCheck.FIELD_WEIGHTS.put(StandardField.AUTHOR, 2.5);
         DuplicateCheck.FIELD_WEIGHTS.put(StandardField.EDITOR, 2.5);
         DuplicateCheck.FIELD_WEIGHTS.put(StandardField.TITLE, 3.);
         DuplicateCheck.FIELD_WEIGHTS.put(StandardField.JOURNAL, 2.);
+        DuplicateCheck.FIELD_WEIGHTS.put(StandardField.JOURNALTITLE, 2.);
         DuplicateCheck.FIELD_WEIGHTS.put(StandardField.NOTE, 0.1);
         DuplicateCheck.FIELD_WEIGHTS.put(StandardField.COMMENT, 0.1);
         DuplicateCheck.FIELD_WEIGHTS.put(StandardField.DOI, 3.);
     }
 
-    private final BibEntryTypesManager entryTypesManager;
-
+    /// The parameter is retained for compatibility; matching does not depend on entry-type definitions.
     public DuplicateCheck(BibEntryTypesManager entryTypesManager) {
-        this.entryTypesManager = entryTypesManager;
     }
 
     private static boolean haveSameIdentifier(final BibEntry one, final BibEntry two) {
@@ -107,43 +96,15 @@ public class DuplicateCheck {
                         (compareSingleField(StandardField.PAGES, one, two) == NOT_EQUAL));
     }
 
-    private static double[] compareRequiredFields(final BibEntryType type, final BibEntry one, final BibEntry two) {
-        final Set<OrFields> requiredFields = type.getRequiredFields();
-        return requiredFields.isEmpty()
-               ? new double[] {0., 0.}
-               : DuplicateCheck.compareFieldSet(requiredFields.stream().map(OrFields::getPrimary).collect(Collectors.toSet()), one, two);
-    }
-
-    private static boolean isFarFromThreshold(double value) {
-        if (value < 0.0) {
-            LOGGER.trace("Value {} is below zero. Should not happen", value);
-        }
-        return value - DuplicateCheck.DUPLICATE_THRESHOLD > DuplicateCheck.DOUBT_RANGE;
-    }
-
-    private static boolean compareOptionalFields(final BibEntryType type,
-                                                 final BibEntry one,
-                                                 final BibEntry two,
-                                                 final double[] req) {
-        final Set<BibField> optionalFields = type.getOptionalFields();
-        if (optionalFields.isEmpty()) {
-            return req[0] >= DuplicateCheck.DUPLICATE_THRESHOLD;
-        }
-        final double[] opt = DuplicateCheck.compareFieldSet(optionalFields.stream().map(BibField::field).collect(Collectors.toSet()), one, two);
-        final double numerator = (DuplicateCheck.REQUIRED_WEIGHT * req[0] * req[1]) + (opt[0] * opt[1]);
-        final double denominator = (req[1] * DuplicateCheck.REQUIRED_WEIGHT) + opt[1];
-        final double totValue = numerator / denominator;
-        return totValue >= DuplicateCheck.DUPLICATE_THRESHOLD;
-    }
-
-    private static double[] compareFieldSet(final Collection<Field> fields, final BibEntry one, final BibEntry two) {
+    private static double compareFieldSet(final Collection<Field> fields, final BibEntry one, final BibEntry two) {
         if (fields.isEmpty()) {
-            return new double[] {0.0, 0.0};
+            return 0.0;
         }
         double equalWeights = 0;
         double totalWeights = 0.;
         for (final Field field : fields) {
-            final double currentWeight = DuplicateCheck.FIELD_WEIGHTS.getOrDefault(field, 1.0);
+            final double currentWeight = DuplicateCheck.FIELD_WEIGHTS.getOrDefault(field, 1.0)
+                    * (CORE_FIELDS.contains(field) ? CORE_FIELD_WEIGHT : 1.0);
             totalWeights += currentWeight;
             int result = DuplicateCheck.compareSingleField(field, one, two);
             if (result == EQUAL) {
@@ -153,10 +114,10 @@ public class DuplicateCheck {
             }
         }
         if (totalWeights > 0) {
-            return new double[] {equalWeights / totalWeights, totalWeights};
+            return equalWeights / totalWeights;
         }
         // all fields are empty in both --> have no difference at all
-        return new double[] {0.0, 0.0};
+        return 0.0;
     }
 
     private static int compareSingleField(final Field field, final BibEntry one, final BibEntry two) {
@@ -282,49 +243,29 @@ public class DuplicateCheck {
         return StringUtil.equalsUnifiedLineBreak(one.getField(field), two.getField(field));
     }
 
-    /// Checks if the two entries represent the same publication.
+    /// Checks if the two entries represent the same publication, independently of their entry types.
+    // [impl->req~duplicates.type-independent-matching~1]
     public boolean isDuplicate(final BibEntry one, final BibEntry two, final BibDatabaseMode bibDatabaseMode) {
-        // Checks DOI and other identifiers
         if (haveSameIdentifier(one, two)) {
             return true;
         }
 
-        // TODO: Work on haveDifferentEntryType - InCollection and InProceedings could point to the same publication
-        if (haveDifferentEntryType(one, two) ||
-                haveDifferentEditions(one, two) ||
-                haveDifferentChaptersOrPagesOfTheSameBook(one, two)) {
+        if (haveDifferentEditions(one, two) || haveDifferentChaptersOrPagesOfTheSameBook(one, two)) {
             return false;
         }
 
-        // In case an ISBN is present, it is a strong indicator that the entries are equal.
-        // Only in InBook, InCollection, or Article the ISBN may be equal and the publication on different pages (and thus not equal)
-        Optional<ISBN> oneISBN = one.getISBN();
-        Optional<ISBN> twoISBN = two.getISBN();
-        if (oneISBN.isPresent() && twoISBN.isPresent()
-                && Objects.equals(oneISBN, twoISBN)
-                && one.getType() instanceof StandardEntryType standardEntry
-                && !STANDARD_ENTRY_TYPES.contains(standardEntry)) {
-            return true;
+        // A shared author or personal metadata alone does not identify a publication.
+        if (compareSingleField(StandardField.TITLE, one, two) != EQUAL ||
+                Stream.of(StandardField.AUTHOR, StandardField.EDITOR, StandardField.DATE, StandardField.YEAR, StandardField.ISBN)
+                      .noneMatch(field -> compareSingleField(field, one, two) == EQUAL)) {
+            return false;
         }
 
-        final Optional<BibEntryType> type = entryTypesManager.enrich(one.getType(), bibDatabaseMode);
-        if (type.isPresent()) {
-            BibEntryType entryType = type.get();
-            final double[] reqCmpResult = compareRequiredFields(entryType, one, two);
-
-            if (isFarFromThreshold(reqCmpResult[0])) {
-                // Far from the threshold value, so we base our decision on the required fields only
-                return reqCmpResult[0] >= DuplicateCheck.DUPLICATE_THRESHOLD;
-            }
-
-            // Close to the threshold value, so we take a look at the optional fields, if any:
-            if (compareOptionalFields(type.get(), one, two, reqCmpResult)) {
-                return true;
-            }
-        }
-        // if type is not present, so simply compare fields without any distinction between optional/required
-        // In case both required and optional fields are equal, we also use this fallback
-        return compareFieldSet(Sets.union(one.getFields(), two.getFields()), one, two)[0] >= DuplicateCheck.DUPLICATE_THRESHOLD;
+        Set<Field> fields = Sets.union(one.getFields(), two.getFields()).stream()
+                               .filter(field -> !(field instanceof InternalField))
+                               .filter(field -> field != StandardField.GROUPS && field != StandardField.FILE)
+                               .collect(Collectors.toSet());
+        return compareFieldSet(fields, one, two) >= DUPLICATE_THRESHOLD;
     }
 
     /// Goes through all entries in the given database, and if at least one of

--- a/jablib/src/main/java/org/jabref/logic/relatedwork/RelatedWorkMatcher.java
+++ b/jablib/src/main/java/org/jabref/logic/relatedwork/RelatedWorkMatcher.java
@@ -11,6 +11,7 @@ import org.jabref.logic.database.DuplicateCheck;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
+import org.jabref.model.entry.field.StandardField;
 
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
@@ -76,7 +77,12 @@ public class RelatedWorkMatcher {
     private Optional<BibEntry> findDuplicateBibEntry(BibEntry sourceEntry,
                                                      BibEntry parsedReference,
                                                      BibDatabaseContext databaseContext) {
-        return duplicateCheck.containsDuplicate(databaseContext.getDatabase(), parsedReference, databaseContext.getMode())
-                             .filter(duplicateEntry -> !duplicateEntry.getId().equals(sourceEntry.getId()));
+        // Imported references may contain only raw reference text rather than structured publication fields.
+        return databaseContext.getEntries().stream()
+                              .filter(entry -> parsedReference.hasField(StandardField.COMMENT) &&
+                                      DuplicateCheck.compareEntriesStrictly(parsedReference, entry) > 1)
+                              .findFirst()
+                              .or(() -> duplicateCheck.containsDuplicate(databaseContext.getDatabase(), parsedReference, databaseContext.getMode()))
+                              .filter(duplicateEntry -> !duplicateEntry.getId().equals(sourceEntry.getId()));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/database/DuplicateCheckTest.java
+++ b/jablib/src/test/java/org/jabref/logic/database/DuplicateCheckTest.java
@@ -29,6 +29,147 @@ public class DuplicateCheckTest {
     private BibEntry simpleInBook;
     private DuplicateCheck duplicateChecker;
 
+    private static BibEntry architecturalDecision(StandardEntryType type) {
+        return new BibEntry(type)
+                .withField(StandardField.AUTHOR, "Zimmermann, Olaf")
+                .withField(StandardField.DATE, "2020")
+                .withField(StandardField.TITLE, "Architectural Decisions --- The Making Of")
+                .withField(StandardField.URL, "https://ozimmer.ch/practices/2020/04/27/ArchitectureDecisionMaking.html");
+    }
+
+    private static Stream<Arguments> entryTypePairs() {
+        return Stream.of(BibDatabaseMode.values()).flatMap(mode -> Stream.of(
+                Arguments.of(StandardEntryType.Article, StandardEntryType.Misc, mode),
+                Arguments.of(StandardEntryType.Misc, StandardEntryType.Article, mode),
+                Arguments.of(StandardEntryType.Article, StandardEntryType.Book, mode),
+                Arguments.of(StandardEntryType.Book, StandardEntryType.Article, mode),
+                Arguments.of(StandardEntryType.InCollection, StandardEntryType.InProceedings, mode),
+                Arguments.of(StandardEntryType.InProceedings, StandardEntryType.InCollection, mode),
+                Arguments.of(StandardEntryType.Article, StandardEntryType.Article, mode)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("entryTypePairs")
+    // [utest->req~duplicates.type-independent-matching~1]
+    void matchingPublicationsAreDuplicatesRegardlessOfType(StandardEntryType firstType, StandardEntryType secondType, BibDatabaseMode mode) {
+        assertTrue(duplicateChecker.isDuplicate(architecturalDecision(firstType), architecturalDecision(secondType), mode));
+    }
+
+    @ParameterizedTest
+    @MethodSource("entryTypePairs")
+    void entriesWithDifferentTitlesAreNotDuplicates(StandardEntryType firstType, StandardEntryType secondType, BibDatabaseMode mode) {
+        BibEntry second = architecturalDecision(secondType).withField(StandardField.TITLE, "A study of marine biology");
+
+        assertFalse(duplicateChecker.isDuplicate(architecturalDecision(firstType), second, mode));
+    }
+
+    @ParameterizedTest
+    @MethodSource("entryTypePairs")
+    void entriesWithDifferentAuthorsAreNotDuplicates(StandardEntryType firstType, StandardEntryType secondType, BibDatabaseMode mode) {
+        BibEntry second = architecturalDecision(secondType).withField(StandardField.AUTHOR, "Joyce, James");
+
+        assertFalse(duplicateChecker.isDuplicate(architecturalDecision(firstType), second, mode));
+    }
+
+    @ParameterizedTest
+    @MethodSource("entryTypePairs")
+    void entriesWithoutTitlesAreNotDuplicates(StandardEntryType firstType, StandardEntryType secondType, BibDatabaseMode mode) {
+        BibEntry first = architecturalDecision(firstType).withField(StandardField.TITLE, "");
+        BibEntry second = architecturalDecision(secondType).withField(StandardField.TITLE, "");
+
+        assertFalse(duplicateChecker.isDuplicate(first, second, mode));
+    }
+
+    @ParameterizedTest
+    @MethodSource("entryTypePairs")
+    void entriesWithOnlyMatchingTitlesAreNotDuplicates(StandardEntryType firstType, StandardEntryType secondType, BibDatabaseMode mode) {
+        BibEntry first = new BibEntry(firstType).withField(StandardField.TITLE, "Architectural Decisions --- The Making Of");
+        BibEntry second = new BibEntry(secondType).withField(StandardField.TITLE, "Architectural Decisions --- The Making Of");
+
+        assertFalse(duplicateChecker.isDuplicate(first, second, mode));
+    }
+
+    @ParameterizedTest
+    @MethodSource("entryTypePairs")
+    void entriesWithOnlyMatchingAuthorsAreNotDuplicates(StandardEntryType firstType, StandardEntryType secondType, BibDatabaseMode mode) {
+        BibEntry first = new BibEntry(firstType).withField(StandardField.AUTHOR, "Zimmermann, Olaf");
+        BibEntry second = new BibEntry(secondType).withField(StandardField.AUTHOR, "Zimmermann, Olaf");
+
+        assertFalse(duplicateChecker.isDuplicate(first, second, mode));
+    }
+
+    @ParameterizedTest
+    @MethodSource("entryTypePairs")
+    void personalFieldsDoNotAffectDuplicateDetection(StandardEntryType firstType, StandardEntryType secondType, BibDatabaseMode mode) {
+        BibEntry first = architecturalDecision(firstType).withCitationKey("first")
+                .withField(StandardField.GROUPS, "To read")
+                .withField(StandardField.FILE, ":first.pdf:PDF");
+        BibEntry second = architecturalDecision(secondType).withCitationKey("second")
+                .withField(StandardField.GROUPS, "Read")
+                .withField(StandardField.FILE, ":second.pdf:PDF");
+
+        assertTrue(duplicateChecker.isDuplicate(first, second, mode));
+    }
+
+    @ParameterizedTest
+    @MethodSource("entryTypePairs")
+    void entriesWithDifferentEditionsAreNotDuplicates(StandardEntryType firstType, StandardEntryType secondType, BibDatabaseMode mode) {
+        BibEntry first = architecturalDecision(firstType).withField(StandardField.EDITION, "1");
+        BibEntry second = architecturalDecision(secondType).withField(StandardField.EDITION, "2");
+
+        assertFalse(duplicateChecker.isDuplicate(first, second, mode));
+    }
+
+    @ParameterizedTest
+    @MethodSource("entryTypePairs")
+    void entriesWithDifferentPagesAreNotDuplicates(StandardEntryType firstType, StandardEntryType secondType, BibDatabaseMode mode) {
+        BibEntry first = architecturalDecision(firstType).withField(StandardField.PAGES, "1--10");
+        BibEntry second = architecturalDecision(secondType).withField(StandardField.PAGES, "11--20");
+
+        assertFalse(duplicateChecker.isDuplicate(first, second, mode));
+    }
+
+    @ParameterizedTest
+    @MethodSource("entryTypePairs")
+    void entriesWithIncompleteMetadataAndSameIsbnAreNotDuplicates(StandardEntryType firstType, StandardEntryType secondType, BibDatabaseMode mode) {
+        BibEntry first = architecturalDecision(firstType)
+                .withField(StandardField.DATE, "")
+                .withField(StandardField.YEAR, "2020")
+                .withField(StandardField.JOURNAL, "Journal of Software Architecture")
+                .withField(StandardField.ISBN, "0-123456-47-9");
+        BibEntry second = architecturalDecision(secondType)
+                .withField(StandardField.DATE, "")
+                .withField(StandardField.ISBN, "0-123456-47-9");
+
+        assertFalse(duplicateChecker.isDuplicate(first, second, mode));
+    }
+
+    @ParameterizedTest
+    @MethodSource("entryTypePairs")
+    void matchingCoreDetailsOutweighDifferentJournalAndVolume(StandardEntryType firstType, StandardEntryType secondType, BibDatabaseMode mode) {
+        BibEntry first = new BibEntry(firstType)
+                .withField(StandardField.AUTHOR, "Billy Bob")
+                .withField(StandardField.YEAR, "2005")
+                .withField(StandardField.TITLE, "A title")
+                .withField(StandardField.JOURNAL, "A")
+                .withField(StandardField.VOLUME, "21")
+                .withField(StandardField.NUMBER, "1")
+                .withField(StandardField.PAGES, "334--337");
+        BibEntry second = new BibEntry(first).withField(StandardField.JOURNAL, "B").withField(StandardField.VOLUME, "22");
+        second.setType(secondType);
+
+        assertTrue(duplicateChecker.isDuplicate(first, second, mode));
+    }
+
+    @ParameterizedTest
+    @MethodSource("entryTypePairs")
+    void matchingTitleAndDateCanIdentifyAnonymousPublications(StandardEntryType firstType, StandardEntryType secondType, BibDatabaseMode mode) {
+        BibEntry first = architecturalDecision(firstType).withField(StandardField.AUTHOR, "");
+        BibEntry second = architecturalDecision(secondType).withField(StandardField.AUTHOR, "");
+
+        assertTrue(duplicateChecker.isDuplicate(first, second, mode));
+    }
+
     private static BibEntry getSimpleArticle() {
         return new BibEntry(StandardEntryType.Article)
                 .withField(StandardField.AUTHOR, "Single Author")
@@ -71,17 +212,17 @@ public class DuplicateCheckTest {
     }
 
     @Test
-    void duplicateDetectionWithSameAuthor() {
+    void sameAuthorAloneDoesNotIdentifyAPublication() {
         BibEntry one = new BibEntry(StandardEntryType.Article).withField(StandardField.AUTHOR, "Billy Bob");
         BibEntry two = new BibEntry(StandardEntryType.Article).withField(StandardField.AUTHOR, "Billy Bob");
 
-        assertTrue(duplicateChecker.isDuplicate(one, two, BibDatabaseMode.BIBTEX));
+        assertFalse(duplicateChecker.isDuplicate(one, two, BibDatabaseMode.BIBTEX));
     }
 
     @Test
     void duplicateDetectionWithSameAuthorAndUmlauts() {
-        BibEntry one = new BibEntry(StandardEntryType.Article).withField(StandardField.AUTHOR, "Billy Bobä");
-        BibEntry two = new BibEntry(StandardEntryType.Article).withField(StandardField.AUTHOR, "Bill{\\\"{a}} Bob{\\\"{a}}");
+        BibEntry one = new BibEntry(StandardEntryType.Article).withField(StandardField.TITLE, "A study of software architecture").withField(StandardField.AUTHOR, "Billy Bobä");
+        BibEntry two = new BibEntry(StandardEntryType.Article).withField(StandardField.TITLE, "A study of software architecture").withField(StandardField.AUTHOR, "Bill{\\\"{a}} Bob{\\\"{a}}");
 
         assertTrue(duplicateChecker.isDuplicate(one, two, BibDatabaseMode.BIBTEX));
     }
@@ -557,21 +698,21 @@ public class DuplicateCheckTest {
     void compareOfTwoEntriesWithSameContentAndLfEndingsReportsNoDifferences() {
         BibEntry entryOne = new BibEntry().withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
         BibEntry entryTwo = new BibEntry().withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
-        assertTrue(duplicateChecker.isDuplicate(entryOne, entryTwo, BibDatabaseMode.BIBTEX));
+        assertEquals(1.01, DuplicateCheck.compareEntriesStrictly(entryOne, entryTwo));
     }
 
     @Test
     void compareOfTwoEntriesWithSameContentAndCrLfEndingsReportsNoDifferences() {
         BibEntry entryOne = new BibEntry().withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
         BibEntry entryTwo = new BibEntry().withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
-        assertTrue(duplicateChecker.isDuplicate(entryOne, entryTwo, BibDatabaseMode.BIBTEX));
+        assertEquals(1.01, DuplicateCheck.compareEntriesStrictly(entryOne, entryTwo));
     }
 
     @Test
     void compareOfTwoEntriesWithSameContentAndMixedLineEndingsReportsNoDifferences() {
         BibEntry entryOne = new BibEntry().withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
         BibEntry entryTwo = new BibEntry().withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
-        assertTrue(duplicateChecker.isDuplicate(entryOne, entryTwo, BibDatabaseMode.BIBTEX));
+        assertEquals(1.01, DuplicateCheck.compareEntriesStrictly(entryOne, entryTwo));
     }
 
     /// Journal articles can have the same ISBN due to the journal has one unique ISBN, but hundreds of different articles.

--- a/jablib/src/test/java/org/jabref/logic/relatedwork/RelatedWorkMatcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/relatedwork/RelatedWorkMatcherTest.java
@@ -144,6 +144,30 @@ class RelatedWorkMatcherTest {
         assertSame(existingLibraryEntry, matchResult.matchedLibraryBibEntry().orElseThrow());
     }
 
+    @Test
+    void matchRelatedWorkDoesNotMatchAuthorOnlyReferences() throws IOException {
+        BibEntry parsedReference = new BibEntry(StandardEntryType.Article).withField(StandardField.AUTHOR, "J. Smith");
+        RelatedWorkReferenceResolver resolver = new RelatedWorkReferenceResolver() {
+            @Override
+            public Map<String, BibEntry> parseReferences(LinkedFile linkedFile,
+                                                         BibDatabaseContext databaseContext,
+                                                         FilePreferences filePreferences) {
+                return Map.of("[1]", parsedReference);
+            }
+        };
+        RelatedWorkMatcher matcher = new RelatedWorkMatcher(
+                new RelatedWorkTextParser(), resolver, new DuplicateCheck(new BibEntryTypesManager()));
+        BibDatabaseContext databaseContext = new BibDatabaseContext();
+        databaseContext.getDatabase().insertEntry(new BibEntry(parsedReference));
+
+        List<RelatedWorkMatchResult> results = matcher.matchRelatedWork(
+                databaseContext, new BibEntry(StandardEntryType.Article), new LinkedFile("", "main.pdf", "PDF"),
+                "A related work sentence [1].", createFilePreferences());
+
+        assertEquals(1, results.size());
+        assertFalse(results.getFirst().hasMatchedLibraryEntry());
+    }
+
     private FilePreferences createFilePreferences() {
         return mock(FilePreferences.class);
     }


### PR DESCRIPTION
### Summary

Duplicate detection now compares publication details independently of entry type, allowing the Article and Misc records in #16580 to be detected as duplicates. Weighted similarity is retained, with minimum publication evidence to avoid matching records on author alone.

This applies across entry types rather than adding an Article/Misc exception. Existing edition and chapter/page exclusions are retained, and exact matching of raw imported references is preserved in related-work matching. Feedback on the broader matching scope would be welcome.

### Steps to test

1. Run `.\gradlew.bat :jabgui:run`.
2. Open a `.bib` library containing the two records shown in #16580, using File → Open.
3. Select Quality → Find Duplicates.
4. Verify that JabRef presents the Article/Misc pair and displays the differing fields.

### Validation

The manual reproduction now detects the pair. The full core check passed using `.\gradlew.bat :jablib:check --max-workers=2`, and the duplicate-detection test class has 209 passing test executions.

Checkstyle, Modernizer, Javadoc, requirement tracing, Markdown lint, and textlint passed. OpenRewrite proposed no changes, with a parse warning for the unchanged `SpecialFieldAction.java`.

Earlier full-suite runs encountered an intermittent localhost communication test failure; that test passed in isolation and in the final full-suite retry.

### Related issues and pull requests

Closes #16580

### AI Usage
I used OpenAI Codex (specifically GPT-6 Astra) to investigate duplicate detection, test changes and help read documentation. I chose the broader type-independent matching approach and manually reproduced the issue before and after the change. 