### PR TITLE
Fix 16995 dropdown spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where generated citation keys could not be undone and no notification appeared. [#16936](https://github.com/JabRef/jabref/pull/16936)
 - We fixed an issue where pressing Escape while a dropdown is open closed the entire dialog instead of just the dropdown. [#16596](https://github.com/JabRef/jabref/issues/16596)
 - We fixed invisible filter text in the keyboard shortcuts preferences when using the light JabRef theme. [#16731](https://github.com/JabRef/jabref/issues/16731)
+- We fixed unwanted empty space at the bottom of the field suggestion dropdown in the entry types preferences. [#16995](https://github.com/JabRef/jabref/issues/16995)
 - We fixed an issue where a full-text PDF link found by DOI lookup was attached in lowercase and failed. [#16762](https://github.com/JabRef/jabref/pull/16762)
 - "Git commit" now saves a modified library first if autosave is enabled, and otherwise lets you choose between saving first and committing only the state on disk, so unsaved changes are no longer silently left out of the commit. [#16718](https://github.com/JabRef/jabref/pull/16718)
 - We fixed an issue where a library could be closed without asking to save changes made after an undo. [#16680](https://github.com/JabRef/jabref/pull/16680)

--- a/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
@@ -63,7 +63,6 @@ import static org.jabref.gui.preferences.forms.FormMetrics.GAP;
 
 public class CustomEntryTypesTab extends AbstractPreferenceTabView<CustomEntryTypesTabViewModel> {
 
-
     private static final double SUGGESTION_CELL_HEIGHT = 24;
     private static final double SUGGESTION_LIST_VERTICAL_PADDING = 2;
     private final TableView<EntryTypeViewModel> entryTypesTable = new TableView<>();
@@ -176,7 +175,6 @@ public class CustomEntryTypesTab extends AbstractPreferenceTabView<CustomEntryTy
     private void setupFieldPropertyCheckComboBox() {
         fieldPropertyCheckComboBox.getItems().addAll(
                 Arrays.stream(FieldProperty.values())
-                      // MULTILINE_TEXT property should be controlled by "multiline" box
                       .filter(fieldProperty -> fieldProperty != FieldProperty.MULTILINE_TEXT)
                       .toList()
         );
@@ -252,7 +250,6 @@ public class CustomEntryTypesTab extends AbstractPreferenceTabView<CustomEntryTy
         entryTypesTable.getColumns().add(entryTypColumn);
         entryTypesTable.getColumns().add(entryTypeActionsColumn);
 
-        // Table View must be editable, otherwise the change of the Radiobuttons does not propagate the commit event
         fields.setEditable(true);
         entryTypesTable.setItems(viewModel.entryTypes());
         entryTypesTable.getSelectionModel().selectFirst();
@@ -339,7 +336,6 @@ public class CustomEntryTypesTab extends AbstractPreferenceTabView<CustomEntryTy
 
             FieldViewModel fieldViewModel = event.getRowValue();
             String currentDisplayName = fieldViewModel.displayNameProperty().getValue();
-            // The first predicate will check if the user input the original field name or doesn't edit anything after double click
             boolean fieldExists = !newDisplayName.equals(currentDisplayName) && viewModel.displayNameExists(newDisplayName);
             if (fieldExists) {
                 dialogService.notify(Localization.lang("Unable to change field name. \"%0\" already in use.", newDisplayName));

--- a/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.collections.ObservableList;
@@ -12,6 +13,7 @@ import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.control.ListView;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
@@ -51,12 +53,23 @@ import org.jabref.model.entry.types.EntryType;
 
 import com.airhacks.afterburner.injection.Injector;
 import com.tobiasdiez.easybind.EasyBind;
+import impl.org.controlsfx.skin.AutoCompletePopup;
+import impl.org.controlsfx.skin.AutoCompletePopupSkin;
 import org.controlsfx.control.CheckComboBox;
+import org.controlsfx.control.textfield.AutoCompletionBinding;
 import org.controlsfx.control.textfield.TextFields;
 
 import static org.jabref.gui.preferences.forms.FormMetrics.GAP;
 
 public class CustomEntryTypesTab extends AbstractPreferenceTabView<CustomEntryTypesTabViewModel> {
+
+    /// Height of a single suggestion row in the "add field" popup. Matches the default cell size of
+    /// JavaFX cells, which neither Modena nor ControlsFX's `autocompletion.css` override.
+    private static final double SUGGESTION_CELL_HEIGHT = 24;
+
+    /// Vertical padding of the suggestion list view (1px at the top and bottom, from Modena's
+    /// `.list-view` rule).
+    private static final double SUGGESTION_LIST_VERTICAL_PADDING = 2;
 
     private final TableView<EntryTypeViewModel> entryTypesTable = new TableView<>();
     private final TextField addNewEntryType = new TextField();
@@ -372,12 +385,13 @@ public class CustomEntryTypesTab extends AbstractPreferenceTabView<CustomEntryTy
                 .setOnDragExited(this::handleOnDragExited)
                 .install(fields);
 
-        TextFields.bindAutoCompletion(
+        AutoCompletionBinding<String> addFieldAutoCompletion = TextFields.bindAutoCompletion(
                 addNewField,
                 viewModel.fieldsForAdding().stream()
                          .map(Field::getName)
                          .collect(Collectors.toList())
         );
+        tightenSuggestionPopupHeight(addFieldAutoCompletion);
 
         // selected field will show in addNewField box with its properties
         fields.getSelectionModel().selectedItemProperty().addListener((_, _, newSelection) -> {
@@ -393,6 +407,30 @@ public class CustomEntryTypesTab extends AbstractPreferenceTabView<CustomEntryTy
                 }
             }
         });
+    }
+
+    /// ControlsFX's default popup skin always reserves 18px of extra vertical space below the last
+    /// suggestion, which shows up as an empty strip at the bottom of the dropdown
+    /// (https://github.com/JabRef/jabref/issues/16995). We keep the default skin (styling, selection,
+    /// and keyboard handling stay untouched) and only replace its height binding by one that hugs
+    /// the content: one row per suggestion, capped at the visible row count, plus the list's own
+    /// vertical padding. The fixed cell size makes the height computation match the layout exactly,
+    /// so no vertical scrollbar appears for fully visible lists.
+    /// The popup normally creates its default skin lazily on first show; it is created eagerly here
+    /// so that its height binding can be adjusted before the popup ever appears.
+    @SuppressWarnings("unchecked")
+    private static void tightenSuggestionPopupHeight(AutoCompletionBinding<String> binding) {
+        AutoCompletePopup<String> popup = binding.getAutoCompletionPopup();
+        AutoCompletePopupSkin<String> skin = new AutoCompletePopupSkin<>(popup);
+        popup.setSkin(skin);
+
+        ListView<String> suggestionList = (ListView<String>) skin.getNode();
+        suggestionList.setFixedCellSize(SUGGESTION_CELL_HEIGHT);
+        suggestionList.prefHeightProperty().unbind();
+        suggestionList.prefHeightProperty().bind(
+                Bindings.min(popup.visibleRowCountProperty(), Bindings.size(suggestionList.getItems()))
+                         .multiply(suggestionList.fixedCellSizeProperty())
+                         .add(SUGGESTION_LIST_VERTICAL_PADDING));
     }
 
     private void makeRotatedColumnHeader(TableColumn<?, ?> column, String text) {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
@@ -409,15 +409,7 @@ public class CustomEntryTypesTab extends AbstractPreferenceTabView<CustomEntryTy
         });
     }
 
-    /// ControlsFX's default popup skin always reserves 18px of extra vertical space below the last
-    /// suggestion, which shows up as an empty strip at the bottom of the dropdown
-    /// (https://github.com/JabRef/jabref/issues/16995). We keep the default skin (styling, selection,
-    /// and keyboard handling stay untouched) and only replace its height binding by one that hugs
-    /// the content: one row per suggestion, capped at the visible row count, plus the list's own
-    /// vertical padding. The fixed cell size makes the height computation match the layout exactly,
-    /// so no vertical scrollbar appears for fully visible lists.
-    /// The popup normally creates its default skin lazily on first show; it is created eagerly here
-    /// so that its height binding can be adjusted before the popup ever appears.
+    // ControlsFX adds 18px of extra height to the autocomplete popup; replace that binding with one based on the actual number of suggestions and ListView padding.
     @SuppressWarnings("unchecked")
     private static void tightenSuggestionPopupHeight(AutoCompletionBinding<String> binding) {
         AutoCompletePopup<String> popup = binding.getAutoCompletionPopup();

--- a/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
@@ -63,14 +63,9 @@ import static org.jabref.gui.preferences.forms.FormMetrics.GAP;
 
 public class CustomEntryTypesTab extends AbstractPreferenceTabView<CustomEntryTypesTabViewModel> {
 
-    /// Height of a single suggestion row in the "add field" popup. Matches the default cell size of
-    /// JavaFX cells, which neither Modena nor ControlsFX's `autocompletion.css` override.
+
     private static final double SUGGESTION_CELL_HEIGHT = 24;
-
-    /// Vertical padding of the suggestion list view (1px at the top and bottom, from Modena's
-    /// `.list-view` rule).
     private static final double SUGGESTION_LIST_VERTICAL_PADDING = 2;
-
     private final TableView<EntryTypeViewModel> entryTypesTable = new TableView<>();
     private final TextField addNewEntryType = new TextField();
     private final TableView<FieldViewModel> fields = new TableView<>();
@@ -78,7 +73,6 @@ public class CustomEntryTypesTab extends AbstractPreferenceTabView<CustomEntryTy
     private final Button addNewEntryTypeButton = new Button();
     private final Button addNewFieldButton = new Button(Localization.lang("Add"));
     private final CheckComboBox<FieldProperty> fieldPropertyCheckComboBox = new CheckComboBox<>();
-
     private final CustomLocalDragboard localDragboard;
 
     public CustomEntryTypesTab() {


### PR DESCRIPTION
### Summary

Fixes the extra empty space shown at the bottom of ControlsFX dropdown suggestions. The fix keeps the default popup skin and its existing styling, selection, and keyboard behavior unchanged while removing the unnecessary space.

**Analogies:** Like honey, the fix keeps things smooth without adding unnecessary weight; like chocolate, it removes one unwanted layer; like the moon, the change is small but clearly visible when you look closely.

### Steps to test

1. Start JabRef.
2. Open a dropdown/autocomplete field that uses the affected suggestion popup.
3. Enter text that produces multiple suggestions.
4. Check the bottom of the dropdown.
5. Verify that there is no unnecessary empty strip below the last suggestion.

Expected result: the dropdown ends directly after the suggestions instead of reserving the extra empty space.

### Related issues and pull requests

Closes #16995

Screenshot:
<img width="936" height="513" alt="Image" src="https://github.com/user-attachments/assets/865ad7d1-ae6a-47f2-927b-5fcdd8a4ccd0" />

<img width="533" height="155" alt="Image" src="https://github.com/user-attachments/assets/eadb975e-71bc-4279-827e-6a95f3258267" />

### AI usage

Claude Code (model claude-opus-5) was used to help identify and fix the issue while checking CI. I reviewed the resulting changes, verified the behavior, and take full ownership of the submitted code.

AIL4

<details>
<summary>AI CHECKLIST.md walkthrough</summary>



</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license]
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation] for up to dateness and submitted a pull request to our [user documentation repository]