### PR TITLE
Fix mermaid syntax

### DIFF
--- a/docs/architecture-and-components.md
+++ b/docs/architecture-and-components.md
@@ -28,23 +28,18 @@ Permitted dependencies in our architecture are:
 
 ```mermaid
 flowchart TD
-    subgraph shared["Accessible from every layer"]
-        direction TD
-        preferences["Preferences"]
-        global["Global Classes"]
-    end
     gui["gui"] --> logic["logic"]
     cli["cli"] --> logic
     logic --> model["model"]
-    model ~~~ shared
+    model --- preferences
+    model --- global
+    linkStyle 3 stroke:transparent
+    linkStyle 4 stroke:transparent
 
-    preferences:::component
-    global:::component
-    gui:::layer
-    logic:::component
-    cli:::layer
-    model:::component
-
+    subgraph shared["Accessible from every layer"]
+        preferences["Preferences"]
+        global["Global Classes"]
+    end
 ```
 
 All packages and classes which are currently not part of these packages (we are still in the process of structuring) are considered as gui classes from a dependency standpoint.


### PR DESCRIPTION
### Summary
This diagram fix syntax error compatiblity with GitHub's rendering engine (Mermaid v9.4.3).

`jabref-contrib-policy:4.2:reviewed​:ok`


<img width="805" height="502" alt="image" src="https://github.com/user-attachments/assets/c395cc26-2901-4c6a-9b26-e58e701c66fe" />



Steps to test
To test this change, open the developer documentation file where the package structure is explained. 

Related issues and pull requests
Closes #16760 

AI usage
Claude (Claude Sonnet 5)


_____

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
