### PR TITLE
Fix crash importing INSPEC files with empty-valued or truncated fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an uncaught error when importing an INSPEC file containing an empty-valued or truncated field (for example an empty abstract), which previously aborted the whole import.
+- We fixed an uncaught error when importing an INSPEC file containing an empty-valued or truncated field (for example an empty abstract), which previously aborted the whole import. [#17094](https://github.com/JabRef/jabref/pull/17094)
 - We fixed missing publication years and empty parentheses in the related articles tab. [#16998](https://github.com/JabRef/jabref/issues/16998)
 - We fixed an issue where <kbd>Ctrl</kbd> + <kbd>W</kbd> did not close the welcome tab. [#16895](https://github.com/JabRef/jabref/pull/16895)
 - We fixed an issue where an entry added by DOI or URL could not be undone. [#8770](https://github.com/JabRef/jabref/issues/8770)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an uncaught error when importing an INSPEC file containing an empty-valued or truncated field (for example an empty abstract), which previously aborted the whole import.
 - We fixed missing publication years and empty parentheses in the related articles tab. [#16998](https://github.com/JabRef/jabref/issues/16998)
 - We fixed an issue where <kbd>Ctrl</kbd> + <kbd>W</kbd> did not close the welcome tab. [#16895](https://github.com/JabRef/jabref/pull/16895)
 - We fixed an issue where an entry added by DOI or URL could not be undone. [#8770](https://github.com/JabRef/jabref/issues/8770)

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/InspecImporter.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/InspecImporter.java
@@ -87,6 +87,13 @@ public class InspecImporter extends Importer {
 
             String[] fields = entry.split("__NEWFIELD__");
             for (String s : fields) {
+                if (s.length() < 5) {
+                    // Skip the record marker and any empty-valued or truncated field line.
+                    // INSPEC fields have the shape "XX ~ value" with content starting at
+                    // index 5, so anything shorter has no value to read (and slicing it
+                    // would throw StringIndexOutOfBoundsException).
+                    continue;
+                }
                 String f3 = s.substring(0, 2);
                 String frest = s.substring(5);
                 switch (f3) {

--- a/jablib/src/test/java/org/jabref/logic/importer/fileformat/InspecImporterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fileformat/InspecImporterTest.java
@@ -104,6 +104,27 @@ class InspecImporterTest {
     }
 
     @Test
+    void importDoesNotCrashOnEmptyValuedField() throws IOException {
+        // Regression: an empty-valued field line such as "AB ~" (shorter than the
+        // "XX ~ value" prefix) used to raise StringIndexOutOfBoundsException from
+        // substring(5), aborting the whole import.
+        String testInput = "Record.*INSPEC.*\n" +
+                "\n" +
+                "TI ~ The SIS project\n" +
+                "AU ~ Prechelt, Lutz\n" +
+                "AB ~\n" +
+                "RT ~ Journal-Paper";
+        BibEntry expectedEntry = new BibEntry(StandardEntryType.Article);
+        expectedEntry.setField(StandardField.TITLE, "The SIS project");
+        expectedEntry.setField(StandardField.AUTHOR, "Prechelt, Lutz");
+
+        try (BufferedReader reader = new BufferedReader(Reader.of(testInput))) {
+            List<BibEntry> entries = importer.importDatabase(reader).getDatabase().getEntries();
+            assertEquals(List.of(expectedEntry), entries);
+        }
+    }
+
+    @Test
     void getFormatName() {
         assertEquals("INSPEC", importer.getName());
     }


### PR DESCRIPTION
`InspecImporter` assumes every field line has the shape `XX ~ value`, with the value starting at index 5. But the only length guard in `importDatabase` drops lines shorter than 2 characters, so a 2–4 character field line still reaches `s.substring(5)` and throws `StringIndexOutOfBoundsException`.

That happens with ordinary data: an entry with an empty-valued field (for example `AB ~` for a missing abstract) or a truncated/wrapped line. The exception isn't caught, so it propagates out of `importDatabase` and aborts the whole import — both on explicit INSPEC import and on format auto-detection (the importer is registered, and `isRecognizedFormat` accepts any file containing a `Record.*INSPEC.*` line).

The sibling `IsiImporter` already guards the same idiom (`length() < 3`, plus a per-field `length() <= 2` check before its `substring`). This brings `InspecImporter` in line by skipping field lines shorter than the `XX ~ ` prefix.

### Steps to test
1. Import an INSPEC file that contains an entry with an empty-valued field, e.g. a record with a bare `AB ~` line.
2. Before: the import fails with `StringIndexOutOfBoundsException`. After: the entry imports and the empty field is skipped.

Added a regression test (`importDoesNotCrashOnEmptyValuedField`).

### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (if applicable)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the [user documentation repository](https://github.com/JabRef/user-documentation).
