### PR TITLE
Fix autosave JavaFX thread exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed invisible filter text in the keyboard shortcuts preferences when using the light JabRef theme. [#16731](https://github.com/JabRef/jabref/issues/16731)
 - We fixed an issue where a full-text PDF link found by DOI lookup was attached in lowercase and failed. [#16762](https://github.com/JabRef/jabref/pull/16762)
 - "Git commit" now saves a modified library first if autosave is enabled, and otherwise lets you choose between saving first and committing only the state on disk, so unsaved changes are no longer silently left out of the commit. [#16718](https://github.com/JabRef/jabref/pull/16718)
+- We fixed an exception when autosave applied save actions. [#17098](https://github.com/JabRef/jabref/issues/17098)
 - We fixed an issue where a library could be closed without asking to save changes made after an undo. [#16680](https://github.com/JabRef/jabref/pull/16680)
 - We fixed the context menu of an automatically found file offering "Remove link" instead of linking the file. [#16898](https://github.com/JabRef/jabref/pull/16898)
 - We fixed an issue where an empty backup could overwrite a library during recovery. [#10853](https://github.com/JabRef/jabref/issues/10853)

--- a/docs/requirements/save.md
+++ b/docs/requirements/save.md
@@ -41,6 +41,7 @@ Needs: impl, utest
 `req~jabgui.autosaveandbackup.autosave-listens~1`
 
 While autosave is enabled for a library, every change to the library must lead to the library being saved shortly afterwards without user interaction.
+Entry mutations made by save actions must run on the JavaFX event thread, while formatting and file writing remain in the background.
 
 When the autosave manager is shut down, its periodic task must stop and pending callbacks must not post further autosave events.
 

--- a/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -9,6 +9,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import javafx.scene.control.ButtonBar;
@@ -356,12 +358,17 @@ public class SaveDatabaseAction {
                         .withJournalAbbreviationRepository(
                                 journalAbbreviationRepository,
                                 preferences.getAbbreviationPreferences().shouldUseFJournalField())
-                        .withMutationScheduler(UiTaskExecutor::runAndWaitInJavaFXThread);
+                        .withMutationScheduler(SaveDatabaseAction::runSaveMutation);
 
-                if (selectedOnly) {
-                    databaseWriter.writePartOfDatabase(bibDatabaseContext, libraryTab.getSelectedEntries());
-                } else {
-                    databaseWriter.writeDatabase(bibDatabaseContext);
+                try {
+                    if (selectedOnly) {
+                        databaseWriter.writePartOfDatabase(bibDatabaseContext, libraryTab.getSelectedEntries());
+                    } else {
+                        databaseWriter.writeDatabase(bibDatabaseContext);
+                    }
+                } catch (CompletionException exception) {
+                    fileWriter.abort();
+                    throw exception;
                 }
 
                 libraryTab.registerUndoableChanges(databaseWriter.getSaveActionsFieldChanges());
@@ -369,6 +376,8 @@ public class SaveDatabaseAction {
                 encodingProblems = fileWriter.getEncodingProblems();
             } catch (UnsupportedCharsetException ex) {
                 throw new SaveException(Localization.lang("Character encoding '%0' is not supported.", encoding.displayName()), ex);
+            } catch (CompletionException ex) {
+                throw new SaveException("Problems applying save actions", ex.getCause());
             } catch (IOException ex) {
                 throw new SaveException("Problems saving: " + ex, ex);
             }
@@ -382,6 +391,14 @@ public class SaveDatabaseAction {
                 }
             }
             return committedState;
+        }
+    }
+
+    private static void runSaveMutation(Runnable mutation) {
+        try {
+            UiTaskExecutor.runAndWaitInJavaFXThreadWithFailurePropagation(mutation);
+        } catch (ExecutionException exception) {
+            throw new CompletionException(exception.getCause());
         }
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -29,6 +29,7 @@ import org.jabref.gui.maintable.BibEntryTableViewModel;
 import org.jabref.gui.maintable.columns.MainTableColumn;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.util.FileDialogConfiguration;
+import org.jabref.gui.util.UiTaskExecutor;
 import org.jabref.logic.exporter.AtomicFileWriter;
 import org.jabref.logic.exporter.BibDatabaseWriter;
 import org.jabref.logic.exporter.BibWriter;
@@ -354,7 +355,8 @@ public class SaveDatabaseAction {
                         entryTypesManager)
                         .withJournalAbbreviationRepository(
                                 journalAbbreviationRepository,
-                                preferences.getAbbreviationPreferences().shouldUseFJournalField());
+                                preferences.getAbbreviationPreferences().shouldUseFJournalField())
+                        .withMutationScheduler(UiTaskExecutor::runAndWaitInJavaFXThread);
 
                 if (selectedOnly) {
                     databaseWriter.writePartOfDatabase(bibDatabaseContext, libraryTab.getSelectedEntries());

--- a/jabgui/src/main/java/org/jabref/gui/util/UiTaskExecutor.java
+++ b/jabgui/src/main/java/org/jabref/gui/util/UiTaskExecutor.java
@@ -87,6 +87,42 @@ public class UiTaskExecutor implements TaskExecutor {
         }
     }
 
+    /// Runs the specified [Runnable] on the JavaFX application thread and waits for completion.
+    ///
+    /// Unlike [#runAndWaitInJavaFXThread(Runnable)], this method propagates an exception raised
+    /// by the action to the waiting thread.
+    ///
+    /// @param action the [Runnable] to run
+    /// @throws ExecutionException if the action fails
+    public static void runAndWaitInJavaFXThreadWithFailurePropagation(@NonNull Runnable action) throws ExecutionException {
+        FutureTask<Void> task = new FutureTask<>(action, null);
+        if (Platform.isFxApplicationThread()) {
+            task.run();
+        } else {
+            try {
+                Platform.runLater(task);
+            } catch (RuntimeException exception) {
+                throw new ExecutionException(exception);
+            }
+        }
+
+        boolean interrupted = false;
+        try {
+            while (true) {
+                try {
+                    task.get();
+                    return;
+                } catch (InterruptedException _) {
+                    interrupted = true;
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
     /// Runs the runnable later. This will guarantee that it runs on the FX UI Thread.
     ///
     /// @param runnable runnable BackgroundTask to run

--- a/jabgui/src/test/java/org/jabref/gui/exporter/SaveDatabaseActionTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/exporter/SaveDatabaseActionTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import javafx.beans.property.SimpleBooleanProperty;
@@ -25,23 +26,30 @@ import org.jabref.logic.LibraryPreferences;
 import org.jabref.logic.bibtex.FieldPreferences;
 import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
 import org.jabref.logic.citationkeypattern.GlobalCitationKeyPatterns;
+import org.jabref.logic.cleanup.FieldFormatterCleanup;
+import org.jabref.logic.cleanup.FieldFormatterCleanupActions;
 import org.jabref.logic.exporter.BibDatabaseWriter;
 import org.jabref.logic.exporter.ExportPreferences;
 import org.jabref.logic.exporter.SaveConfiguration;
+import org.jabref.logic.formatter.casechanger.LowerCaseFormatter;
 import org.jabref.logic.git.preferences.GitPreferences;
 import org.jabref.logic.git.util.GitHandlerRegistry;
 import org.jabref.logic.journals.AbbreviationPreferences;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.shared.DatabaseLocation;
 import org.jabref.logic.util.CurrentThreadTaskExecutor;
+import org.jabref.model.FieldChange;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryTypesManager;
+import org.jabref.model.entry.event.EntriesEventSource;
+import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.model.metadata.SaveOrder;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -263,6 +271,34 @@ class SaveDatabaseActionTest {
         assertEquals("external content", Files.readString(file));
         assertEquals(SaveDatabaseAction.SaveResult.FAILURE, result);
         verify(libraryTab, never()).resetChangedProperties();
+    }
+
+    @Test
+    @ExtendWith(JavaFxExtension.class)
+    void saveReportsFailureAndDoesNotReplaceFileWhenSaveMutationFails() throws IOException {
+        AtomicBoolean failSaveMutation = new AtomicBoolean();
+        BibEntry entry = new BibEntry() {
+            @Override
+            public Optional<FieldChange> setField(Field field, @Nullable String value, EntriesEventSource eventSource) {
+                if (failSaveMutation.get() && eventSource == EntriesEventSource.SAVE_ACTION) {
+                    throw new IllegalArgumentException("expected failure");
+                }
+                return super.setField(field, value, eventSource);
+            }
+        };
+        entry.setField(StandardField.TITLE, "UPPERCASE TITLE");
+        failSaveMutation.set(true);
+        BibDatabase database = new BibDatabase(List.of(entry));
+        saveDatabaseAction = createSaveDatabaseActionForBibDatabase(database);
+        when(metaData.getSaveActions()).thenReturn(Optional.of(new FieldFormatterCleanupActions(
+                true,
+                List.of(new FieldFormatterCleanup(StandardField.TITLE, new LowerCaseFormatter())))));
+
+        SaveDatabaseAction.SaveResult result = saveDatabaseAction.save();
+
+        assertEquals(SaveDatabaseAction.SaveResult.FAILURE, result);
+        assertEquals("", Files.readString(file));
+        verify(libraryTab, never()).registerUndoableChanges(any());
     }
 
     @Test

--- a/jabgui/src/test/java/org/jabref/gui/util/UiTaskExecutorTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/util/UiTaskExecutorTest.java
@@ -1,0 +1,35 @@
+package org.jabref.gui.util;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.jabref.gui.testutils.JavaFxExtension;
+
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(JavaFxExtension.class)
+@NullMarked
+class UiTaskExecutorTest {
+
+    @Test
+    void runAndWaitInJavaFXThreadWithFailurePropagationPropagatesBackgroundThreadFailure() throws InterruptedException, ExecutionException {
+        try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+            Future<ExecutionException> future = executor.submit(() -> assertThrows(
+                    ExecutionException.class,
+                    () -> UiTaskExecutor.runAndWaitInJavaFXThreadWithFailurePropagation(() -> {
+                        throw new IllegalArgumentException("expected failure");
+                    })));
+
+            ExecutionException exception = future.get();
+
+            assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
+        }
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/cleanup/FieldFormatterCleanupActions.java
+++ b/jablib/src/main/java/org/jabref/logic/cleanup/FieldFormatterCleanupActions.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.formatter.Formatters;
@@ -106,18 +107,27 @@ public class FieldFormatterCleanupActions {
 
     /// @param libraryKeywordSeparator the separator declared by the library the entry belongs to, or `null` for the global preference
     public List<FieldChange> applySaveActions(BibEntry entry, @Nullable Character libraryKeywordSeparator) {
+        return applySaveActions(entry, libraryKeywordSeparator, Runnable::run);
+    }
+
+    /// @param mutationScheduler routes [BibEntry] field mutations to the correct thread
+    public List<FieldChange> applySaveActions(BibEntry entry,
+                                              @Nullable Character libraryKeywordSeparator,
+                                              Consumer<Runnable> mutationScheduler) {
         if (enabled) {
-            return applyAllActions(entry, libraryKeywordSeparator);
+            return applyAllActions(entry, libraryKeywordSeparator, mutationScheduler);
         } else {
             return List.of();
         }
     }
 
-    private List<FieldChange> applyAllActions(BibEntry entry, @Nullable Character libraryKeywordSeparator) {
+    private List<FieldChange> applyAllActions(BibEntry entry,
+                                              @Nullable Character libraryKeywordSeparator,
+                                              Consumer<Runnable> mutationScheduler) {
         List<FieldChange> result = new ArrayList<>();
 
         for (FieldFormatterCleanup action : getConfiguredActions(libraryKeywordSeparator)) {
-            result.addAll(action.cleanup(entry));
+            result.addAll(action.cleanup(entry, mutationScheduler));
         }
 
         return result;

--- a/jablib/src/main/java/org/jabref/logic/exporter/BibDatabaseWriter.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/BibDatabaseWriter.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -77,6 +78,7 @@ public class BibDatabaseWriter {
 
     @Nullable private JournalAbbreviationRepository journalAbbreviationRepository;
     private boolean useFJournalField;
+    private Consumer<Runnable> mutationScheduler = Runnable::run;
 
     public BibDatabaseWriter(@NonNull BibWriter bibWriter,
                              SelfContainedSaveConfiguration saveConfiguration,
@@ -106,14 +108,17 @@ public class BibDatabaseWriter {
                 preferences.getCustomEntryTypesRepository());
     }
 
-    private static List<FieldChange> applySaveActions(List<BibEntry> toChange, MetaData metaData, FieldPreferences fieldPreferences) {
+    private static List<FieldChange> applySaveActions(List<BibEntry> toChange,
+                                                       MetaData metaData,
+                                                       FieldPreferences fieldPreferences,
+                                                       Consumer<Runnable> mutationScheduler) {
         List<FieldChange> changes = new ArrayList<>();
 
         Optional<FieldFormatterCleanupActions> saveActions = metaData.getSaveActions();
         saveActions.ifPresent(actions -> {
             // save actions defined -> apply for every entry
             for (BibEntry entry : toChange) {
-                changes.addAll(actions.applySaveActions(entry, metaData.getKeywordSeparator().orElse(null)));
+                changes.addAll(actions.applySaveActions(entry, metaData.getKeywordSeparator().orElse(null), mutationScheduler));
             }
         });
 
@@ -123,8 +128,8 @@ public class BibDatabaseWriter {
         for (BibEntry entry : toChange) {
             // Only apply the trimming if the entry itself has other changes (e.g., by the user or by save actions)
             if (entry.hasChanged()) {
-                changes.addAll(trimWhiteSpaces.cleanup(entry));
-                changes.addAll(normalizeWhitespacesCleanup.cleanup(entry));
+                changes.addAll(trimWhiteSpaces.cleanup(entry, mutationScheduler));
+                changes.addAll(normalizeWhitespacesCleanup.cleanup(entry, mutationScheduler));
             }
         }
 
@@ -132,7 +137,7 @@ public class BibDatabaseWriter {
     }
 
     public static List<FieldChange> applySaveActions(BibEntry entry, MetaData metaData, FieldPreferences fieldPreferences) {
-        return applySaveActions(List.of(entry), metaData, fieldPreferences);
+        return applySaveActions(List.of(entry), metaData, fieldPreferences, Runnable::run);
     }
 
     private static List<Comparator<BibEntry>> getSaveComparators(SaveOrder saveOrder) {
@@ -180,6 +185,13 @@ public class BibDatabaseWriter {
         return this;
     }
 
+    /// Routes [BibEntry] field mutations performed while saving to the correct thread.
+    /// The scheduler must execute each mutation synchronously so the written file contains it.
+    public BibDatabaseWriter withMutationScheduler(Consumer<Runnable> mutationScheduler) {
+        this.mutationScheduler = mutationScheduler;
+        return this;
+    }
+
     /// Saves the complete database.
     public void writeDatabase(@NonNull BibDatabaseContext bibDatabaseContext) throws IOException {
         List<BibEntry> entries = bibDatabaseContext.getDatabase().getEntries()
@@ -215,7 +227,7 @@ public class BibDatabaseWriter {
 
         // FIXME: "Clean" architecture violation: We modify the entries here, which should not happen during a write
         //        The cleanup should be done before the write operation
-        List<FieldChange> saveActionChanges = applySaveActions(sortedEntries, bibDatabaseContext.getMetaData(), fieldPreferences);
+        List<FieldChange> saveActionChanges = applySaveActions(sortedEntries, bibDatabaseContext.getMetaData(), fieldPreferences, mutationScheduler);
         saveActionsFieldChanges.addAll(saveActionChanges);
 
         if (journalAbbreviationRepository != null && saveConfiguration.getSaveType() == SaveType.WITH_JABREF_META_DATA) {
@@ -223,13 +235,13 @@ public class BibDatabaseWriter {
                 AbbreviateJournalCleanup cleanup = new AbbreviateJournalCleanup(
                         bibDatabaseContext.getDatabase(), journalAbbreviationRepository, abbreviationType, useFJournalField);
                 for (BibEntry entry : sortedEntries) {
-                    saveActionsFieldChanges.addAll(cleanup.cleanup(entry));
+                    saveActionsFieldChanges.addAll(cleanup.cleanup(entry, mutationScheduler));
                 }
             });
         }
 
         if (keyPatternPreferences.shouldGenerateCiteKeysBeforeSaving()) {
-            List<FieldChange> keyChanges = generateCitationKeys(bibDatabaseContext, sortedEntries);
+            List<FieldChange> keyChanges = generateCitationKeys(bibDatabaseContext, sortedEntries, mutationScheduler);
             saveActionsFieldChanges.addAll(keyChanges);
         }
 
@@ -427,14 +439,15 @@ public class BibDatabaseWriter {
     }
 
     /// Generate keys for all entries that are lacking keys.
-    protected List<FieldChange> generateCitationKeys(BibDatabaseContext databaseContext, List<BibEntry> entries) {
+    protected List<FieldChange> generateCitationKeys(BibDatabaseContext databaseContext,
+                                                      List<BibEntry> entries,
+                                                      Consumer<Runnable> mutationScheduler) {
         List<FieldChange> changes = new ArrayList<>();
         CitationKeyGenerator keyGenerator = new CitationKeyGenerator(databaseContext, keyPatternPreferences);
         for (BibEntry bes : entries) {
             Optional<String> oldKey = bes.getCitationKey();
             if (StringUtil.isBlank(oldKey)) {
-                Optional<FieldChange> change = keyGenerator.generateAndSetKey(bes);
-                change.ifPresent(changes::add);
+                mutationScheduler.accept(() -> keyGenerator.generateAndSetKey(bes).ifPresent(changes::add));
             }
         }
         return changes;

--- a/jablib/src/main/java/org/jabref/logic/exporter/BibDatabaseWriter.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/BibDatabaseWriter.java
@@ -109,9 +109,9 @@ public class BibDatabaseWriter {
     }
 
     private static List<FieldChange> applySaveActions(List<BibEntry> toChange,
-                                                       MetaData metaData,
-                                                       FieldPreferences fieldPreferences,
-                                                       Consumer<Runnable> mutationScheduler) {
+                                                      MetaData metaData,
+                                                      FieldPreferences fieldPreferences,
+                                                      Consumer<Runnable> mutationScheduler) {
         List<FieldChange> changes = new ArrayList<>();
 
         Optional<FieldFormatterCleanupActions> saveActions = metaData.getSaveActions();
@@ -440,8 +440,8 @@ public class BibDatabaseWriter {
 
     /// Generate keys for all entries that are lacking keys.
     protected List<FieldChange> generateCitationKeys(BibDatabaseContext databaseContext,
-                                                      List<BibEntry> entries,
-                                                      Consumer<Runnable> mutationScheduler) {
+                                                     List<BibEntry> entries,
+                                                     Consumer<Runnable> mutationScheduler) {
         List<FieldChange> changes = new ArrayList<>();
         CitationKeyGenerator keyGenerator = new CitationKeyGenerator(databaseContext, keyPatternPreferences);
         for (BibEntry bes : entries) {

--- a/jablib/src/test/java/org/jabref/logic/exporter/BibDatabaseWriterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/exporter/BibDatabaseWriterTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jabref.logic.bibtex.FieldPreferences;
 import org.jabref.logic.citationkeypattern.AbstractCitationKeyPatterns;
@@ -1014,6 +1015,25 @@ class BibDatabaseWriterTest {
                         "  note = {some note}," + OS.NEWLINE +
                         "}" + OS.NEWLINE,
                 stringWriter.toString());
+    }
+
+    @Test
+    void saveActionsUseConfiguredMutationScheduler() throws IOException {
+        AtomicInteger scheduledMutations = new AtomicInteger();
+        databaseWriter.withMutationScheduler(mutation -> {
+            scheduledMutations.incrementAndGet();
+            mutation.run();
+        });
+        metaData.setSaveActions(new FieldFormatterCleanupActions(true, List.of(
+                new FieldFormatterCleanup(StandardField.TITLE, new LowerCaseFormatter()))));
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.TITLE, "SOME TITLE");
+        database.insertEntry(entry);
+
+        databaseWriter.writeDatabase(bibtexContext);
+
+        assertEquals(1, scheduledMutations.get());
+        assertEquals("some title", entry.getField(StandardField.TITLE).orElseThrow());
     }
 
     @Test


### PR DESCRIPTION
### Summary

Autosave keeps formatting and file writes on its worker thread, while synchronously dispatching save-time `BibEntry` mutations to the JavaFX event thread. This prevents native menu updates from running on the autosave executor and preserves the serialized, cleaned value.

#### Analogies

Like honey stays in its jar while a spoon takes only what it needs, the worker keeps its work while mutations cross threads. Like chocolate is tempered briefly, mutations touch the UI thread only for the required moment. Like the moon reflects light without becoming the sun, the UI reflects model changes without taking over file writing.

jabref-contrib-policy:4.2:reviewed​:ok

### Steps to test

1. In Preferences → General → Saving, enable **Autosave local libraries**, then reopen a saved local library.
2. Change an entry title to include leading or trailing whitespace and do not save manually.
3. Wait for autosave (up to 31 seconds).
4. Verify that the title is normalized and saved without a JavaFX event-thread exception in the log.

### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/17098

### AI usage

OpenAI Codex (model GPT-5), AIL2. It assisted with investigation, implementation, tests, and this draft; a human must review, understand, own, and manually test the final change before marking the PR ready.

<details>
<summary>AI CHECKLIST.md walkthrough</summary>

## 1. Code self-review

### Nullability and control flow

- [x] No `== null` / `!= null` checks — JSpecify annotations (`@NullMarked`, `@Nullable`, `@NonNull`) used instead.
- [x] No `Objects.requireNonNull(...)` — nullability expressed via JSpecify annotations.
- [/] New classes annotated with `@NullMarked` (`org.jspecify.annotations.NullMarked`). No classes were added.
- [x] `Optional` consumed with `ifPresent` / `ifPresentOrElse` / `map` / `orElseThrow` — never `orElse(unusedValue)` nor an `isPresent()` + `get()` block.
- [x] `StringUtil.isBlank(...)` used instead of `s == null || s.isBlank()`.

### Exceptions

- [x] No `catch (Exception e)` — only specific exceptions are caught.
- [x] No `throw new RuntimeException(...)` / `IllegalStateException(...)` — these tear down the whole application.
- [x] Logged exceptions are passed as the **last** logger argument (`LOGGER.info("...", e)`), not concatenated into the message string.

### Style and idioms

- [x] New `BibEntry` objects built with withers (`withField`, not `setField`).
- [x] Modern Java used: `List.of()` / `Map.of()` / `Set.of()`, `Path.of()`, `SequencedCollection` / `SequencedSet`, text blocks.
- [x] Regexes use a precompiled `Pattern.compile(...)` constant, not `String.matches(...)`.
- [x] Background work uses `org.jabref.logic.util.BackgroundTask`, not `new Thread()`.
- [x] No commented-out code, no trivial comments restating the code, no AI-disclosure comments in source.
- [x] Markdown Javadoc (`///`) uses Markdown syntax, not JavaDoc inline tags: `` `code` `` instead of `{@code}`, `[ClassName]` instead of `{@link}`.

### User-facing text

- [/] All user-facing text localized (`Localization.lang` in Java, `%` prefix in FXML). No user-facing text was added.
- [/] Sentence case (not Title Case); no trailing `!`; labels do not end with `:`. No UI labels were added.
- [/] Variance expressed with placeholders (`"...: %0"`), not string concatenation. No user-facing text was added.

### Security

- [/] User-controlled data (request params, entry fields, file contents) is HTML-escaped before being written into any `text/html` response — including exception/error messages, not just the success body (XSS). No HTML response is affected.

### Tests

- [x] Behavior changes in `org.jabref.model` / `org.jabref.logic` have added or updated tests.
- [x] Tests assert object contents (`assertEquals`), use plain JUnit asserts (not AssertJ), have no `@DisplayName`, do not catch exceptions, and use `@TempDir` instead of manual temp directories.
- [/] Fetcher tests hit the live endpoints — the remote API is not mocked or stubbed. No fetcher test is affected.

## 2. Verification commands

- [x] `./gradlew :jablib:check` (or `./gradlew check` for all modules).
- [x] `./gradlew checkstyleMain checkstyleTest checkstyleJmh`.
- [x] `./gradlew modernizer`.
- [x] `./gradlew --no-configuration-cache :rewriteDryRun` reports no changes.
- [x] `./gradlew javadoc`.
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"`.
- [x] `npm ci && npm run textlint` reports no misspellings.
- [/] Docker IntelliJ formatting was not needed after `rewriteDryRun`.

## 3. Documentation

- [x] `CHANGELOG.md` entry added with the linked issue.
- [x] Searched [jabref/issues](https://github.com/JabRef/jabref/issues) and [jabref-koppor/issues](https://github.com/JabRef/jabref-koppor/issues) for a related issue; linked the confident match.
- [x] Requirement updated in `docs/requirements/save.md` for this significant bug fix.
- [x] Developer documentation under `docs/` updated for the thread-affinity behavior.

## 4. Pull request

- [x] PR body built from `.github/PULL_REQUEST_TEMPLATE.md`, every section filled.
- [x] All checklist items kept and marked `[x]`, `[ ]`, or `[/]`.
- [/] The fix has no visible UI change, so no screenshot is applicable.
- [x] All HTML comments removed from the PR body.
- [x] PR created with `gh pr create --body-file <file>`.
- [/] No `TODO` placeholder is used in `CHANGELOG.md`.

</details>

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en) (not applicable: user documentation does not describe this internal thread-affinity fix)
