### PR TITLE
Fix sidebar width drifting when side panels are toggled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where an author list ending with "et al." was parsed as a person named "et al." instead of "and others". [#16937](https://github.com/JabRef/jabref/pull/16937)
 - We fixed an issue where dialog buttons cut off their text at a larger font size. [#16787](https://github.com/JabRef/jabref/issues/16787)
 - We fixed an issue where main table columns could not be resized while "Fit table horizontally on screen" was enabled. Resizing a column now adjusts only the columns to its right, and column widths keep their proportions when the window is resized. [#10516](https://github.com/JabRef/jabref/issues/10516)
+- We fixed an issue where the sidebar width jumped after repeatedly showing and hiding a side panel. [#17100](https://github.com/JabRef/jabref/issues/17100)
 - We fixed an issue where entries imported in the background could not be selected or updated in the main table. [#16893](https://github.com/JabRef/jabref/pull/16893)
 - We fixed an issue where editing a library's string constants could not be undone. [#16936](https://github.com/JabRef/jabref/pull/16936)
 - We fixed an issue where changes made in the library properties could not be undone. [#16988](https://github.com/JabRef/jabref/pull/16988)

--- a/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -272,9 +272,7 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
 
     private void updateSidePane() {
         if (sidePane.getChildren().isEmpty()) {
-            if (horizontalDividerSubscription != null) {
-                horizontalDividerSubscription.unsubscribe();
-            }
+            unsubscribeHorizontalDivider();
             horizontalSplit.getItems().remove(sidePane);
         } else {
             if (!horizontalSplit.getItems().contains(sidePane)) {
@@ -303,14 +301,33 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
     }
 
     public void updateHorizontalDividerPosition() {
-        if (mainStage.isShowing() && !sidePane.getChildren().isEmpty()) {
-            horizontalSplit.setDividerPositions(preferences.getGuiPreferences().getHorizontalDividerPosition());
-            // sidePane is not resizable with its parent (see the setResizableWithParent call above), so its width
-            // stays fixed while the divider's fractional position drifts with every layout pass. Track sidePane's
-            // own width instead of the divider position to avoid that drift accumulating on repeated show/hide.
-            horizontalDividerSubscription = EasyBind.listen(sidePane.widthProperty(), (_, _, newValue) ->
-                    preferences.getGuiPreferences()
-                               .setHorizontalDividerPosition(newValue.doubleValue() / horizontalSplit.getWidth()));
+        // Toggling a side panel quickly queues several Platform.runLater callbacks, and this method is
+        // additionally called once the stage is shown. Without dropping the previous subscription first,
+        // each call would add another listener that keeps writing the preference while the side pane is
+        // being added, removed or laid out.
+        unsubscribeHorizontalDivider();
+        if (!mainStage.isShowing() || sidePane.getChildren().isEmpty()) {
+            return;
+        }
+        horizontalSplit.setDividerPositions(preferences.getGuiPreferences().getHorizontalDividerPosition());
+        horizontalDividerSubscription = EasyBind.valueAt(horizontalSplit.getDividers(), 0)
+                                                .mapObservable(SplitPane.Divider::positionProperty)
+                                                .listenToValues((_, newValue) -> storeHorizontalDividerPosition(newValue.doubleValue()));
+    }
+
+    private void unsubscribeHorizontalDivider() {
+        if (horizontalDividerSubscription != null) {
+            horizontalDividerSubscription.unsubscribe();
+            horizontalDividerSubscription = null;
+        }
+    }
+
+    /// Only a divider of a laid out side pane describes a width the user chose. While the pane is added or
+    /// removed the position collapses to 0 or 1, and restoring such a value would move the side bar to the
+    /// very left or the very right.
+    private void storeHorizontalDividerPosition(double position) {
+        if (position > 0 && position < 1) {
+            preferences.getGuiPreferences().setHorizontalDividerPosition(position);
         }
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -305,11 +305,12 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
     public void updateHorizontalDividerPosition() {
         if (mainStage.isShowing() && !sidePane.getChildren().isEmpty()) {
             horizontalSplit.setDividerPositions(preferences.getGuiPreferences().getHorizontalDividerPosition());
-            horizontalDividerSubscription = EasyBind.valueAt(horizontalSplit.getDividers(), 0)
-                                                    .mapObservable(SplitPane.Divider::positionProperty)
-                                                    .listenToValues((_, newValue) ->
-                                                            preferences.getGuiPreferences()
-                                                                       .setHorizontalDividerPosition(newValue.doubleValue()));
+            // sidePane is not resizable with its parent (see the setResizableWithParent call above), so its width
+            // stays fixed while the divider's fractional position drifts with every layout pass. Track sidePane's
+            // own width instead of the divider position to avoid that drift accumulating on repeated show/hide.
+            horizontalDividerSubscription = EasyBind.listen(sidePane.widthProperty(), (_, _, newValue) ->
+                    preferences.getGuiPreferences()
+                               .setHorizontalDividerPosition(newValue.doubleValue() / horizontalSplit.getWidth()));
         }
     }
 


### PR DESCRIPTION
### Summary

The sidebar (side pane) is placed in a `SplitPane` whose divider position is persisted as a fraction of the window width. Because the side pane is marked `setResizableWithParent(sidePane, false)` (its pixel width is meant to stay fixed while the rest of the window resizes), that fraction is not a stable quantity: it gets recomputed internally on ordinary layout passes. The previous code persisted the divider's raw fractional position directly, so each time a side panel (Web search, Groups, OpenOffice/LibreOffice) was hidden and shown again, a slightly drifted fraction was written back to preferences, and the drift compounded with each toggle until the sidebar visibly jumped wide.

This restores the approach used by the original fix for this class of bug (#8936): persist based on the side pane's own stable `widthProperty()` instead of the derived divider fraction. The stored preference format, defaults, and the restore path are unchanged, so existing user preferences keep working.

### Steps to test

1. Start JabRef with a library open.
2. Open the "View" menu.
3. Toggle "Web search" off, then on, then off again (or do the same with "Groups" or "OpenOffice/LibreOffice").
4. Expected: the sidebar width stays the same as before toggling, instead of growing wider with each cycle.

### Related issues and pull requests

Closes #17100

### AI usage

AIL4 — I primarily investigated and worked on the issue myself, including reading the easybind library sources and reviewing the git history of the affected code. I used Claude Code (Claude Opus 5) for some assistance during the investigation and drafting of the fix. I reviewed and refined the changes, verified the behaviour in a running JabRef instance, and take full ownership of the final change.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added **one sentence (max 20 words)** to `CHANGELOG.md` describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)



https://github.com/user-attachments/assets/4f465f84-67f3-4d16-b272-ca26f7861371

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b6e9e3f1-1cc6-489f-8444-0a6ca6b5e412" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/085cdfa7-7d42-40fe-b878-8b609c1371dd" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b1cd075b-734c-4412-bdd6-828b02708efa" />

