### PR TITLE
Tag BookCoverFetcherTest as ExternalServicesTest

### DIFF
--- a/.github/workflows/tests-code-fetchers.yml
+++ b/.github/workflows/tests-code-fetchers.yml
@@ -14,6 +14,8 @@ on:
       - '.github/workflows/tests-code-fetchers.yml'
       - '.github/actions/setup-gradle/action.yml'
       - 'jablib/build.gradle.kts'
+      - 'jabgui/src/test/java/org/jabref/gui/importer/**'
+      - 'jabgui/build.gradle.kts'
   pull_request:
     paths:
       - 'jablib/src/main/java/org/jabref/logic/importer/fetcher/**'
@@ -25,6 +27,8 @@ on:
       - '.github/actions/setup-gradle/action.yml'
       - '.github/workflows/tests-code-fetchers.yml'
       - 'jablib/build.gradle.kts'
+      - 'jabgui/src/test/java/org/jabref/gui/importer/**'
+      - 'jabgui/build.gradle.kts'
   schedule:
     # run on each Monday
     - cron: '2 3 * * 1'
@@ -61,6 +65,6 @@ jobs:
           show-progress: 'false'
       - uses: ./.github/actions/setup-gradle
       - name: Run external services tests
-        run: gradle externalServicesTest
+        run: gradle externalServicesTest jabgui:externalServicesTest
         env:
           CI: "true"

--- a/.github/workflows/tests-code-fetchers.yml
+++ b/.github/workflows/tests-code-fetchers.yml
@@ -14,6 +14,7 @@ on:
       - '.github/workflows/tests-code-fetchers.yml'
       - '.github/actions/setup-gradle/action.yml'
       - 'jablib/build.gradle.kts'
+      - 'jabgui/src/main/java/org/jabref/gui/importer/**'
       - 'jabgui/src/test/java/org/jabref/gui/importer/**'
       - 'jabgui/build.gradle.kts'
   pull_request:
@@ -27,6 +28,7 @@ on:
       - '.github/actions/setup-gradle/action.yml'
       - '.github/workflows/tests-code-fetchers.yml'
       - 'jablib/build.gradle.kts'
+      - 'jabgui/src/main/java/org/jabref/gui/importer/**'
       - 'jabgui/src/test/java/org/jabref/gui/importer/**'
       - 'jabgui/build.gradle.kts'
   schedule:
@@ -65,6 +67,6 @@ jobs:
           show-progress: 'false'
       - uses: ./.github/actions/setup-gradle
       - name: Run external services tests
-        run: gradle externalServicesTest jabgui:externalServicesTest
+        run: gradle externalServicesTest
         env:
           CI: "true"

--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -307,6 +307,10 @@ tasks.test {
     systemProperty("glass.platform", "Headless")
     systemProperty("prism.order", "sw")
 
+    useJUnitPlatform {
+        excludeTags("ExternalServicesTest")
+    }
+
     jvmArgs = listOf(
         "-javaagent:${configurations.mockitoAgent.get().asPath}",
 
@@ -318,6 +322,26 @@ tasks.test {
         // "--add-reads", "org.jabref=wiremock"
     ) + useLibericaJdkFullJvmArgs
 
+    maxParallelForks = 1
+}
+
+val testSourceSet = sourceSets.test.get()
+
+tasks.register<Test>("externalServicesTest") {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    testClassesDirs = testSourceSet.output.classesDirs
+    classpath = testSourceSet.runtimeClasspath
+    useJUnitPlatform {
+        includeTags("ExternalServicesTest")
+    }
+    systemProperty("glass.platform", "Headless")
+    systemProperty("prism.order", "sw")
+    jvmArgs = listOf(
+        "-javaagent:${configurations.mockitoAgent.get().asPath}",
+        "--add-opens", "java.base/jdk.internal.ref=org.apache.pdfbox.io",
+        "--add-opens", "java.base/java.nio=org.apache.pdfbox.io",
+        "--enable-native-access=javafx.graphics,com.sun.jna"
+    ) + useLibericaJdkFullJvmArgs
     maxParallelForks = 1
 }
 

--- a/jabgui/src/test/java/org/jabref/gui/importer/BookCoverFetcherTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/importer/BookCoverFetcherTest.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@Tag("ExternalServicesTest")
 class BookCoverFetcherTest {
     private final ExternalApplicationsPreferences externalApplicationsPreferences = mock(ExternalApplicationsPreferences.class);
     private final BookCoverFetcher bookCoverFetcher = new BookCoverFetcher(externalApplicationsPreferences);
@@ -75,6 +74,7 @@ class BookCoverFetcherTest {
     /// "toFile". This should then cause the expected file to
     /// be created.
     @Test
+    @Tag("ExternalServicesTest")
     void createNotAvailableFileAfterFailedDownload() throws Exception {
         bookCoverFetcher.downloadCoversForEntry(badEntry);
 
@@ -128,6 +128,7 @@ class BookCoverFetcherTest {
     /// We create a new .not-available file in the cover directory with a modification time more than 24 hours ago
     /// When we try to download the book and fail to do so, the modification time should be set to now.
     @Test
+    @Tag("ExternalServicesTest")
     void modificationTimeChangesWhenMoreThan24Hours() throws IOException, FetcherException {
         Instant now = Instant.now();
         Files.createFile(badNotAvailablePath);
@@ -166,6 +167,7 @@ class BookCoverFetcherTest {
     /// We create a new .not-available file in the cover directory with a modification time more than 24 hours ago
     /// When we try to download the book and succeed, the file should be deleted.
     @Test
+    @Tag("ExternalServicesTest")
     void notAvailableFileIsDeletedAfterSuccessfulDownload() throws IOException, FetcherException {
         Files.createFile(notAvailablePath);
         Files.setLastModifiedTime(notAvailablePath, FileTime.from(Instant.now().minus(25, ChronoUnit.HOURS)));

--- a/jabgui/src/test/java/org/jabref/gui/importer/BookCoverFetcherTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/importer/BookCoverFetcherTest.java
@@ -22,6 +22,7 @@ import org.jabref.model.entry.types.StandardEntryType;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
@@ -32,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Tag("ExternalServicesTest")
 class BookCoverFetcherTest {
     private final ExternalApplicationsPreferences externalApplicationsPreferences = mock(ExternalApplicationsPreferences.class);
     private final BookCoverFetcher bookCoverFetcher = new BookCoverFetcher(externalApplicationsPreferences);


### PR DESCRIPTION
### Summary

Tag `BookCoverFetcherTest` with `@Tag("ExternalServicesTest")`, exclude it from the regular `jabgui:test` suite, and run it in the dedicated `jabgui:externalServicesTest` CI job. This mirrors `jablib`'s convention and prevents PR checks from failing when external cover services (such as OpenLibrary or Longitood) experience downtime.

### Steps to test

1. Run the standard unit test task:
   `./gradlew :jabgui:test`
   Verify that `BookCoverFetcherTest` is excluded and does not make live network calls.
2. Run the external services test task:
   `./gradlew :jabgui:externalServicesTest`
   Verify that `BookCoverFetcherTest` executes in this dedicated task.

### Related issues and pull requests

Closes #17107

### AI usage

Assisted by Antigravity (Gemini 2.5) to locate related CI workflows (`tests-code-fetchers.yml`) and Gradle task configurations. All code changes and Gradle configurations were reviewed, verified, and locally compiled by the contributor.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added one sentence (max 20 words) to CHANGELOG.md describing the change from the user's point of view (if the change is visible to the user)
- [/] I checked the user documentation for up to dateness and submitted a pull request to our user documentation repository
